### PR TITLE
CI docs: use gir-rustdoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,8 @@ jobs:
         run: cargo build --release
       - run: cargo install rustdoc-stripper
       - run: python3 ./generator.py --embed-docs --yes ./
+      - run: git clone https://gitlab.gnome.org/World/Rust/gir-rustdoc/ # checkout action doesn't support random urls
+      - run: echo "RUSTDOCFLAGS=$(eval python3 ./gir-rustdoc/gir-rustdoc.py --pages-url 'https://gtk-rs.org/gtk-rs-core/' --default-branch 'master' --branch 'master' pre-docs | xargs)" >> ${GITHUB_ENV}
       - uses: actions-rs/cargo@v1
         with:
           command: doc
@@ -43,3 +45,14 @@ jobs:
           publish_dir: ./target/doc/
           keep_files: false
           destination_dir: ${{ env.DEST }}/docs
+
+      - run: python3 ./gir-rustdoc/gir-rustdoc.py --project-title 'GTK Core Rust bindings' html-index
+      - name: deploy index page
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public/
+          keep_files: true
+          destination_dir: ./
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,4 +55,3 @@ jobs:
           publish_dir: ./public/
           keep_files: true
           destination_dir: ./
-


### PR DESCRIPTION
This generates a main page along with a popover to point to latest docs if the user is reading an old/git version of it