### PR TITLE
glib-macros: add proc_macro_error attribute to clone

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -239,6 +239,7 @@ use syn::{parse_macro_input, DeriveInput, LitStr};
 /// }
 /// ```
 #[proc_macro]
+#[proc_macro_error]
 pub fn clone(item: TokenStream) -> TokenStream {
     clone::clone_inner(item)
 }


### PR DESCRIPTION
Should hopefully fix #124