### PR TITLE
CI: add the 0.10 release to the index page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,9 @@ jobs:
           destination_dir: ${{ env.DEST }}/docs
 
       - run: python3 ./gir-rustdoc/gir-rustdoc.py --project-title 'GTK Core Rust bindings' html-index
+        env:
+          RELEASES: |
+            0.10=0.10
       - name: deploy index page
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release' }}


### PR DESCRIPTION
the gir-rustdoc looks for this env variable to define a list of releases on the index page. This would show a link to the versioned 0.10 docs