### PR TITLE
Add cairo::Result type alias

### DIFF
--- a/cairo/src/error.rs
+++ b/cairo/src/error.rs
@@ -255,3 +255,5 @@ pub enum BorrowError {
     #[error("Can't get exclusive access")]
     NonExclusive,
 }
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -122,7 +122,7 @@ pub use crate::device::Device;
 
 pub use crate::enums::*;
 
-pub use crate::error::{BorrowError, Error, IoError};
+pub use crate::error::{BorrowError, Error, IoError, Result};
 
 pub use crate::patterns::{
     Gradient, LinearGradient, Mesh, Pattern, RadialGradient, SolidPattern, SurfacePattern,


### PR DESCRIPTION
Because it's really convenient.