### PR TITLE
glib: adapt to signed vs. unsigned libc::c_char to fix non-x86 builds

### DIFF
--- a/glib/src/variant_iter.rs
+++ b/glib/src/variant_iter.rs
@@ -85,7 +85,7 @@ impl<'a> VariantStrIter<'a> {
             ffi::g_variant_get_child(
                 self.variant.to_glib_none().0,
                 i,
-                s as *const u8 as *const i8,
+                s as *const u8 as *const _,
                 &p,
                 std::ptr::null::<i8>(),
             );


### PR DESCRIPTION
Fixes #244

Changing to the simpler `s as *const _` does not work, as it creates the opposite effect (glib fails to compile on x86 targets), so the double cast seems to be necessary.

I have confirmed that the glib crate with this patch compiles successfully on x86_64, i686, ppc64le, aarch64, armv7hl, and s390x.