### PR TITLE
Add function to consume raw data of ImageSurface

### DIFF
--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::region::Region;
 
 pub use crate::surface::{MappedImageSurface, Surface};
 
-pub use crate::image_surface::{ImageSurface, ImageSurfaceData};
+pub use crate::image_surface::{ImageSurface, ImageSurfaceData, ImageSurfaceDataOwned};
 
 #[cfg(any(feature = "pdf", feature = "svg", feature = "ps", feature = "dox"))]
 pub use stream::StreamWithError;


### PR DESCRIPTION
This introduces a new function for `ImageSurface` which consumes the object, checks for exclusivity on the reference counter and returns a mutable slice of the raw data. Also added a minimal test case to verify.

Fixes #29 