### PR TITLE
glib: ignore unref return value

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -309,8 +309,9 @@ macro_rules! glib_boxed_wrapper {
             }
 
             #[inline]
+            #[allow(clippy::no_effect)]
             unsafe fn free($free_arg: *mut $ffi_name) {
-                $free_expr
+                $free_expr;
             }
 
             #[inline]
@@ -335,18 +336,21 @@ macro_rules! glib_boxed_wrapper {
             }
 
             #[inline]
+            #[allow(clippy::no_effect)]
             unsafe fn free($free_arg: *mut $ffi_name) {
-                $free_expr
+                $free_expr;
             }
 
             #[inline]
+            #[allow(clippy::no_effect)]
             unsafe fn init($init_arg: *mut $ffi_name) {
-                $init_expr
+                $init_expr;
             }
 
             #[inline]
+            #[allow(clippy::no_effect)]
             unsafe fn clear($clear_arg: *mut $ffi_name) {
-                $clear_expr
+                $clear_expr;
             }
         }
 

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -89,8 +89,9 @@ macro_rules! glib_shared_wrapper {
             }
 
             #[inline]
+            #[allow(clippy::no_effect)]
             unsafe fn unref($unref_arg: *mut $ffi_name) {
-                $unref_expr
+                $unref_expr;
             }
         }
 


### PR DESCRIPTION
Some unref APIs (vte_regex_unref) have return values. Ignore that to fix
compilation issues, and return void.

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>