### PR TITLE
glib: implement Clone on SourceId

### DIFF
--- a/glib/src/signal.rs
+++ b/glib/src/signal.rs
@@ -12,6 +12,9 @@ use std::num::NonZeroU64;
 
 /// The id of a signal that is returned by `connect`.
 ///
+/// This type does not implement `Clone` to prevent disconnecting
+/// the same signal handler multiple times.
+///
 /// ```ignore
 /// use glib::SignalHandlerId;
 /// use gtk::prelude::*;

--- a/glib/src/source.rs
+++ b/glib/src/source.rs
@@ -17,6 +17,9 @@ use crate::MainContext;
 use crate::Source;
 
 /// The id of a source that is returned by `idle_add` and `timeout_add`.
+///
+/// This type does not implement `Clone` to prevent calling [`source_remove()`]
+/// multiple times on the same source.
 #[derive(Debug, Eq, PartialEq)]
 pub struct SourceId(NonZeroU32);
 


### PR DESCRIPTION
I need to store the SourceId in a struct so it's automatically removed
on Drop. But I cannot do so as the SourceId does not implement Copy or
Clone and source_remove() consumes the SourceId.