### PR TITLE
Make stronger guarantees on `ToValue`

### DIFF
--- a/glib/tests/value.rs
+++ b/glib/tests/value.rs
@@ -1,0 +1,66 @@
+use glib::*;
+use std::ops::Deref;
+
+// FIXME all .get::<i32>() should be replaced with .get(); the compiler is totally able to infer the type itself.
+// But somehow without some tests are failing on Windows because the type inference doesn't work or something.
+
+/// Test that `ToValue` (and conversely, `FromValue`) uphold the promised invariants
+#[test]
+pub fn to_value_invariants() {
+    // Inverse
+    assert_eq!(0i32, 0i32.to_value().get::<i32>().unwrap());
+    assert_eq!(0i32, (&0i32.to_value()).get::<i32>().unwrap());
+
+    // Idempotence
+    assert_eq!(
+        &0i32.to_value().type_(),
+        &0i32.to_value().to_value().type_()
+    );
+    assert_eq!(0i32, 0i32.to_value().to_value().get::<i32>().unwrap());
+    assert_eq!(
+        0i32,
+        0i32.to_value()
+            .get::<Value>()
+            .unwrap()
+            .get::<i32>()
+            .unwrap()
+    );
+    assert_eq!(
+        0i32,
+        (&0i32.to_value())
+            .get::<Value>()
+            .unwrap()
+            .get::<i32>()
+            .unwrap()
+    );
+}
+
+/// Test that `ToValue` and `FromValue` handle nexted boxed values correctly (as per the documentation)
+#[test]
+pub fn to_value_boxed() {
+    let x = 0i32.to_value();
+    let boxed = BoxedValue(x);
+    assert_eq!(
+        0i32,
+        boxed
+            .to_value()
+            .to_value()
+            .get::<BoxedValue>()
+            .unwrap()
+            .deref()
+            .get::<i32>()
+            .unwrap()
+    );
+    assert_eq!(
+        0i32,
+        boxed
+            .to_value()
+            .get::<Value>()
+            .unwrap()
+            .get::<BoxedValue>()
+            .unwrap()
+            .deref()
+            .get::<i32>()
+            .unwrap()
+    );
+}


### PR DESCRIPTION
This more or less reverts https://github.com/gtk-rs/glib/commit/390ca3a2 ("Don't implement ToValue for Value").

Closes #4.

To be honest, I'm not 100% sure if this is the best way forward. The traits and trait bounds are really convoluted and hard to keep track of. For example, I don't know how well this works for `SendValue`. Let me know what you think.