### PR TITLE
Ignore find_with_equal_func for ListStore until a suitable API is provided by the C library

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -704,6 +704,9 @@ manual_traits = ["ListStoreExtManual"]
     name = "sort"
     manual = true
     doc_trait_name = "ListStoreExtManual"
+    [[object.function]]
+    name = "find_with_equal_func"
+    ignore = true # See https://gitlab.gnome.org/GNOME/glib/-/issues/2447
 
 [[object]]
 name = "Gio.MemoryInputStream"

--- a/gio/src/auto/list_store.rs
+++ b/gio/src/auto/list_store.rs
@@ -63,13 +63,6 @@ impl ListStore {
         }
     }
 
-    //#[cfg(any(feature = "v2_64", feature = "dox"))]
-    //#[cfg_attr(feature = "dox", doc(cfg(feature = "v2_64")))]
-    //#[doc(alias = "g_list_store_find_with_equal_func")]
-    //pub fn find_with_equal_func<P: IsA<glib::Object>>(&self, item: &P, equal_func: /*Unimplemented*/FnMut(/*Unimplemented*/Option<Fundamental: Pointer>, /*Unimplemented*/Option<Fundamental: Pointer>) -> bool) -> Option<u32> {
-    //    unsafe { TODO: call ffi:g_list_store_find_with_equal_func() }
-    //}
-
     #[doc(alias = "g_list_store_insert")]
     pub fn insert<P: IsA<glib::Object>>(&self, position: u32, item: &P) {
         unsafe {


### PR DESCRIPTION
Fixes #202.