### PR TITLE
variant: Add an API to iterate over `as`

### DIFF
--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -41,7 +41,7 @@ pub use self::types::{ILong, StaticType, Type, ULong};
 pub use self::value::{BoxedValue, SendValue, ToSendValue, ToValue, Value};
 pub use self::variant::{FromVariant, StaticVariantType, ToVariant, Variant};
 pub use self::variant_dict::VariantDict;
-pub use self::variant_iter::VariantIter;
+pub use self::variant_iter::{VariantIter, VariantStrIter};
 pub use self::variant_type::{VariantTy, VariantType};
 
 pub mod clone;

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -88,9 +88,9 @@ use crate::gstring::GString;
 use crate::translate::*;
 use crate::StaticType;
 use crate::Type;
-use crate::VariantIter;
 use crate::VariantTy;
 use crate::VariantType;
+use crate::{VariantIter, VariantStrIter};
 use std::borrow::Cow;
 use std::cmp::{Eq, Ordering, PartialEq, PartialOrd};
 use std::collections::HashMap;
@@ -391,10 +391,44 @@ impl Variant {
     }
 
     /// Create an iterator over items in the variant.
+    ///
+    /// Note that this heap allocates a variant for each element,
+    /// which can be particularly expensive for large arrays.
     pub fn iter(&self) -> VariantIter {
         assert!(self.is_container());
 
         VariantIter::new(self.clone())
+    }
+
+    /// Create an iterator over borrowed strings from a GVariant of type `as` (array of string).
+    ///
+    /// This will fail if the variant is not an array of with
+    /// the expected child type.
+    ///
+    /// A benefit of this API over [`Self::iter()`] is that it
+    /// minimizes allocation, and provides strongly typed access.
+    ///
+    /// ```
+    /// # use glib::prelude::*;
+    /// let strs = &["foo", "bar"];
+    /// let strs_variant: glib::Variant = strs.to_variant();
+    /// for s in strs_variant.array_iter_str()? {
+    ///     println!("{}", s);
+    /// }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn array_iter_str(&self) -> Result<VariantStrIter, VariantTypeMismatchError> {
+        let child_ty = String::static_variant_type();
+        let actual_ty = self.type_();
+        let expected_ty = child_ty.with_array();
+        if actual_ty != expected_ty {
+            return Err(VariantTypeMismatchError {
+                actual: actual_ty.to_owned(),
+                expected: expected_ty,
+            });
+        }
+
+        Ok(VariantStrIter::new(self))
     }
 
     /// Variant has a container type.
@@ -642,12 +676,7 @@ impl<T: StaticVariantType + FromVariant> FromVariant for Option<T> {
 
 impl<T: StaticVariantType> StaticVariantType for [T] {
     fn static_variant_type() -> Cow<'static, VariantTy> {
-        let child_type = T::static_variant_type();
-        let signature = format!("a{}", child_type.to_str());
-
-        VariantType::new(&signature)
-            .expect("incorrect signature")
-            .into()
+        T::static_variant_type().with_array().into()
     }
 }
 
@@ -1033,6 +1062,9 @@ mod tests {
         );
         let a = ["foo", "bar", "baz"].to_variant();
         assert_eq!(a.normal_form(), a);
+        assert_eq!(a.array_iter_str().unwrap().len(), 3);
+        let o = 0u32.to_variant();
+        assert!(o.array_iter_str().is_err());
     }
 
     #[test]

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -193,6 +193,11 @@ impl VariantTy {
     pub fn to_str(&self) -> &str {
         &self.inner
     }
+
+    /// Return this type as an array.
+    pub(crate) fn with_array(&self) -> VariantType {
+        VariantType::new(&format!("a{}", self.to_str())).expect("invalid variant signature")
+    }
 }
 
 unsafe impl Sync for VariantTy {}


### PR DESCRIPTION
In ostree and rpm-ostree in particular we have quite a lot of
variants of type `as` (array of string).  Right now, accessing
those requires lots and lots of allocations.  Honestly, it's
mostly not truly performance sensitive, but I'd like to avoid
doing obviously silly things so that it doesn't become
a problem down the line.

We've had `.str()` for quite a while to access a variant of type `s`
without copying out the string data.  This extends that model to
variants of type `as` by allowing iteration over the values.