### PR TITLE
translate/TryFromGlib: add shortcut func.

### DIFF
--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -1194,6 +1194,14 @@ pub trait TryFromGlib<G: Copy>: Sized {
     fn try_from_glib(val: G) -> Result<Self, Self::Error>;
 }
 
+/// Translate from a Glib type which can result in an undefined and/or invalid value.
+#[inline]
+pub fn try_from_glib<G: Copy, T: TryFromGlib<G>>(
+    val: G,
+) -> Result<T, <T as TryFromGlib<G>>::Error> {
+    TryFromGlib::try_from_glib(val)
+}
+
 /// Error type for [`TryFromGlib`] when the Glib value is None.
 #[derive(Debug, PartialEq, Eq)]
 pub struct GlibNoneError;


### PR DESCRIPTION
This commit adds a free standing shortcut function `try_fom_glib` similar to `from_glib`.

Goes with https://github.com/gtk-rs/gir/pull/1135.
Used in [this `gstreamer-rs` PR](https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/merge_requests/760).

## Example

### Before

```rust
    pub fn end_of_stream(&self) -> Result<gst::FlowSuccess, gst::FlowError> {
        unsafe {
            gst::FlowSuccess::try_from_glib(ffi::gst_app_src_end_of_stream(self.to_glib_none().0))
        }
    }
```

### After

```rust
    pub fn end_of_stream(&self) -> Result<gst::FlowSuccess, gst::FlowError> {
        unsafe { try_from_glib(ffi::gst_app_src_end_of_stream(self.to_glib_none().0)) }
    }
```