### PR TITLE
cairo docs: use mod for linking glib

### DIFF
--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Default-on features
 //!
-//! * **use_glib** - Use with [glib](https://gtk-rs.org/docs/glib/)
+//! * **use_glib** - Use with [glib](mod@glib)
 //!
 //! ## Fileformat features
 //!


### PR DESCRIPTION
so that the link works properly for both stable/git docs