### PR TITLE
cairo: silence self_named_constructor

### DIFF
--- a/cairo/src/utils.rs
+++ b/cairo/src/utils.rs
@@ -37,8 +37,7 @@ pub struct Version {
 impl Version {
     #[doc(alias = "cairo_version")]
     #[doc(alias = "get_version")]
-    #[allow(clippy::self_named_constructor)]
-    pub fn version() -> Version {
+    pub fn new() -> Version {
         let version = unsafe { ffi::cairo_version() };
         Version {
             major: (version / 10_000 % 100) as _,
@@ -60,6 +59,6 @@ mod tests {
 
     #[test]
     fn check_versions() {
-        assert_eq!(version_string(), Version::version().to_string());
+        assert_eq!(version_string(), Version::new().to_string());
     }
 }

--- a/cairo/src/utils.rs
+++ b/cairo/src/utils.rs
@@ -47,6 +47,12 @@ impl Version {
     }
 }
 
+impl Default for Version {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}.{}.{}", self.major, self.minor, self.micro)

--- a/cairo/src/utils.rs
+++ b/cairo/src/utils.rs
@@ -37,6 +37,7 @@ pub struct Version {
 impl Version {
     #[doc(alias = "cairo_version")]
     #[doc(alias = "get_version")]
+    #[allow(clippy::self_named_constructor)]
     pub fn version() -> Version {
         let version = unsafe { ffi::cairo_version() };
         Version {


### PR DESCRIPTION
Silence a clippy warning.

Or do we want to break API here and rename it "new"?

