### PR TITLE
Add minimal crate info

### DIFF
--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -5,33 +5,35 @@
 //! This library contains safe Rust bindings for [Cairo](https://www.cairographics.org/).
 //! It is a part of [Gtk-rs](https://gtk-rs.org/).
 //!
-//! ## Crate features
+//! Cairo 1.14 is the lowest supported version for the underlying library.
 //!
-//! ### Default-on features
+//! # Crate features
+//!
+//! ## Default-on features
 //!
 //! * **use_glib** - Use with [glib](https://gtk-rs.org/docs/glib/)
 //!
-//! ### Fileformat features
+//! ## Fileformat features
 //!
 //! * **png** - Reading and writing PNG images
 //! * **pdf** - Rendering PDF documents
 //! * **svg** - Rendering SVG documents
 //! * **ps** - Rendering PostScript documents
 //!
-//! ### Cairo API version features
+//! ## Cairo API version features
 //!
 //! * **v1_16** - Use Cairo 1.16 APIs
 //!
-//! ### Documentation features
+//! ## Documentation features
 //!
 //! * **dox** - Used to keep system dependent items in documentation
 //!
-//! ### X Window features
+//! ## X Window features
 //!
 //! * **xcb** - X Window System rendering using the XCB library
 //! * **xlib** - X Window System rendering using XLib
 //!
-//! ### Windows API features
+//! ## Windows API features
 //!
 //! * **win32-surface** - Microsoft Windows surface support
 

--- a/gdk-pixbuf/src/lib.rs
+++ b/gdk-pixbuf/src/lib.rs
@@ -1,5 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+//! # Rust GDK-PixBuf bindings
+//!
+//! This library contains safe Rust bindings for [GDK-PixBuf](https://docs.gtk.org/gdk-pixbuf).
+//! It is a part of [Gtk-rs](https://gtk-rs.org/).
+//!
+//! GDK-PixBuf 2.32 is the lowest supported version for the underlying library.
+
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 pub use ffi;

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -1,5 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+//! # Rust GIO bindings
+//!
+//! This library contains safe Rust bindings for [GIO](https://developer.gnome.org/gio/).
+//! It is a part of [Gtk-rs](https://gtk-rs.org/).
+//!
+//! GIO 2.48 is the lowest supported version for the underlying library.
+
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -12,6 +12,8 @@
 //! would often amount to duplicating the Rust Standard Library or other utility
 //! crates.
 //!
+//! GLib 2.48 is the lowest supported version for the underlying library.
+//!
 //! # Dynamic typing
 //!
 //! Most types in the GLib family have [`Type`] identifiers.

--- a/graphene/src/lib.rs
+++ b/graphene/src/lib.rs
@@ -1,5 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+//! # Rust Graphene bindings
+//!
+//! This library contains safe Rust bindings for [Graphene](https://github.com/ebassi/graphene).
+//! It is a part of [Gtk-rs](https://gtk-rs.org/).
+//!
+//! Graphene 2.44 is the lowest supported version for the underlying library.
+
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 pub use ffi;

--- a/pango/src/lib.rs
+++ b/pango/src/lib.rs
@@ -1,5 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+//! # Rust Pango bindings
+//!
+//! This library contains safe Rust bindings for [Pango](https://docs.gtk.org/Pango/).
+//! It is a part of [Gtk-rs](https://gtk-rs.org/).
+//!
+//! Pango 1.38 is the lowest supported version for the underlying library.
+
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 pub use ffi;

--- a/pangocairo/src/lib.rs
+++ b/pangocairo/src/lib.rs
@@ -1,5 +1,14 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+//! # Rust PangoCairo bindings
+//!
+//! This library contains safe Rust bindings for [PangoCairo](https://docs.gtk.org/PangoCairo).
+//! It is a part of [Gtk-rs](https://gtk-rs.org/).
+//!
+//! PangoCairo 1.38 is the lowest supported version for the underlying library.
+
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
 
 pub use cairo;


### PR DESCRIPTION
Also adds minimum required version of the library to every crate doc.