### PR TITLE
Add missing doc aliases

### DIFF
--- a/cairo/src/context.rs
+++ b/cairo/src/context.rs
@@ -165,52 +165,63 @@ impl Context {
         ctx.status().map(|_| ctx)
     }
 
+    #[doc(alias = "cairo_save")]
     pub fn save(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_save(self.0.as_ptr()) }
         self.status()
     }
 
+    #[doc(alias = "cairo_restore")]
     pub fn restore(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_restore(self.0.as_ptr()) }
         self.status()
     }
 
     #[doc(alias = "get_target")]
+    #[doc(alias = "cairo_get_target")]
     pub fn target(&self) -> Surface {
         unsafe { Surface::from_raw_none(ffi::cairo_get_target(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_push_group")]
     pub fn push_group(&self) {
         unsafe { ffi::cairo_push_group(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_push_group_with_content")]
     pub fn push_group_with_content(&self, content: Content) {
         unsafe { ffi::cairo_push_group_with_content(self.0.as_ptr(), content.into()) }
     }
 
+    #[doc(alias = "cairo_pop_group")]
     pub fn pop_group(&self) -> Result<Pattern, Error> {
         let pattern = unsafe { Pattern::from_raw_full(ffi::cairo_pop_group(self.0.as_ptr())) };
         self.status().map(|_| pattern)
     }
 
+    #[doc(alias = "cairo_pop_group_to_source")]
     pub fn pop_group_to_source(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_pop_group_to_source(self.0.as_ptr()) };
         self.status()
     }
 
     #[doc(alias = "get_group_target")]
+    #[doc(alias = "cairo_get_group_target")]
     pub fn group_target(&self) -> Surface {
         unsafe { Surface::from_raw_none(ffi::cairo_get_group_target(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_source_rgb")]
     pub fn set_source_rgb(&self, red: f64, green: f64, blue: f64) {
         unsafe { ffi::cairo_set_source_rgb(self.0.as_ptr(), red, green, blue) }
     }
 
+    #[doc(alias = "cairo_set_source_rgba")]
     pub fn set_source_rgba(&self, red: f64, green: f64, blue: f64, alpha: f64) {
         unsafe { ffi::cairo_set_source_rgba(self.0.as_ptr(), red, green, blue, alpha) }
     }
 
+    #[doc(alias = "cairo_set_source")]
     pub fn set_source(&self, source: &Pattern) -> Result<(), Error> {
         source.status()?;
         unsafe {
@@ -220,10 +231,12 @@ impl Context {
     }
 
     #[doc(alias = "get_source")]
+    #[doc(alias = "cairo_get_source")]
     pub fn source(&self) -> Pattern {
         unsafe { Pattern::from_raw_none(ffi::cairo_get_source(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_source_surface")]
     pub fn set_source_surface(&self, surface: &Surface, x: f64, y: f64) -> Result<(), Error> {
         surface.status()?;
         unsafe {
@@ -232,15 +245,18 @@ impl Context {
         self.status()
     }
 
+    #[doc(alias = "cairo_set_antialias")]
     pub fn set_antialias(&self, antialias: Antialias) {
         unsafe { ffi::cairo_set_antialias(self.0.as_ptr(), antialias.into()) }
     }
 
     #[doc(alias = "get_antialias")]
+    #[doc(alias = "cairo_get_antialias")]
     pub fn antialias(&self) -> Antialias {
         unsafe { Antialias::from(ffi::cairo_get_antialias(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_dash")]
     pub fn set_dash(&self, dashes: &[f64], offset: f64) {
         unsafe {
             ffi::cairo_set_dash(
@@ -253,11 +269,13 @@ impl Context {
     }
 
     #[doc(alias = "get_dash_count")]
+    #[doc(alias = "cairo_get_dash_count")]
     pub fn dash_count(&self) -> i32 {
         unsafe { ffi::cairo_get_dash_count(self.0.as_ptr()) }
     }
 
     #[doc(alias = "get_dash")]
+    #[doc(alias = "cairo_get_dash")]
     pub fn dash(&self) -> (Vec<f64>, f64) {
         let dash_count = self.dash_count() as usize;
         let mut dashes: Vec<f64> = Vec::with_capacity(dash_count);
@@ -282,6 +300,7 @@ impl Context {
         offset
     }
 
+    #[doc(alias = "cairo_set_fill_rule")]
     pub fn set_fill_rule(&self, fill_rule: FillRule) {
         unsafe {
             ffi::cairo_set_fill_rule(self.0.as_ptr(), fill_rule.into());
@@ -289,46 +308,56 @@ impl Context {
     }
 
     #[doc(alias = "get_fill_rule")]
+    #[doc(alias = "cairo_get_fill_rule")]
     pub fn fill_rule(&self) -> FillRule {
         unsafe { FillRule::from(ffi::cairo_get_fill_rule(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_line_cap")]
     pub fn set_line_cap(&self, arg: LineCap) {
         unsafe { ffi::cairo_set_line_cap(self.0.as_ptr(), arg.into()) }
     }
 
     #[doc(alias = "get_line_cap")]
+    #[doc(alias = "cairo_get_line_cap")]
     pub fn line_cap(&self) -> LineCap {
         unsafe { LineCap::from(ffi::cairo_get_line_cap(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_line_join")]
     pub fn set_line_join(&self, arg: LineJoin) {
         unsafe { ffi::cairo_set_line_join(self.0.as_ptr(), arg.into()) }
     }
 
     #[doc(alias = "get_line_join")]
+    #[doc(alias = "cairo_get_line_join")]
     pub fn line_join(&self) -> LineJoin {
         unsafe { LineJoin::from(ffi::cairo_get_line_join(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_line_width")]
     pub fn set_line_width(&self, arg: f64) {
         unsafe { ffi::cairo_set_line_width(self.0.as_ptr(), arg) }
     }
 
     #[doc(alias = "get_line_width")]
+    #[doc(alias = "cairo_get_line_width")]
     pub fn line_width(&self) -> f64 {
         unsafe { ffi::cairo_get_line_width(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_set_miter_limit")]
     pub fn set_miter_limit(&self, arg: f64) {
         unsafe { ffi::cairo_set_miter_limit(self.0.as_ptr(), arg) }
     }
 
     #[doc(alias = "get_miter_limit")]
+    #[doc(alias = "cairo_get_miter_limit")]
     pub fn miter_limit(&self) -> f64 {
         unsafe { ffi::cairo_get_miter_limit(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_set_operator")]
     pub fn set_operator(&self, op: Operator) {
         unsafe {
             ffi::cairo_set_operator(self.0.as_ptr(), op.into());
@@ -336,27 +365,33 @@ impl Context {
     }
 
     #[doc(alias = "get_operator")]
+    #[doc(alias = "cairo_get_operator")]
     pub fn operator(&self) -> Operator {
         unsafe { Operator::from(ffi::cairo_get_operator(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_tolerance")]
     pub fn set_tolerance(&self, arg: f64) {
         unsafe { ffi::cairo_set_tolerance(self.0.as_ptr(), arg) }
     }
 
     #[doc(alias = "get_tolerance")]
+    #[doc(alias = "cairo_get_tolerance")]
     pub fn tolerance(&self) -> f64 {
         unsafe { ffi::cairo_get_tolerance(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_clip")]
     pub fn clip(&self) {
         unsafe { ffi::cairo_clip(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_clip_preserve")]
     pub fn clip_preserve(&self) {
         unsafe { ffi::cairo_clip_preserve(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_clip_extents")]
     pub fn clip_extents(&self) -> Result<(f64, f64, f64, f64), Error> {
         let mut x1: f64 = 0.0;
         let mut y1: f64 = 0.0;
@@ -369,15 +404,18 @@ impl Context {
         self.status().map(|_| (x1, y1, x2, y2))
     }
 
+    #[doc(alias = "cairo_in_clip")]
     pub fn in_clip(&self, x: f64, y: f64) -> Result<bool, Error> {
         let in_clip = unsafe { ffi::cairo_in_clip(self.0.as_ptr(), x, y).as_bool() };
         self.status().map(|_| in_clip)
     }
 
+    #[doc(alias = "cairo_reset_clip")]
     pub fn reset_clip(&self) {
         unsafe { ffi::cairo_reset_clip(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_copy_clip_rectangle_list")]
     pub fn copy_clip_rectangle_list(&self) -> Result<RectangleList, Error> {
         unsafe {
             let rectangle_list = ffi::cairo_copy_clip_rectangle_list(self.0.as_ptr());
@@ -390,16 +428,19 @@ impl Context {
         }
     }
 
+    #[doc(alias = "cairo_fill")]
     pub fn fill(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_fill(self.0.as_ptr()) };
         self.status()
     }
 
+    #[doc(alias = "cairo_fill_preserve")]
     pub fn fill_preserve(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_fill_preserve(self.0.as_ptr()) };
         self.status()
     }
 
+    #[doc(alias = "cairo_fill_extents")]
     pub fn fill_extents(&self) -> Result<(f64, f64, f64, f64), Error> {
         let mut x1: f64 = 0.0;
         let mut y1: f64 = 0.0;
@@ -412,17 +453,20 @@ impl Context {
         self.status().map(|_| (x1, y1, x2, y2))
     }
 
+    #[doc(alias = "cairo_in_fill")]
     pub fn in_fill(&self, x: f64, y: f64) -> Result<bool, Error> {
         let in_fill = unsafe { ffi::cairo_in_fill(self.0.as_ptr(), x, y).as_bool() };
         self.status().map(|_| in_fill)
     }
 
+    #[doc(alias = "cairo_mask")]
     pub fn mask(&self, pattern: &Pattern) -> Result<(), Error> {
         pattern.status()?;
         unsafe { ffi::cairo_mask(self.0.as_ptr(), pattern.to_raw_none()) };
         self.status()
     }
 
+    #[doc(alias = "cairo_mask_surface")]
     pub fn mask_surface(&self, surface: &Surface, x: f64, y: f64) -> Result<(), Error> {
         surface.status()?;
         unsafe {
@@ -431,26 +475,31 @@ impl Context {
         self.status()
     }
 
+    #[doc(alias = "cairo_paint")]
     pub fn paint(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_paint(self.0.as_ptr()) };
         self.status()
     }
 
+    #[doc(alias = "cairo_paint_with_alpha")]
     pub fn paint_with_alpha(&self, alpha: f64) -> Result<(), Error> {
         unsafe { ffi::cairo_paint_with_alpha(self.0.as_ptr(), alpha) };
         self.status()
     }
 
+    #[doc(alias = "cairo_stroke")]
     pub fn stroke(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_stroke(self.0.as_ptr()) };
         self.status()
     }
 
+    #[doc(alias = "cairo_stroke_preserve")]
     pub fn stroke_preserve(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_stroke_preserve(self.0.as_ptr()) };
         self.status()
     }
 
+    #[doc(alias = "cairo_stroke_extents")]
     pub fn stroke_extents(&self) -> Result<(f64, f64, f64, f64), Error> {
         let mut x1: f64 = 0.0;
         let mut y1: f64 = 0.0;
@@ -463,16 +512,19 @@ impl Context {
         self.status().map(|_| (x1, y1, x2, y2))
     }
 
+    #[doc(alias = "cairo_in_stroke")]
     pub fn in_stroke(&self, x: f64, y: f64) -> Result<bool, Error> {
         let in_stroke = unsafe { ffi::cairo_in_stroke(self.0.as_ptr(), x, y).as_bool() };
         self.status().map(|_| in_stroke)
     }
 
+    #[doc(alias = "cairo_copy_page")]
     pub fn copy_page(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_copy_page(self.0.as_ptr()) };
         self.status()
     }
 
+    #[doc(alias = "cairo_show_page")]
     pub fn show_page(&self) -> Result<(), Error> {
         unsafe { ffi::cairo_show_page(self.0.as_ptr()) };
         self.status()
@@ -485,24 +537,29 @@ impl Context {
 
     // transformations stuff
 
+    #[doc(alias = "cairo_translate")]
     pub fn translate(&self, tx: f64, ty: f64) {
         unsafe { ffi::cairo_translate(self.0.as_ptr(), tx, ty) }
     }
 
+    #[doc(alias = "cairo_scale")]
     pub fn scale(&self, sx: f64, sy: f64) {
         unsafe { ffi::cairo_scale(self.0.as_ptr(), sx, sy) }
     }
 
+    #[doc(alias = "cairo_rotate")]
     pub fn rotate(&self, angle: f64) {
         unsafe { ffi::cairo_rotate(self.0.as_ptr(), angle) }
     }
 
+    #[doc(alias = "cairo_transform")]
     pub fn transform(&self, matrix: Matrix) {
         unsafe {
             ffi::cairo_transform(self.0.as_ptr(), matrix.ptr());
         }
     }
 
+    #[doc(alias = "cairo_set_matrix")]
     pub fn set_matrix(&self, matrix: Matrix) {
         unsafe {
             ffi::cairo_set_matrix(self.0.as_ptr(), matrix.ptr());
@@ -510,6 +567,7 @@ impl Context {
     }
 
     #[doc(alias = "get_matrix")]
+    #[doc(alias = "cairo_get_matrix")]
     pub fn matrix(&self) -> Matrix {
         let mut matrix = Matrix::null();
         unsafe {
@@ -518,10 +576,12 @@ impl Context {
         matrix
     }
 
+    #[doc(alias = "cairo_identity_matrix")]
     pub fn identity_matrix(&self) {
         unsafe { ffi::cairo_identity_matrix(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_user_to_device")]
     pub fn user_to_device(&self, mut x: f64, mut y: f64) -> (f64, f64) {
         unsafe {
             ffi::cairo_user_to_device(self.0.as_ptr(), &mut x, &mut y);
@@ -529,6 +589,7 @@ impl Context {
         }
     }
 
+    #[doc(alias = "cairo_user_to_device_distance")]
     pub fn user_to_device_distance(&self, mut dx: f64, mut dy: f64) -> Result<(f64, f64), Error> {
         unsafe {
             ffi::cairo_user_to_device_distance(self.0.as_ptr(), &mut dx, &mut dy);
@@ -536,6 +597,7 @@ impl Context {
         self.status().map(|_| (dx, dy))
     }
 
+    #[doc(alias = "cairo_device_to_user")]
     pub fn device_to_user(&self, mut x: f64, mut y: f64) -> Result<(f64, f64), Error> {
         unsafe {
             ffi::cairo_device_to_user(self.0.as_ptr(), &mut x, &mut y);
@@ -543,6 +605,7 @@ impl Context {
         self.status().map(|_| (x, y))
     }
 
+    #[doc(alias = "cairo_device_to_user_distance")]
     pub fn device_to_user_distance(&self, mut dx: f64, mut dy: f64) -> Result<(f64, f64), Error> {
         unsafe {
             ffi::cairo_device_to_user_distance(self.0.as_ptr(), &mut dx, &mut dy);
@@ -552,6 +615,7 @@ impl Context {
 
     // font stuff
 
+    #[doc(alias = "cairo_select_font_face")]
     pub fn select_font_face(&self, family: &str, slant: FontSlant, weight: FontWeight) {
         unsafe {
             let family = CString::new(family).unwrap();
@@ -564,16 +628,19 @@ impl Context {
         }
     }
 
+    #[doc(alias = "cairo_set_font_size")]
     pub fn set_font_size(&self, size: f64) {
         unsafe { ffi::cairo_set_font_size(self.0.as_ptr(), size) }
     }
 
     // FIXME probably needs a heap allocation
+    #[doc(alias = "cairo_set_font_matrix")]
     pub fn set_font_matrix(&self, matrix: Matrix) {
         unsafe { ffi::cairo_set_font_matrix(self.0.as_ptr(), matrix.ptr()) }
     }
 
     #[doc(alias = "get_font_matrix")]
+    #[doc(alias = "cairo_get_font_matrix")]
     pub fn font_matrix(&self) -> Matrix {
         let mut matrix = Matrix::null();
         unsafe {
@@ -582,11 +649,13 @@ impl Context {
         matrix
     }
 
+    #[doc(alias = "cairo_set_font_options")]
     pub fn set_font_options(&self, options: &FontOptions) {
         unsafe { ffi::cairo_set_font_options(self.0.as_ptr(), options.to_raw_none()) }
     }
 
     #[doc(alias = "get_font_options")]
+    #[doc(alias = "cairo_get_font_options")]
     pub fn font_options(&self) -> Result<FontOptions, Error> {
         let out = FontOptions::new()?;
         unsafe {
@@ -595,24 +664,29 @@ impl Context {
         Ok(out)
     }
 
+    #[doc(alias = "cairo_set_font_face")]
     pub fn set_font_face(&self, font_face: &FontFace) {
         unsafe { ffi::cairo_set_font_face(self.0.as_ptr(), font_face.to_raw_none()) }
     }
 
     #[doc(alias = "get_font_face")]
+    #[doc(alias = "cairo_get_font_face")]
     pub fn font_face(&self) -> FontFace {
         unsafe { FontFace::from_raw_none(ffi::cairo_get_font_face(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_set_scaled_font")]
     pub fn set_scaled_font(&self, scaled_font: &ScaledFont) {
         unsafe { ffi::cairo_set_scaled_font(self.0.as_ptr(), scaled_font.to_raw_none()) }
     }
 
     #[doc(alias = "get_scaled_font")]
+    #[doc(alias = "cairo_get_scaled_font")]
     pub fn scaled_font(&self) -> ScaledFont {
         unsafe { ScaledFont::from_raw_none(ffi::cairo_get_scaled_font(self.0.as_ptr())) }
     }
 
+    #[doc(alias = "cairo_show_text")]
     pub fn show_text(&self, text: &str) -> Result<(), Error> {
         unsafe {
             let text = CString::new(text).unwrap();
@@ -621,11 +695,13 @@ impl Context {
         self.status()
     }
 
+    #[doc(alias = "cairo_show_glyphs")]
     pub fn show_glyphs(&self, glyphs: &[Glyph]) -> Result<(), Error> {
         unsafe { ffi::cairo_show_glyphs(self.0.as_ptr(), glyphs.as_ptr(), glyphs.len() as c_int) };
         self.status()
     }
 
+    #[doc(alias = "cairo_show_text_glyphs")]
     pub fn show_text_glyphs(
         &self,
         text: &str,
@@ -649,6 +725,7 @@ impl Context {
         self.status()
     }
 
+    #[doc(alias = "cairo_font_extents")]
     pub fn font_extents(&self) -> Result<FontExtents, Error> {
         let mut extents = FontExtents {
             ascent: 0.0,
@@ -665,6 +742,7 @@ impl Context {
         self.status().map(|_| extents)
     }
 
+    #[doc(alias = "cairo_text_extents")]
     pub fn text_extents(&self, text: &str) -> Result<TextExtents, Error> {
         let mut extents = TextExtents {
             x_bearing: 0.0,
@@ -682,6 +760,7 @@ impl Context {
         self.status().map(|_| extents)
     }
 
+    #[doc(alias = "cairo_glyph_extents")]
     pub fn glyph_extents(&self, glyphs: &[Glyph]) -> Result<TextExtents, Error> {
         let mut extents = TextExtents {
             x_bearing: 0.0,
@@ -706,26 +785,31 @@ impl Context {
 
     // paths stuff
 
+    #[doc(alias = "cairo_copy_path")]
     pub fn copy_path(&self) -> Result<Path, Error> {
         let path = unsafe { Path::from_raw_full(ffi::cairo_copy_path(self.0.as_ptr())) };
         self.status().map(|_| path)
     }
 
+    #[doc(alias = "cairo_copy_path_flat")]
     pub fn copy_path_flat(&self) -> Result<Path, Error> {
         let path = unsafe { Path::from_raw_full(ffi::cairo_copy_path_flat(self.0.as_ptr())) };
         self.status().map(|_| path)
     }
 
+    #[doc(alias = "cairo_append_path")]
     pub fn append_path(&self, path: &Path) {
         unsafe { ffi::cairo_append_path(self.0.as_ptr(), path.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_has_current_point")]
     pub fn has_current_point(&self) -> Result<bool, Error> {
         let has_current_point = unsafe { ffi::cairo_has_current_point(self.0.as_ptr()).as_bool() };
         self.status().map(|_| has_current_point)
     }
 
     #[doc(alias = "get_current_point")]
+    #[doc(alias = "cairo_get_current_point")]
     pub fn current_point(&self) -> Result<(f64, f64), Error> {
         unsafe {
             let mut x = 0.0;
@@ -735,42 +819,52 @@ impl Context {
         }
     }
 
+    #[doc(alias = "cairo_new_path")]
     pub fn new_path(&self) {
         unsafe { ffi::cairo_new_path(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_new_sub_path")]
     pub fn new_sub_path(&self) {
         unsafe { ffi::cairo_new_sub_path(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_close_path")]
     pub fn close_path(&self) {
         unsafe { ffi::cairo_close_path(self.0.as_ptr()) }
     }
 
+    #[doc(alias = "cairo_arc")]
     pub fn arc(&self, xc: f64, yc: f64, radius: f64, angle1: f64, angle2: f64) {
         unsafe { ffi::cairo_arc(self.0.as_ptr(), xc, yc, radius, angle1, angle2) }
     }
 
+    #[doc(alias = "cairo_arc_negative")]
     pub fn arc_negative(&self, xc: f64, yc: f64, radius: f64, angle1: f64, angle2: f64) {
         unsafe { ffi::cairo_arc_negative(self.0.as_ptr(), xc, yc, radius, angle1, angle2) }
     }
 
+    #[doc(alias = "cairo_curve_to")]
     pub fn curve_to(&self, x1: f64, y1: f64, x2: f64, y2: f64, x3: f64, y3: f64) {
         unsafe { ffi::cairo_curve_to(self.0.as_ptr(), x1, y1, x2, y2, x3, y3) }
     }
 
+    #[doc(alias = "cairo_line_to")]
     pub fn line_to(&self, x: f64, y: f64) {
         unsafe { ffi::cairo_line_to(self.0.as_ptr(), x, y) }
     }
 
+    #[doc(alias = "cairo_move_to")]
     pub fn move_to(&self, x: f64, y: f64) {
         unsafe { ffi::cairo_move_to(self.0.as_ptr(), x, y) }
     }
 
+    #[doc(alias = "cairo_rectangle")]
     pub fn rectangle(&self, x: f64, y: f64, width: f64, height: f64) {
         unsafe { ffi::cairo_rectangle(self.0.as_ptr(), x, y, width, height) }
     }
 
+    #[doc(alias = "cairo_text_path")]
     pub fn text_path(&self, str_: &str) {
         unsafe {
             let str_ = CString::new(str_).unwrap();
@@ -778,22 +872,27 @@ impl Context {
         }
     }
 
+    #[doc(alias = "cairo_glyph_path")]
     pub fn glyph_path(&self, glyphs: &[Glyph]) {
         unsafe { ffi::cairo_glyph_path(self.0.as_ptr(), glyphs.as_ptr(), glyphs.len() as i32) }
     }
 
+    #[doc(alias = "cairo_rel_curve_to")]
     pub fn rel_curve_to(&self, dx1: f64, dy1: f64, dx2: f64, dy2: f64, dx3: f64, dy3: f64) {
         unsafe { ffi::cairo_rel_curve_to(self.0.as_ptr(), dx1, dy1, dx2, dy2, dx3, dy3) }
     }
 
+    #[doc(alias = "cairo_rel_line_to")]
     pub fn rel_line_to(&self, dx: f64, dy: f64) {
         unsafe { ffi::cairo_rel_line_to(self.0.as_ptr(), dx, dy) }
     }
 
+    #[doc(alias = "cairo_rel_move_to")]
     pub fn rel_move_to(&self, dx: f64, dy: f64) {
         unsafe { ffi::cairo_rel_move_to(self.0.as_ptr(), dx, dy) }
     }
 
+    #[doc(alias = "cairo_path_extents")]
     pub fn path_extents(&self) -> Result<(f64, f64, f64, f64), Error> {
         let mut x1: f64 = 0.0;
         let mut y1: f64 = 0.0;
@@ -807,6 +906,7 @@ impl Context {
     }
 
     #[cfg(any(feature = "v1_16", feature = "dox"))]
+    #[doc(alias = "cairo_tag_begin")]
     pub fn tag_begin(&self, tag_name: &str, attributes: &str) {
         unsafe {
             let tag_name = CString::new(tag_name).unwrap();
@@ -816,6 +916,7 @@ impl Context {
     }
 
     #[cfg(any(feature = "v1_16", feature = "dox"))]
+    #[doc(alias = "cairo_tag_end")]
     pub fn tag_end(&self, tag_name: &str) {
         unsafe {
             let tag_name = CString::new(tag_name).unwrap();

--- a/cairo/src/device.rs
+++ b/cairo/src/device.rs
@@ -161,6 +161,7 @@ impl Device {
         Ok(DeviceAcquireGuard { 0: self })
     }
 
+    #[doc(alias = "cairo_device_release")]
     fn release(&self) {
         unsafe { ffi::cairo_device_release(self.to_raw_none()) }
     }
@@ -197,6 +198,7 @@ impl Device {
 
     #[cfg(any(feature = "xlib", feature = "xcb", feature = "dox"))]
     #[doc(alias = "cairo_xlib_device_debug_cap_xrender_version")]
+    #[doc(alias = "cairo_xcb_device_debug_cap_xrender_version")]
     pub fn debug_cap_xrender_version(&self, major_version: i32, minor_version: i32) {
         unsafe {
             match self.type_() {
@@ -235,6 +237,7 @@ impl Device {
 
     #[cfg(any(feature = "xlib", feature = "xcb", feature = "dox"))]
     #[doc(alias = "cairo_xlib_device_debug_get_precision")]
+    #[doc(alias = "cairo_xcb_device_debug_get_precision")]
     pub fn debug_get_precision(&self) -> i32 {
         unsafe {
             match self.type_() {
@@ -265,6 +268,7 @@ impl Device {
 
     #[cfg(any(feature = "xlib", feature = "xcb", feature = "dox"))]
     #[doc(alias = "cairo_xlib_device_debug_set_precision")]
+    #[doc(alias = "cairo_xcb_device_debug_set_precision")]
     pub fn debug_set_precision(&self, precision: i32) {
         unsafe {
             match self.type_() {

--- a/cairo/src/enums.rs
+++ b/cairo/src/enums.rs
@@ -1411,6 +1411,7 @@ impl fmt::Display for Format {
 gvalue_impl!(Format, ffi::gobject::cairo_gobject_format_get_type);
 
 impl Format {
+    #[doc(alias = "cairo_format_stride_for_width")]
     pub fn stride_for_width(self, width: u32) -> Result<i32, Error> {
         assert!(width <= i32::MAX as u32);
         let width = width as i32;

--- a/cairo/src/pdf.rs
+++ b/cairo/src/pdf.rs
@@ -95,6 +95,7 @@ impl PdfSurface {
     }
 
     #[cfg(any(all(feature = "pdf", feature = "v1_16"), feature = "dox"))]
+    #[doc(alias = "cairo_pdf_surface_set_thumbnail_size")]
     pub fn set_thumbnail_size(&self, width: i32, height: i32) -> Result<(), Error> {
         unsafe {
             ffi::cairo_pdf_surface_set_thumbnail_size(

--- a/cairo/src/region.rs
+++ b/cairo/src/region.rs
@@ -92,6 +92,7 @@ impl Drop for Region {
 }
 
 impl PartialEq for Region {
+    #[doc(alias = "cairo_region_equal")]
     fn eq(&self, other: &Region) -> bool {
         unsafe { ffi::cairo_region_equal(self.0.as_ptr(), other.0.as_ptr()).as_bool() }
     }
@@ -123,14 +124,17 @@ impl Region {
         self.0.as_ptr()
     }
 
+    #[doc(alias = "cairo_region_create")]
     pub fn create() -> Region {
         unsafe { Self::from_raw_full(ffi::cairo_region_create()) }
     }
 
+    #[doc(alias = "cairo_region_create_rectangle")]
     pub fn create_rectangle(rectangle: &RectangleInt) -> Region {
         unsafe { Self::from_raw_full(ffi::cairo_region_create_rectangle(rectangle.to_raw_none())) }
     }
 
+    #[doc(alias = "cairo_region_create_rectangles")]
     pub fn create_rectangles(rectangles: &[RectangleInt]) -> Region {
         unsafe {
             Self::from_raw_full(ffi::cairo_region_create_rectangles(
@@ -140,20 +144,24 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_copy")]
     pub fn copy(&self) -> Region {
         unsafe { Self::from_raw_full(ffi::cairo_region_copy(self.0.as_ptr())) }
     }
 
     #[doc(alias = "get_extents")]
+    #[doc(alias = "cairo_region_get_extents")]
     pub fn extents(&self, rectangle: &mut RectangleInt) {
         unsafe { ffi::cairo_region_get_extents(self.0.as_ptr(), rectangle.to_raw_none()) }
     }
 
+    #[doc(alias = "cairo_region_num_rectangles")]
     pub fn num_rectangles(&self) -> i32 {
         unsafe { ffi::cairo_region_num_rectangles(self.0.as_ptr()) }
     }
 
     #[doc(alias = "get_rectangle")]
+    #[doc(alias = "cairo_region_get_rectangle")]
     pub fn rectangle(&self, nth: i32) -> RectangleInt {
         unsafe {
             let rectangle: RectangleInt = ::std::mem::zeroed();
@@ -162,14 +170,17 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_is_empty")]
     pub fn is_empty(&self) -> bool {
         unsafe { ffi::cairo_region_is_empty(self.0.as_ptr()).as_bool() }
     }
 
+    #[doc(alias = "cairo_region_contains_point")]
     pub fn contains_point(&self, x: i32, y: i32) -> bool {
         unsafe { ffi::cairo_region_contains_point(self.0.as_ptr(), x, y).as_bool() }
     }
 
+    #[doc(alias = "cairo_region_contains_rectangle")]
     pub fn contains_rectangle(&self, rectangle: &RectangleInt) -> RegionOverlap {
         unsafe {
             RegionOverlap::from(ffi::cairo_region_contains_rectangle(
@@ -179,10 +190,12 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_translate")]
     pub fn translate(&self, dx: i32, dy: i32) {
         unsafe { ffi::cairo_region_translate(self.0.as_ptr(), dx, dy) }
     }
 
+    #[doc(alias = "cairo_region_intersect")]
     pub fn intersect(&self, other: &Region) -> Result<(), Error> {
         unsafe {
             let status = ffi::cairo_region_intersect(self.0.as_ptr(), other.0.as_ptr());
@@ -190,6 +203,7 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_intersect_rectangle")]
     pub fn intersect_rectangle(&self, rectangle: &RectangleInt) -> Result<(), Error> {
         unsafe {
             let status =
@@ -198,6 +212,7 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_subtract")]
     pub fn subtract(&self, other: &Region) -> Result<(), Error> {
         unsafe {
             let status = ffi::cairo_region_subtract(self.0.as_ptr(), other.0.as_ptr());
@@ -205,6 +220,7 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_subtract_rectangle")]
     pub fn subtract_rectangle(&self, rectangle: &RectangleInt) -> Result<(), Error> {
         unsafe {
             let status =
@@ -213,6 +229,7 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_union")]
     pub fn union(&self, other: &Region) -> Result<(), Error> {
         unsafe {
             let status = ffi::cairo_region_union(self.0.as_ptr(), other.0.as_ptr());
@@ -220,6 +237,7 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_union_rectangle")]
     pub fn union_rectangle(&self, rectangle: &RectangleInt) -> Result<(), Error> {
         unsafe {
             let status =
@@ -228,6 +246,7 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_xor")]
     pub fn xor(&self, other: &Region) -> Result<(), Error> {
         unsafe {
             let status = ffi::cairo_region_xor(self.0.as_ptr(), other.0.as_ptr());
@@ -235,6 +254,7 @@ impl Region {
         }
     }
 
+    #[doc(alias = "cairo_region_xor_rectangle")]
     pub fn xor_rectangle(&self, rectangle: &RectangleInt) -> Result<(), Error> {
         unsafe {
             let status = ffi::cairo_region_xor_rectangle(self.0.as_ptr(), rectangle.to_raw_none());

--- a/gdk-pixbuf/src/pixbuf.rs
+++ b/gdk-pixbuf/src/pixbuf.rs
@@ -447,6 +447,7 @@ impl Pixbuf {
 
     #[cfg(any(feature = "v2_36", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2_36")))]
+    #[doc(alias = "gdk_pixbuf_save_to_streamv")]
     pub fn save_to_streamv<P: IsA<gio::OutputStream>, Q: IsA<gio::Cancellable>>(
         &self,
         stream: &P,

--- a/gio/src/converter.rs
+++ b/gio/src/converter.rs
@@ -9,6 +9,7 @@ use std::mem;
 use std::ptr;
 
 pub trait ConverterExtManual {
+    #[doc(alias = "g_converter_convert")]
     fn convert<IN: AsRef<[u8]>, OUT: AsMut<[u8]>>(
         &self,
         inbuf: IN,

--- a/gio/src/data_input_stream.rs
+++ b/gio/src/data_input_stream.rs
@@ -11,11 +11,13 @@ use std::pin::Pin;
 use std::ptr;
 
 pub trait DataInputStreamExtManual: 'static {
+    #[doc(alias = "g_data_input_stream_read_line")]
     fn read_line<P: IsA<Cancellable>>(
         &self,
         cancellable: Option<&P>,
     ) -> Result<Vec<u8>, glib::Error>;
 
+    #[doc(alias = "g_data_input_stream_read_line_async")]
     fn read_line_async<
         P: IsA<Cancellable>,
         Q: FnOnce(Result<Vec<u8>, glib::Error>) + Send + 'static,
@@ -31,6 +33,7 @@ pub trait DataInputStreamExtManual: 'static {
         io_priority: glib::Priority,
     ) -> Pin<Box_<dyn std::future::Future<Output = Result<Vec<u8>, glib::Error>> + 'static>>;
 
+    #[doc(alias = "g_data_input_stream_read_line_utf8")]
     fn read_line_utf8<P: IsA<Cancellable>>(
         &self,
         cancellable: Option<&P>,
@@ -52,6 +55,7 @@ pub trait DataInputStreamExtManual: 'static {
     ) -> Pin<Box_<dyn std::future::Future<Output = Result<Option<GString>, glib::Error>> + 'static>>;
 
     #[cfg_attr(feature = "v2_56", deprecated)]
+    #[doc(alias = "g_data_input_stream_read_until")]
     fn read_until<P: IsA<Cancellable>>(
         &self,
         stop_chars: &[u8],
@@ -59,6 +63,7 @@ pub trait DataInputStreamExtManual: 'static {
     ) -> Result<Vec<u8>, glib::Error>;
 
     #[cfg_attr(feature = "v2_56", deprecated)]
+    #[doc(alias = "g_data_input_stream_read_until_async")]
     fn read_until_async<
         P: IsA<Cancellable>,
         Q: FnOnce(Result<Vec<u8>, glib::Error>) + Send + 'static,
@@ -77,12 +82,14 @@ pub trait DataInputStreamExtManual: 'static {
         io_priority: glib::Priority,
     ) -> Pin<Box_<dyn std::future::Future<Output = Result<Vec<u8>, glib::Error>> + 'static>>;
 
+    #[doc(alias = "g_data_input_stream_read_upto")]
     fn read_upto<P: IsA<Cancellable>>(
         &self,
         stop_chars: &[u8],
         cancellable: Option<&P>,
     ) -> Result<Vec<u8>, glib::Error>;
 
+    #[doc(alias = "g_data_input_stream_read_upto_async")]
     fn read_upto_async<
         P: IsA<Cancellable>,
         Q: FnOnce(Result<Vec<u8>, glib::Error>) + Send + 'static,

--- a/gio/src/dbus.rs
+++ b/gio/src/dbus.rs
@@ -49,6 +49,7 @@ where
     })
 }
 
+#[doc(alias = "g_bus_own_name_on_connection_with_closures")]
 pub fn bus_own_name_on_connection<NameAcquired, NameLost>(
     connection: &DBusConnection,
     name: &str,
@@ -72,6 +73,7 @@ where
     }
 }
 
+#[doc(alias = "g_bus_own_name_with_closures")]
 pub fn bus_own_name<BusAcquired, NameAcquired, NameLost>(
     bus_type: BusType,
     name: &str,
@@ -105,12 +107,14 @@ where
     }
 }
 
+#[doc(alias = "g_bus_unown_name")]
 pub fn bus_unown_name(owner_id: OwnerId) {
     unsafe {
         ffi::g_bus_unown_name(owner_id.0.into());
     }
 }
 
+#[doc(alias = "g_bus_watch_name_on_connection_with_closures")]
 pub fn bus_watch_name_on_connection<NameAppeared, NameVanished>(
     connection: &DBusConnection,
     name: &str,
@@ -134,6 +138,7 @@ where
     }
 }
 
+#[doc(alias = "g_bus_watch_name_with_closures")]
 pub fn bus_watch_name<NameAppeared, NameVanished>(
     bus_type: BusType,
     name: &str,
@@ -157,6 +162,7 @@ where
     }
 }
 
+#[doc(alias = "g_bus_unwatch_name")]
 pub fn bus_unwatch_name(watcher_id: WatcherId) {
     unsafe {
         ffi::g_bus_unwatch_name(watcher_id.0.into());

--- a/gio/src/dbus_connection.rs
+++ b/gio/src/dbus_connection.rs
@@ -26,6 +26,7 @@ pub struct FilterId(NonZeroU32);
 pub struct SignalSubscriptionId(NonZeroU32);
 
 impl DBusConnection {
+    #[doc(alias = "g_dbus_connection_register_object_with_closures")]
     pub fn register_object<MethodCall, SetProperty, GetProperty>(
         &self,
         object_path: &str,
@@ -115,6 +116,7 @@ impl DBusConnection {
         }
     }
 
+    #[doc(alias = "g_dbus_connection_unregister_object")]
     pub fn unregister_object(
         &self,
         registration_id: RegistrationId,
@@ -130,6 +132,7 @@ impl DBusConnection {
         }
     }
 
+    #[doc(alias = "g_dbus_connection_export_action_group")]
     pub fn export_action_group<P: IsA<ActionGroup>>(
         &self,
         object_path: &str,
@@ -151,12 +154,14 @@ impl DBusConnection {
         }
     }
 
+    #[doc(alias = "g_dbus_connection_unexport_action_group")]
     pub fn unexport_action_group(&self, export_id: ActionGroupExportId) {
         unsafe {
             ffi::g_dbus_connection_unexport_action_group(self.to_glib_none().0, export_id.0.into());
         }
     }
 
+    #[doc(alias = "g_dbus_connection_export_menu_model")]
     pub fn export_menu_model<P: IsA<MenuModel>>(
         &self,
         object_path: &str,
@@ -178,12 +183,14 @@ impl DBusConnection {
         }
     }
 
+    #[doc(alias = "g_dbus_connection_unexport_menu_model")]
     pub fn unexport_menu_model(&self, export_id: MenuModelExportId) {
         unsafe {
             ffi::g_dbus_connection_unexport_menu_model(self.to_glib_none().0, export_id.0.into());
         }
     }
 
+    #[doc(alias = "g_dbus_connection_add_filter")]
     pub fn add_filter<
         P: Fn(&DBusConnection, &DBusMessage, bool) -> Option<DBusMessage> + 'static,
     >(
@@ -227,12 +234,14 @@ impl DBusConnection {
         }
     }
 
+    #[doc(alias = "g_dbus_connection_remove_filter")]
     pub fn remove_filter(&self, filter_id: FilterId) {
         unsafe {
             ffi::g_dbus_connection_remove_filter(self.to_glib_none().0, filter_id.0.into());
         }
     }
 
+    #[doc(alias = "g_dbus_connection_signal_subscribe")]
     pub fn signal_subscribe<
         P: Fn(&DBusConnection, &str, &str, &str, &str, &glib::Variant) + 'static,
     >(
@@ -300,6 +309,7 @@ impl DBusConnection {
         }
     }
 
+    #[doc(alias = "g_dbus_connection_signal_unsubscribe")]
     pub fn signal_unsubscribe(&self, subscription_id: SignalSubscriptionId) {
         unsafe {
             ffi::g_dbus_connection_signal_unsubscribe(

--- a/gio/src/dbus_method_invocation.rs
+++ b/gio/src/dbus_method_invocation.rs
@@ -5,6 +5,7 @@ use glib::error::ErrorDomain;
 use glib::translate::*;
 
 impl DBusMethodInvocation {
+    #[doc(alias = "g_dbus_method_invocation_return_error_literal")]
     pub fn return_error<T: ErrorDomain>(&self, error: T, message: &str) {
         unsafe {
             ffi::g_dbus_method_invocation_return_error_literal(
@@ -16,6 +17,7 @@ impl DBusMethodInvocation {
         }
     }
 
+    #[doc(alias = "g_dbus_method_invocation_return_gerror")]
     pub fn return_gerror(&self, error: glib::Error) {
         unsafe {
             ffi::g_dbus_method_invocation_return_gerror(

--- a/gio/src/inet_address.rs
+++ b/gio/src/inet_address.rs
@@ -44,6 +44,7 @@ impl InetAddress {
 }
 
 pub trait InetAddressExtManual {
+    #[doc(alias = "g_inet_address_to_bytes")]
     fn to_bytes(&self) -> Option<InetAddressBytes<'_>>;
 }
 

--- a/gio/src/input_stream.rs
+++ b/gio/src/input_stream.rs
@@ -17,18 +17,21 @@ use std::pin::Pin;
 use std::ptr;
 
 pub trait InputStreamExtManual: Sized {
+    #[doc(alias = "g_input_stream_read")]
     fn read<B: AsMut<[u8]>, C: IsA<Cancellable>>(
         &self,
         buffer: B,
         cancellable: Option<&C>,
     ) -> Result<usize, glib::Error>;
 
+    #[doc(alias = "g_input_stream_read_all")]
     fn read_all<B: AsMut<[u8]>, C: IsA<Cancellable>>(
         &self,
         buffer: B,
         cancellable: Option<&C>,
     ) -> Result<(usize, Option<glib::Error>), glib::Error>;
 
+    #[doc(alias = "g_input_stream_read_all_async")]
     fn read_all_async<
         B: AsMut<[u8]> + Send + 'static,
         Q: FnOnce(Result<(B, usize, Option<glib::Error>), (B, glib::Error)>) + Send + 'static,
@@ -41,6 +44,7 @@ pub trait InputStreamExtManual: Sized {
         callback: Q,
     );
 
+    #[doc(alias = "g_input_stream_read_async")]
     fn read_async<
         B: AsMut<[u8]> + Send + 'static,
         Q: FnOnce(Result<(B, usize), (B, glib::Error)>) + Send + 'static,

--- a/gio/src/output_stream.rs
+++ b/gio/src/output_stream.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 use std::ptr;
 
 pub trait OutputStreamExtManual: Sized + OutputStreamExt {
+    #[doc(alias = "g_output_stream_write_async")]
     fn write_async<
         B: AsRef<[u8]> + Send + 'static,
         Q: FnOnce(Result<(B, usize), (B, glib::Error)>) + Send + 'static,
@@ -26,12 +27,14 @@ pub trait OutputStreamExtManual: Sized + OutputStreamExt {
         callback: Q,
     );
 
+    #[doc(alias = "g_output_stream_write_all")]
     fn write_all<C: IsA<Cancellable>>(
         &self,
         buffer: &[u8],
         cancellable: Option<&C>,
     ) -> Result<(usize, Option<glib::Error>), glib::Error>;
 
+    #[doc(alias = "g_output_stream_write_all_async")]
     fn write_all_async<
         B: AsRef<[u8]> + Send + 'static,
         Q: FnOnce(Result<(B, usize, Option<glib::Error>), (B, glib::Error)>) + Send + 'static,

--- a/gio/src/pollable_input_stream.rs
+++ b/gio/src/pollable_input_stream.rs
@@ -16,6 +16,7 @@ use futures_core::stream::Stream;
 use std::pin::Pin;
 
 pub trait PollableInputStreamExtManual: Sized {
+    #[doc(alias = "g_pollable_input_stream_create_source")]
     fn create_source<F, C>(
         &self,
         cancellable: Option<&C>,
@@ -39,6 +40,7 @@ pub trait PollableInputStreamExtManual: Sized {
         priority: glib::Priority,
     ) -> Pin<Box<dyn Stream<Item = ()> + 'static>>;
 
+    #[doc(alias = "g_pollable_input_stream_read_nonblocking")]
     fn read_nonblocking<C: IsA<Cancellable>>(
         &self,
         buffer: &mut [u8],

--- a/gio/src/pollable_output_stream.rs
+++ b/gio/src/pollable_output_stream.rs
@@ -18,6 +18,7 @@ use std::pin::Pin;
 use futures_core::stream::Stream;
 
 pub trait PollableOutputStreamExtManual {
+    #[doc(alias = "g_pollable_output_stream_create_source")]
     fn create_source<F, C>(
         &self,
         cancellable: Option<&C>,

--- a/gio/src/socket.rs
+++ b/gio/src/socket.rs
@@ -62,16 +62,19 @@ impl AsRawSocket for Socket {
 }
 
 pub trait SocketExtManual: Sized {
+    #[doc(alias = "g_socket_receive")]
     fn receive<B: AsMut<[u8]>, C: IsA<Cancellable>>(
         &self,
         buffer: B,
         cancellable: Option<&C>,
     ) -> Result<usize, glib::Error>;
+    #[doc(alias = "g_socket_receive_from")]
     fn receive_from<B: AsMut<[u8]>, C: IsA<Cancellable>>(
         &self,
         buffer: B,
         cancellable: Option<&C>,
     ) -> Result<(usize, SocketAddress), glib::Error>;
+    #[doc(alias = "g_socket_receive_with_blocking")]
     fn receive_with_blocking<B: AsMut<[u8]>, C: IsA<Cancellable>>(
         &self,
         buffer: B,
@@ -79,17 +82,20 @@ pub trait SocketExtManual: Sized {
         cancellable: Option<&C>,
     ) -> Result<usize, glib::Error>;
 
+    #[doc(alias = "g_socket_send")]
     fn send<B: AsRef<[u8]>, C: IsA<Cancellable>>(
         &self,
         buffer: B,
         cancellable: Option<&C>,
     ) -> Result<usize, glib::Error>;
+    #[doc(alias = "g_socket_send_to")]
     fn send_to<B: AsRef<[u8]>, P: IsA<SocketAddress>, C: IsA<Cancellable>>(
         &self,
         address: Option<&P>,
         buffer: B,
         cancellable: Option<&C>,
     ) -> Result<usize, glib::Error>;
+    #[doc(alias = "g_socket_send_with_blocking")]
     fn send_with_blocking<B: AsRef<[u8]>, C: IsA<Cancellable>>(
         &self,
         buffer: B,
@@ -100,13 +106,16 @@ pub trait SocketExtManual: Sized {
     #[cfg(any(unix, feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     #[doc(alias = "get_fd")]
+    #[doc(alias = "g_socket_get_fd")]
     fn fd<T: FromRawFd>(&self) -> T;
 
     #[cfg(any(windows, feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(windows)))]
     #[doc(alias = "get_socket")]
+    #[doc(alias = "g_socket_get_fd")]
     fn socket<T: FromRawSocket>(&self) -> T;
 
+    #[doc(alias = "g_socket_create_source")]
     fn create_source<F, C>(
         &self,
         condition: glib::IOCondition,

--- a/gio/src/task.rs
+++ b/gio/src/task.rs
@@ -10,6 +10,7 @@ use std::boxed::Box as Box_;
 use std::ptr;
 
 impl Task {
+    #[doc(alias = "g_task_new")]
     pub fn new<P: IsA<Cancellable>, Q: FnOnce(&AsyncResult, Option<&glib::Object>) + 'static>(
         source_object: Option<&glib::Object>,
         cancellable: Option<&P>,
@@ -39,6 +40,7 @@ impl Task {
         }
     }
 
+    #[doc(alias = "g_task_return_error")]
     pub fn return_error(&self, error: glib::Error) {
         unsafe {
             ffi::g_task_return_error(self.to_glib_none().0, error.to_glib_full() as *mut _);
@@ -46,10 +48,12 @@ impl Task {
     }
 
     #[doc(alias = "get_priority")]
+    #[doc(alias = "g_task_get_priority")]
     pub fn priority(&self) -> glib::source::Priority {
         unsafe { FromGlib::from_glib(ffi::g_task_get_priority(self.to_glib_none().0)) }
     }
 
+    #[doc(alias = "g_task_set_priority")]
     pub fn set_priority(&self, priority: glib::source::Priority) {
         unsafe {
             ffi::g_task_set_priority(self.to_glib_none().0, priority.into_glib());

--- a/glib/src/array.rs
+++ b/glib/src/array.rs
@@ -27,6 +27,7 @@ impl Array {
         unsafe { (*self.to_glib_none().0).data as _ }
     }
 
+    #[doc(alias = "g_array_get_element_size")]
     pub fn element_size(&self) -> usize {
         unsafe { ffi::g_array_get_element_size(self.to_glib_none().0) as usize }
     }

--- a/glib/src/bytes.rs
+++ b/glib/src/bytes.rs
@@ -114,6 +114,7 @@ impl Deref for Bytes {
 }
 
 impl PartialEq for Bytes {
+    #[doc(alias = "g_bytes_equal")]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
             from_glib(ffi::g_bytes_equal(

--- a/glib/src/date.rs
+++ b/glib/src/date.rs
@@ -27,6 +27,7 @@ unsafe impl Sync for Date {}
 
 impl Date {
     #[doc(alias = "g_date_valid_dmy")]
+    #[doc(alias = "g_date_new_dmy")]
     pub fn new_dmy(day: DateDay, month: DateMonth, year: DateYear) -> Result<Date, BoolError> {
         let month = month.into_glib();
         unsafe {

--- a/glib/src/date.rs
+++ b/glib/src/date.rs
@@ -26,7 +26,6 @@ unsafe impl Send for Date {}
 unsafe impl Sync for Date {}
 
 impl Date {
-    #[doc(alias = "g_date_valid_dmy")]
     #[doc(alias = "g_date_new_dmy")]
     pub fn new_dmy(day: DateDay, month: DateMonth, year: DateYear) -> Result<Date, BoolError> {
         let month = month.into_glib();

--- a/glib/src/main_context_futures.rs
+++ b/glib/src/main_context_futures.rs
@@ -131,6 +131,7 @@ unsafe impl Sync for WakerSource {}
 
 impl TaskSource {
     #[allow(clippy::new_ret_no_self)]
+    #[doc(alias = "g_source_new")]
     fn new(priority: Priority, future: FutureWrapper) -> Source {
         unsafe {
             static TASK_SOURCE_FUNCS: ffi::GSourceFuncs = ffi::GSourceFuncs {

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1208,6 +1208,7 @@ pub trait ObjectExt: ObjectType {
     #[doc(alias = "get_interface")]
     fn interface<T: IsInterface>(&self) -> Option<InterfaceRef<T>>;
 
+    #[doc(alias = "g_object_set_property")]
     fn set_property<'a, N: Into<&'a str>, V: ToValue>(
         &self,
         property_name: N,
@@ -1222,6 +1223,7 @@ pub trait ObjectExt: ObjectType {
     fn set_properties_from_value(&self, property_values: &[(&str, Value)])
         -> Result<(), BoolError>;
     #[doc(alias = "get_property")]
+    #[doc(alias = "g_object_get_property")]
     fn property<'a, N: Into<&'a str>>(&self, property_name: N) -> Result<Value, BoolError>;
     fn has_property<'a, N: Into<&'a str>>(&self, property_name: N, type_: Option<Type>) -> bool;
     #[doc(alias = "get_property_type")]
@@ -1334,6 +1336,7 @@ pub trait ObjectExt: ObjectType {
     where
         F: Fn(&[Value]) -> Option<Value>;
     /// Emit signal by signal id.
+    #[doc(alias = "g_signal_emitv")]
     fn emit(&self, signal_id: SignalId, args: &[&dyn ToValue]) -> Result<Option<Value>, BoolError>;
     /// Same as `emit` but takes `Value` for the arguments.
     fn emit_with_values(
@@ -1367,6 +1370,7 @@ pub trait ObjectExt: ObjectType {
         details: Quark,
         args: &[Value],
     ) -> Result<Option<Value>, BoolError>;
+    #[doc(alias = "g_signal_handler_disconnect")]
     fn disconnect(&self, handler_id: SignalHandlerId);
 
     fn connect_notify<F: Fn(&Self, &crate::ParamSpec) + Send + Sync + 'static>(
@@ -1384,7 +1388,9 @@ pub trait ObjectExt: ObjectType {
         name: Option<&str>,
         f: F,
     ) -> SignalHandlerId;
+    #[doc(alias = "g_object_notify")]
     fn notify<'a, N: Into<&'a str>>(&self, property_name: N);
+    #[doc(alias = "g_object_notify_by_pspec")]
     fn notify_by_pspec(&self, pspec: &crate::ParamSpec);
 
     fn downgrade(&self) -> WeakRef<Self>;
@@ -2385,6 +2391,7 @@ impl ObjectClass {
             .map(|pspec| pspec.value_type())
     }
 
+    #[doc(alias = "g_object_class_find_property")]
     pub fn find_property<'a, N: Into<&'a str>>(
         &self,
         property_name: N,
@@ -2400,6 +2407,7 @@ impl ObjectClass {
         }
     }
 
+    #[doc(alias = "g_object_class_list_properties")]
     pub fn list_properties(&self) -> Vec<crate::ParamSpec> {
         unsafe {
             let klass = self as *const _ as *const gobject_ffi::GObjectClass;
@@ -2436,6 +2444,7 @@ impl<T: ObjectType> WeakRef<T> {
         }
     }
 
+    #[doc(alias = "g_weak_ref_set")]
     pub fn set(&self, obj: Option<&T>) {
         unsafe {
             gobject_ffi::g_weak_ref_set(
@@ -2751,6 +2760,7 @@ impl<T: IsClass> Class<T> {
     }
 
     /// Gets the parent class struct, if any.
+    #[doc(alias = "g_type_class_peek_parent")]
     pub fn parent(&self) -> Option<ClassRef<T>> {
         unsafe {
             let ptr = gobject_ffi::g_type_class_peek_parent(&self.0 as *const _ as *mut _);
@@ -2897,6 +2907,7 @@ impl<T: IsInterface> Interface<T> {
     }
 
     /// Gets the default interface struct for `Self`.
+    #[doc(alias = "g_type_default_interface_ref")]
     pub fn default() -> InterfaceRef<'static, T> {
         unsafe {
             let ptr = gobject_ffi::g_type_default_interface_ref(T::static_type().into_glib());
@@ -2913,6 +2924,7 @@ impl<T: IsInterface> Interface<T> {
     ///
     /// This returns the parent interface if a parent type of the instance type also implements the
     /// interface.
+    #[doc(alias = "g_type_interface_peek_parent")]
     pub fn parent(&self) -> Option<InterfaceRef<T>> {
         unsafe {
             let ptr = gobject_ffi::g_type_interface_peek_parent(&self.0 as *const _ as *mut _);

--- a/glib/src/source.rs
+++ b/glib/src/source.rs
@@ -696,6 +696,7 @@ where
 /// For historical reasons, the native function always returns true, so we
 /// ignore it here.
 #[allow(clippy::needless_pass_by_value)]
+#[doc(alias = "g_source_remove")]
 pub fn source_remove(source_id: SourceId) {
     unsafe {
         ffi::g_source_remove(source_id.as_raw());

--- a/glib/src/string.rs
+++ b/glib/src/string.rs
@@ -127,6 +127,7 @@ impl fmt::Display for String {
 }
 
 impl PartialEq for String {
+    #[doc(alias = "g_string_equal")]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
             from_glib(ffi::g_string_equal(

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -127,6 +127,7 @@ pub struct GenericValueTypeChecker<T>(std::marker::PhantomData<T>);
 unsafe impl<T: StaticType> ValueTypeChecker for GenericValueTypeChecker<T> {
     type Error = ValueTypeMismatchError;
 
+    #[doc(alias = "g_type_check_value_holds")]
     fn check(value: &Value) -> Result<(), Self::Error> {
         unsafe {
             if gobject_ffi::g_type_check_value_holds(&value.0, T::static_type().into_glib())
@@ -356,6 +357,7 @@ impl Value {
     }
 
     /// Returns whether `Value`s of type `src` can be transformed to type `dst`.
+    #[doc(alias = "g_value_type_transformable")]
     pub fn type_transformable(src: Type, dst: Type) -> bool {
         unsafe {
             from_glib(gobject_ffi::g_value_type_transformable(
@@ -366,6 +368,7 @@ impl Value {
     }
 
     /// Tries to transform the value into a value of the target type
+    #[doc(alias = "g_value_transform")]
     pub fn transform<T: ValueType>(&self) -> Result<Value, crate::BoolError> {
         unsafe {
             let mut dest = Value::for_value_type::<T>();

--- a/glib/src/value_array.rs
+++ b/glib/src/value_array.rs
@@ -18,10 +18,12 @@ wrapper! {
 }
 
 impl ValueArray {
+    #[doc(alias = "g_value_array_new")]
     pub fn new(n_prealloced: u32) -> ValueArray {
         unsafe { from_glib_full(gobject_ffi::g_value_array_new(n_prealloced)) }
     }
 
+    #[doc(alias = "g_value_array_append")]
     pub fn append(&mut self, value: &Value) {
         let value = value.to_glib_none();
         unsafe {
@@ -39,6 +41,7 @@ impl ValueArray {
     }
 
     #[doc(alias = "get_nth")]
+    #[doc(alias = "g_value_array_get_nth")]
     pub fn nth(&self, index_: u32) -> Option<Value> {
         unsafe {
             from_glib_none(gobject_ffi::g_value_array_get_nth(
@@ -48,6 +51,7 @@ impl ValueArray {
         }
     }
 
+    #[doc(alias = "g_value_array_insert")]
     pub fn insert(&mut self, index_: u32, value: &Value) {
         let value = value.to_glib_none();
         unsafe {
@@ -55,6 +59,7 @@ impl ValueArray {
         }
     }
 
+    #[doc(alias = "g_value_array_prepend")]
     pub fn prepend(&mut self, value: &Value) {
         let value = value.to_glib_none();
         unsafe {
@@ -62,12 +67,14 @@ impl ValueArray {
         }
     }
 
+    #[doc(alias = "g_value_array_remove")]
     pub fn remove(&mut self, index_: u32) {
         unsafe {
             gobject_ffi::g_value_array_remove(self.to_glib_none_mut().0, index_);
         }
     }
 
+    #[doc(alias = "g_value_array_sort_with_data")]
     pub fn sort_with_data<F: FnMut(&Value, &Value) -> Ordering>(&mut self, compare_func: F) {
         unsafe extern "C" fn compare_func_trampoline(
             a: ffi::gconstpointer,

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -208,6 +208,7 @@ impl Variant {
     /// * if `self` is not a container type.
     /// * if given `index` is larger than number of children.
     #[doc(alias = "get_child_value")]
+    #[doc(alias = "g_variant_get_child_value")]
     pub fn child_value(&self, index: usize) -> Variant {
         assert!(index < self.n_children());
         assert!(self.is_container());
@@ -220,6 +221,7 @@ impl Variant {
     /// Returns `Some` if the variant has a string type (`s`, `o` or `g` type
     /// strings).
     #[doc(alias = "get_str")]
+    #[doc(alias = "g_variant_get_string")]
     pub fn str(&self) -> Option<&str> {
         unsafe {
             match self.type_().to_str() {
@@ -285,6 +287,7 @@ impl Variant {
     }
 
     /// Constructs a new serialised-mode GVariant instance.
+    #[doc(alias = "g_variant_new_from_bytes")]
     pub fn from_bytes<T: StaticVariantType>(bytes: &Bytes) -> Self {
         unsafe {
             from_glib_none(ffi::g_variant_new_from_bytes(
@@ -317,11 +320,13 @@ impl Variant {
 
     /// Returns the serialised form of a GVariant instance.
     #[doc(alias = "get_data_as_bytes")]
+    #[doc(alias = "g_variant_get_data_as_bytes")]
     pub fn data_as_bytes(&self) -> Bytes {
         unsafe { from_glib_full(ffi::g_variant_get_data_as_bytes(self.to_glib_none().0)) }
     }
 
     /// Determines the number of children in a container GVariant instance.
+    #[doc(alias = "g_variant_n_children")]
     pub fn n_children(&self) -> usize {
         assert!(self.is_container());
 
@@ -336,6 +341,7 @@ impl Variant {
     }
 
     /// Variant has a container type.
+    #[doc(alias = "g_variant_is_container")]
     pub fn is_container(&self) -> bool {
         unsafe { ffi::g_variant_is_container(self.to_glib_none().0) != ffi::GFALSE }
     }
@@ -367,6 +373,7 @@ impl fmt::Display for Variant {
 }
 
 impl PartialEq for Variant {
+    #[doc(alias = "g_variant_equal")]
     fn eq(&self, other: &Self) -> bool {
         unsafe {
             from_glib(ffi::g_variant_equal(
@@ -403,6 +410,7 @@ impl PartialOrd for Variant {
 }
 
 impl Hash for Variant {
+    #[doc(alias = "g_variant_hash")]
     fn hash<H: Hasher>(&self, state: &mut H) {
         unsafe { state.write_u32(ffi::g_variant_hash(self.to_glib_none().0 as *const _)) }
     }

--- a/glib/src/variant_dict.rs
+++ b/glib/src/variant_dict.rs
@@ -36,6 +36,7 @@ impl VariantDict {
     /// # Panics
     ///
     /// This function will panic if the given `Variant` is not of the correct type.
+    #[doc(alias = "g_variant_dict_new")]
     pub fn new(from_asv: Option<&Variant>) -> Self {
         if let Some(var) = from_asv {
             assert_eq!(var.type_(), VariantDict::static_variant_type());
@@ -47,6 +48,7 @@ impl VariantDict {
     ///
     /// Look up whether or not the given key is present, returning `true` if it
     /// is present in `self`.
+    #[doc(alias = "g_variant_dict_contains")]
     pub fn contains(&self, key: &str) -> bool {
         unsafe {
             from_glib(ffi::g_variant_dict_contains(
@@ -65,6 +67,7 @@ impl VariantDict {
     /// or if it is present but the type of the value does not match a given
     /// `expected_type`.  Otherwise `Some(value)` will be returned where
     /// the `value` is an instance of [`Variant`](variant/struct.Variant.html).
+    #[doc(alias = "g_variant_dict_lookup_value")]
     pub fn lookup_value(&self, key: &str, expected_type: Option<&VariantTy>) -> Option<Variant> {
         unsafe {
             from_glib_full(ffi::g_variant_dict_lookup_value(
@@ -82,6 +85,7 @@ impl VariantDict {
     ///
     /// For convenience, you may use the [`insert()`](#method.insert) if
     /// you have a value which implements [`ToVariant`](variant/trait.ToVariant.html).
+    #[doc(alias = "g_variant_dict_insert_value")]
     pub fn insert_value(&self, key: &str, value: &Variant) {
         unsafe {
             ffi::g_variant_dict_insert_value(
@@ -104,6 +108,7 @@ impl VariantDict {
     /// If, on the other hand, you have a [`Variant`](variant/struct.Variant.html)
     /// instance already, you should use the [`insert_value()`](#method.insert_value)
     /// method instead.
+    #[doc(alias = "g_variant_dict_insert_value")]
     pub fn insert<T: ToVariant>(&self, key: &str, value: &T) {
         unsafe {
             ffi::g_variant_dict_insert_value(
@@ -121,6 +126,7 @@ impl VariantDict {
     ///
     /// If a `key`/`value` pair was removed from the dictionary, `true` is
     /// returned.  If `key` was not present then `false` is returned instead.
+    #[doc(alias = "g_variant_dict_remove")]
     pub fn remove(&self, key: &str) -> bool {
         unsafe {
             from_glib(ffi::g_variant_dict_remove(

--- a/pango/src/language.rs
+++ b/pango/src/language.rs
@@ -58,20 +58,24 @@ impl FromGlibPtrFull<*const ffi::PangoLanguage> for Language {
 }
 
 impl Default for Language {
+    #[doc(alias = "pango_language_get_default")]
     fn default() -> Self {
         unsafe { from_glib_full(ffi::pango_language_get_default()) }
     }
 }
 
 impl Language {
+    #[doc(alias = "pango_language_from_string")]
     pub fn from_string(language: &str) -> Self {
         unsafe { from_glib_full(ffi::pango_language_from_string(language.to_glib_none().0)) }
     }
 
+    #[doc(alias = "pango_language_to_string")]
     pub fn to_string(&self) -> GString {
         unsafe { from_glib_none(ffi::pango_language_to_string(self.to_glib_none().0)) }
     }
 
+    #[doc(alias = "pango_language_matches")]
     pub fn matches(&self, range_list: &str) -> bool {
         unsafe {
             from_glib(ffi::pango_language_matches(
@@ -81,6 +85,7 @@ impl Language {
         }
     }
 
+    #[doc(alias = "pango_language_includes_script")]
     pub fn includes_script(&self, script: Script) -> bool {
         unsafe {
             from_glib(ffi::pango_language_includes_script(
@@ -91,6 +96,7 @@ impl Language {
     }
 
     #[doc(alias = "get_scripts")]
+    #[doc(alias = "pango_language_get_scripts")]
     pub fn scripts(&self) -> Vec<Script> {
         let mut num_scripts = 0;
         let mut ret = Vec::new();
@@ -110,6 +116,7 @@ impl Language {
     }
 
     #[doc(alias = "get_sample_string")]
+    #[doc(alias = "pango_language_get_sample_string")]
     pub fn sample_string(&self) -> GString {
         unsafe { from_glib_none(ffi::pango_language_get_sample_string(self.to_glib_none().0)) }
     }


### PR DESCRIPTION
Fixes https://github.com/gtk-rs/gtk-rs-core/issues/79.

I improved the previous python script:

<details>

```python
import os
import sys


IGNORE_C_FNS = ["_get_reference_count", "_status", "_free", "_destroy", "_unref"]
IGNORE_FNS = [
    "deref", "deref_mut", "drop", "fmt", "clone", "to_value", "g_value_get_flags",
    "g_value_set_flags", "get_type",
]
IGNORE_FNS_START = ["to_glib", "from_glib", "from_raw", "to_raw"]


def is_valid_name(s):
    for c in s:
        if not c.isalnum() and c != '_':
            return False
    for x in IGNORE_C_FNS:
        if s.endswith(x):
            return False
    return True


def get_fn_name(s):
    parts = s.split(" ")
    x = 0
    while x < len(parts) and parts[x] != "fn":
        x += 1
    x += 1
    if x >= len(parts):
        return None
    fn_name = parts[x].split("<")[0].split("(")[0]
    for x in IGNORE_FNS_START:
        if fn_name.startswith(x):
            return None
    if fn_name in IGNORE_FNS:
        return None
    return fn_name


# This to prevent to add the same doc alias more than once on a same function.
def need_doc_alias(content, pos, alias):
    pos -= 1
    while pos >= 0:
        stripped = content[pos].strip()
        if not stripped.startswith("#[") and not stripped.startswith("///"):
            return True
        elif stripped == alias:
            return False
        pos -= 1
    return True


def find_method_in_trait(content, start_line, fn_name):
    if start_line is None:
        return None
    start_line += 1
    while start_line < len(content):
        clean = content[start_line].strip()
        if clean.startswith("fn "):
            name = clean[3:].split("<")[0].split("(")[0]
            if name == fn_name:
                return start_line
        elif content[start_line] == "}":
            # We reached the end of the trait declaration and found nothing...
            break
        start_line += 1
    return None


def add_parts(path):
    print("=> Updating '{}'".format(path))
    with open(path, 'r') as f:
        content = f.read().split('\n')
    x = 0
    # The key is the trait name, the value is its line number.
    traits = {}
    is_in_trait = None
    while x < len(content):
        clean = content[x].lstrip()
        if not clean.startswith("pub fn") and not clean.startswith("fn"):
            if content[x] == "}":
                is_in_trait = None
            elif (clean.startswith("impl ") or clean.startswith("impl<")) and " for " in clean:
                name = clean.split(" for ")[0].split(" ")[-1].strip()
                if name.endswith("Ext") or name.endswith("ExtManual"):
                    is_in_trait = name
            # This is needed because we want to put Ext traits doc aliases on the trait methods
            # directly and not on their implementation.
            if clean.startswith("pub trait") or clean.startswith("trait"):
                name = clean.split("trait")[1].split("<")[0].split(":")[0].split("{")[0].strip()
                if name.endswith("Ext") or name.endswith("ExtManual"):
                    traits[name] = x
                    # Completely skip the trait declaration.
                    while x < len(content) and content[x] != "}":
                        x += 1
                    continue
            x += 1
            continue

        if clean.endswith(';'): # very likely a trait method declaration.
            x += 1
            continue
        fn_name = get_fn_name(clean)
        if fn_name is None:
            x += 1
            continue
        spaces = ''
        for _ in range(0, len(content[x]) - len(clean)):
            spaces += ' '
        spaces_and_braces = spaces + '}'
        start = x
        need_traits_update = False
        if is_in_trait is not None:
            trait_method_pos = find_method_in_trait(content, traits.get(is_in_trait), fn_name)
            if trait_method_pos is None:
                print("Cannot find `{}` in trait `{}`, putting doc aliases on implementation".format(fn_name, is_in_trait))
            else:
                start = trait_method_pos
                need_traits_update = True
        x += 1
        added = 0
        while x < len(content):
            if content[x] == spaces_and_braces:
                break
            if "ffi::" in content[x]:
                sys_name = content[x].split("ffi::")[1].split("(")[0]
                if is_valid_name(sys_name):
                    alias = '#[doc(alias = "{}")]'.format(sys_name)
                    if need_doc_alias(content, start, alias) and fn_name in sys_name:
                        content.insert(start, spaces + alias)
                        added += 1
                        start += 1
                        x += 1
            x += 1
        if need_traits_update and added > 0:
            # move their start pos
            for trait in traits:
                if traits[trait] > start:
                    traits[trait] += added
        x += 1
    with open(path, 'w') as f:
        f.write('\n'.join(content))


def run_dirs(path):
    for entry in os.listdir(path):
        full = os.path.join(path, entry)
        if os.path.isdir(full):
            # We don't want to go in auto code parts. They already have everything they need.
            if not entry in ["auto", "subclass"]:
                run_dirs(full)
        elif entry.endswith(".rs"):
            add_parts(full)


def main():
    if len(sys.argv) < 2:
        print("No folder given as argument, updating current `src` (if any)")
        run_dirs("src")
    else:
        for x in sys.argv[1:]:
            print("> Going into folder `{}`...".format(x))
            run_dirs(x)
            print("< Done!")


if __name__ == "__main__":
    main()
```

</details>