### PR TITLE
glib: Make `SignalHandlerId` implement `Clone` and `Copy`

### DIFF
--- a/glib/src/signal.rs
+++ b/glib/src/signal.rs
@@ -41,7 +41,7 @@ use std::num::NonZeroU64;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SignalHandlerId(NonZeroU64);
 
 impl SignalHandlerId {


### PR DESCRIPTION
It's just a wrapper around a non-zero integer, so I don't see any reason it can't be `Copy`.