### PR TITLE
Add an Iterator for ListModel

### DIFF
--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -47,6 +47,7 @@ mod io_stream;
 pub use crate::io_stream::IOStreamAsyncReadWrite;
 mod input_stream;
 pub use crate::input_stream::{InputStreamAsyncBufRead, InputStreamRead};
+mod list_model;
 mod list_store;
 #[cfg(test)]
 mod memory_input_stream;

--- a/gio/src/list_model.rs
+++ b/gio/src/list_model.rs
@@ -1,0 +1,88 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use std::cell::Cell;
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+use glib::{clone, IsA, Object};
+
+use crate::prelude::*;
+use crate::ListModel;
+
+pub trait ListModelExtManual: ListModelExt {
+    /// Returns an iterator over the ListModel elements.
+    fn iter<T: IsA<Object>>(&self) -> ListModelIter<Self, T>
+    where
+        Self: Sized + Clone;
+}
+
+impl<O: IsA<ListModel>> ListModelExtManual for O {
+    fn iter<T: IsA<Object>>(&self) -> ListModelIter<Self, T>
+    where
+        Self: Sized + Clone,
+    {
+        ListModelIter::new(self.clone())
+    }
+}
+
+pub struct ListModelIter<M: ListModelExt, T: ObjectExt> {
+    data_type: PhantomData<T>,
+    model: M,
+    i: Rc<Cell<u32>>,
+}
+
+impl<M: ListModelExt + Clone, T: IsA<Object>> ListModelIter<M, T> {
+    /// Creates a new ListModel iterator.
+    /// 
+    /// ### Panics
+    /// Panics if `T::static_type()` is not of the model’s item type.
+    fn new(model: M) -> Self {
+        if !T::static_type().is_a(model.item_type()) {
+            panic!(
+                "Item type {} is not a subtype of model type {}.",
+                T::static_type(),
+                model.item_type()
+            );
+        }
+
+        let iter = ListModelIter::<M, T> {
+            data_type: PhantomData,
+            model: model.clone(),
+            i: Rc::new(Cell::new(0)),
+        };
+
+        // Adjust index when the underlying model changes.
+        model.connect_items_changed(
+            clone!(@weak iter.i as i_rc => move |_model, pos, n_removed, n_added| {
+                i_rc.set(adjust_index(i_rc.get(), pos, n_removed, n_added));
+            }),
+        );
+
+        iter
+    }
+}
+
+impl<M: ListModelExt, T: IsA<Object>> Iterator for ListModelIter<M, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.model.item(self.i.get());
+        self.i.set(self.i.get() + 1);
+        item.map(|x| x.downcast::<T>().unwrap())
+    }
+}
+
+/// Calculates the new index from the given change.
+fn adjust_index(index: u32, pos: u32, n_removed: u32, n_added: u32) -> u32 {
+    if index <= pos {
+        // Before the changed area; do nothing.
+        index
+    } else if index < pos + n_removed {
+        // In the changed area; skip the new elements.
+        pos + n_added
+    } else {
+        // index >= pos + n_removed
+        // After the changed area; move by the difference.
+        index + n_added - n_removed
+    }
+}

--- a/gio/src/prelude.rs
+++ b/gio/src/prelude.rs
@@ -19,6 +19,7 @@ pub use crate::file::FileExtManual;
 pub use crate::inet_address::InetAddressExtManual;
 pub use crate::input_stream::InputStreamExtManual;
 pub use crate::io_stream::IOStreamExtManual;
+pub use crate::list_model::ListModelExtManual;
 pub use crate::list_store::ListStoreExtManual;
 pub use crate::output_stream::OutputStreamExtManual;
 pub use crate::pollable_input_stream::PollableInputStreamExtManual;


### PR DESCRIPTION
This PR implements an Iterator for the `ListModel` interface.

The Iterator can be created by the interface’s `iter` method. Example usage:
```rust
for member in members.iter::<User>() {
    …
}
```
As you can see, the `iter` method takes a type parameter `T` that is the type of the yielded items. At creation time of the Iterator a type check is performed to make sure it is a subtype of the model’s item type. Having a type-wise more convenient Iterator is also the reason I decided against implementing `IntoIterator` as it forces you to yield `Object`-type items. (This restriction could be lifted, if `ListModel` itself had the correct type parameter.)

The Iterator gives always sensible results, even if the model underneath it changes. That means no duplicates or unnecessary omissions. It accomplishes that cheaply by listening to the `items-changed` signal of the underlying model and adjusting its internal index accordingly.

Implementing `DoubleEndedIterator` and `ExactSizeIterator` should be possible, too, I might do that after a round of feedback.