### PR TITLE
glib: Mark various Variant getter functions correctly as (transfer fu…

### DIFF
--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -198,7 +198,7 @@ impl Variant {
     #[inline]
     #[doc(alias = "get_variant")]
     pub fn as_variant(&self) -> Option<Variant> {
-        unsafe { from_glib_none(ffi::g_variant_get_variant(self.to_glib_none().0)) }
+        unsafe { from_glib_full(ffi::g_variant_get_variant(self.to_glib_none().0)) }
     }
 
     /// Reads a child item out of a container `Variant` instance.
@@ -212,7 +212,7 @@ impl Variant {
         assert!(index < self.n_children());
         assert!(self.is_container());
 
-        unsafe { from_glib_none(ffi::g_variant_get_child_value(self.to_glib_none().0, index)) }
+        unsafe { from_glib_full(ffi::g_variant_get_child_value(self.to_glib_none().0, index)) }
     }
 
     /// Tries to extract a `&str`.

--- a/glib/src/variant_dict.rs
+++ b/glib/src/variant_dict.rs
@@ -67,7 +67,7 @@ impl VariantDict {
     /// the `value` is an instance of [`Variant`](variant/struct.Variant.html).
     pub fn lookup_value(&self, key: &str, expected_type: Option<&VariantTy>) -> Option<Variant> {
         unsafe {
-            from_glib_none(ffi::g_variant_dict_lookup_value(
+            from_glib_full(ffi::g_variant_dict_lookup_value(
                 self.to_glib_none().0,
                 key.to_glib_none().0,
                 expected_type.to_glib_none().0,


### PR DESCRIPTION
…ll) in their return value

Fixes a couple of memory leaks.