### PR TITLE
variant: Use into_owned()

### DIFF
--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -218,7 +218,7 @@ impl Variant {
         self.get().ok_or_else(|| {
             VariantTypeMismatchError::new(
                 self.type_().to_owned(),
-                (&*T::static_variant_type()).to_owned(),
+                T::static_variant_type().into_owned(),
             )
         })
     }


### PR DESCRIPTION
I was adding another variant of this (pun intended) and did
some searching to notice there's a better way than juggling
`(&*...)`.