### PR TITLE
CI docs: define releases env variable for all steps

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,9 @@ jobs:
     name: build
     container:
       image: ghcr.io/gtk-rs/gtk-rs/gtk:latest
+    env:
+      RELEASES: |
+        0.10=0.10
     steps:
       - uses: actions/checkout@v2
         with:
@@ -45,9 +48,6 @@ jobs:
           destination_dir: ${{ env.DEST }}/docs
 
       - run: python3 ./gir-rustdoc/gir-rustdoc.py --project-title 'GTK Core Rust bindings' html-index
-        env:
-          RELEASES: |
-            0.10=0.10
       - name: deploy index page
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release' }}


### PR DESCRIPTION
so that the pre-docs step generates a link to the latest release correctly