### PR TITLE
translate: make try_from_glib unsafe

### DIFF
--- a/glib-macros/src/genum_derive.rs
+++ b/glib-macros/src/genum_derive.rs
@@ -98,7 +98,7 @@ pub fn impl_genum(input: &syn::DeriveInput) -> TokenStream {
         impl #crate_ident::translate::TryFromGlib<i32> for #name {
             type Error = i32;
 
-            fn try_from_glib(value: i32) -> Result<Self, i32> {
+            unsafe fn try_from_glib(value: i32) -> Result<Self, i32> {
                 let from_glib = || {
                     #from_glib
                 };


### PR DESCRIPTION
A defunct implementation could lead to inconsistencies or UB due to
a valid Rust value being constructed from an invalid or undefined
(aka None) C value.

Re-opened and updated to master from https://github.com/gtk-rs/gtk3-rs/pull/463