### PR TITLE
stable docs: make cairo link to current glib

### DIFF
--- a/stable/0.10/docs/cairo/index.html
+++ b/stable/0.10/docs/cairo/index.html
@@ -4,7 +4,7 @@
 It is a part of <a href="http://gtk-rs.org/">Gtk-rs</a>.</p>
 <h2 id="crate-features" class="section-header"><a href="#crate-features">Crate features</a></h2><h3 id="default-on-features" class="section-header"><a href="#default-on-features">Default-on features</a></h3>
 <ul>
-<li><strong>use_glib</strong> - Use with <a href="https://gtk-rs.org/docs/glib/">glib</a></li>
+<li><strong>use_glib</strong> - Use with <a href="https://gtk-rs.org/gtk-rs-core/stable/0.10/docs/glib/index.html">glib</a></li>
 </ul>
 <h3 id="fileformat-features" class="section-header"><a href="#fileformat-features">Fileformat features</a></h3>
 <ul>


### PR DESCRIPTION
otherwise the 0.10 cairo docs redirects the user to another docs source which isn't a great experience