### PR TITLE
Fix glib re-export detection for macros

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,6 +104,10 @@ jobs:
         run: cargo build --manifest-path glib-macros/Cargo.toml
       - name: "glib-macros: test"
         run: cargo test --manifest-path glib-macros/Cargo.toml
+      # glib-macros in 2 levels dependent
+      - name: Check two levels glib dependent
+        run: cargo check
+        working-directory: tests/two-levels-glib-dependent
       # examples
       - name: "examples"
         run: cargo build --manifest-path examples/Cargo.toml --bins --examples --all-features

--- a/tests/two-levels-glib-dependent/Cargo.toml
+++ b/tests/two-levels-glib-dependent/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+
+members = [
+    "gstreamer",
+    "gtk",
+    "glib-dependent-dependent"
+]

--- a/tests/two-levels-glib-dependent/README.md
+++ b/tests/two-levels-glib-dependent/README.md
@@ -1,0 +1,10 @@
+# glib-rs Two Levels Dependent Test
+
+This repository is intended at checking `glib` macro
+re-export detection in two levels dependencies.
+
+The detection mechanism used to stop at the first identified crate known
+to re-export `glib` and which was found in `Cargo.toml`. When used in a crate
+that depends both on `gstreamer` and `gtk` and `gtk` is optional, the detection
+mechanism stopped at `gtk` and preprended `gtk` to `glib`, leading to errors
+compiling `glib` proc-macros.

--- a/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
+++ b/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "glib-dependent-dependent"
+version = "0.1.0"
+authors = ["François Laignel <fengalin@free.fr>"]
+description = "crate that depends on a glib-rs dependent crate for validation of glib re-exports in proc-macros"
+keywords = ["gtk-rs-core", "integration"]
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+[dependencies]
+# Use `gstreamer` as a simulation of an identified crate re-exporting `glib`.
+gst = { package = "gstreamer", path = "../gstreamer" }
+# Use `gtk` optionally so that it is part of the declared dependencies.
+gtk = { path = "../gtk", optional = true }

--- a/tests/two-levels-glib-dependent/glib-dependent-dependent/src/lib.rs
+++ b/tests/two-levels-glib-dependent/glib-dependent-dependent/src/lib.rs
@@ -1,0 +1,34 @@
+use gst::glib;
+use gst::glib::prelude::*;
+use gst::glib::subclass::prelude::*;
+
+pub mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct Foo {}
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Foo {
+        const NAME: &'static str = "MyFoo";
+        type Type = super::Foo;
+        type ParentType = glib::Object;
+    }
+
+    impl ObjectImpl for Foo {}
+}
+
+pub trait FooExt: 'static {
+    fn test(&self);
+}
+
+impl<O: IsA<Foo>> FooExt for O {
+    fn test(&self) {
+        let _self = imp::Foo::from_instance(self.as_ref().downcast_ref::<Foo>().unwrap());
+        unimplemented!();
+    }
+}
+
+glib::wrapper! {
+    pub struct Foo(ObjectSubclass<imp::Foo>);
+}

--- a/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+# This crate is named `gstreamer` so that we can check that `glib` re-export detection succeeds.
+name = "gstreamer"
+version = "0.1.0"
+authors = ["François Laignel <fengalin@free.fr>"]
+description = "gstreamer simulator as a glib dependent crate for validation of glib re-exports in proc-macros"
+keywords = ["gtk-rs-core", "integration"]
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+[dependencies]
+glib = { path = "../../../glib" }

--- a/tests/two-levels-glib-dependent/gstreamer/src/lib.rs
+++ b/tests/two-levels-glib-dependent/gstreamer/src/lib.rs
@@ -1,0 +1,1 @@
+pub use glib;

--- a/tests/two-levels-glib-dependent/gtk/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gtk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+# This crate is named `gtk` so that we can check that `glib` re-export detection succeeds.
+name = "gtk"
+version = "0.1.0"
+authors = ["François Laignel <fengalin@free.fr>"]
+description = "gtk simulator as a glib dependent crate for validation of glib re-exports in proc-macros"
+keywords = ["gtk-rs-core", "integration"]
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+[dependencies]
+glib = { path = "../../../glib" }

--- a/tests/two-levels-glib-dependent/gtk/src/lib.rs
+++ b/tests/two-levels-glib-dependent/gtk/src/lib.rs
@@ -1,0 +1,1 @@
+pub use glib;


### PR DESCRIPTION
When a crate includes 2 `glib` dependent known crates, the first known is
selected to prepend to `glib` in macros. If this first crate is optional
and not selected, it is not reachable and causes compilation error.