### PR TITLE
Revert "glib: Provide default implementations for `IsSubclassable` methods"

### DIFF
--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -343,7 +343,7 @@ impl<T: ApplicationImpl> ApplicationImplExt for T {
 
 unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application {
     fn class_init(class: &mut ::glib::Class<Self>) {
-        Self::parent_class_init::<T>(class);
+        <glib::Object as IsSubclassable<T>>::class_init(class);
 
         let klass = class.as_mut();
         klass.activate = Some(application_activate::<T>);
@@ -357,6 +357,10 @@ unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application {
         klass.shutdown = Some(application_shutdown::<T>);
         klass.startup = Some(application_startup::<T>);
         klass.handle_local_options = Some(application_handle_local_options::<T>);
+    }
+
+    fn instance_init(instance: &mut glib::subclass::InitializingObject<T>) {
+        <glib::Object as IsSubclassable<T>>::instance_init(instance);
     }
 }
 

--- a/gio/src/subclass/input_stream.rs
+++ b/gio/src/subclass/input_stream.rs
@@ -146,12 +146,16 @@ impl<T: InputStreamImpl> InputStreamImplExt for T {
 
 unsafe impl<T: InputStreamImpl> IsSubclassable<T> for InputStream {
     fn class_init(class: &mut ::glib::Class<Self>) {
-        Self::parent_class_init::<T>(class);
+        <glib::Object as IsSubclassable<T>>::class_init(class);
 
         let klass = class.as_mut();
         klass.read_fn = Some(stream_read::<T>);
         klass.close_fn = Some(stream_close::<T>);
         klass.skip = Some(stream_skip::<T>);
+    }
+
+    fn instance_init(instance: &mut glib::subclass::InitializingObject<T>) {
+        <glib::Object as IsSubclassable<T>>::instance_init(instance);
     }
 }
 

--- a/gio/src/subclass/io_stream.rs
+++ b/gio/src/subclass/io_stream.rs
@@ -90,12 +90,16 @@ impl<T: IOStreamImpl> IOStreamImplExt for T {
 
 unsafe impl<T: IOStreamImpl> IsSubclassable<T> for IOStream {
     fn class_init(class: &mut ::glib::Class<Self>) {
-        Self::parent_class_init::<T>(class);
+        <glib::Object as IsSubclassable<T>>::class_init(class);
 
         let klass = class.as_mut();
         klass.get_input_stream = Some(stream_get_input_stream::<T>);
         klass.get_output_stream = Some(stream_get_output_stream::<T>);
         klass.close_fn = Some(stream_close::<T>);
+    }
+
+    fn instance_init(instance: &mut glib::subclass::InitializingObject<T>) {
+        <glib::Object as IsSubclassable<T>>::instance_init(instance);
     }
 }
 

--- a/gio/src/subclass/output_stream.rs
+++ b/gio/src/subclass/output_stream.rs
@@ -186,13 +186,17 @@ impl<T: OutputStreamImpl> OutputStreamImplExt for T {
 
 unsafe impl<T: OutputStreamImpl> IsSubclassable<T> for OutputStream {
     fn class_init(class: &mut ::glib::Class<Self>) {
-        Self::parent_class_init::<T>(class);
+        <glib::Object as IsSubclassable<T>>::class_init(class);
 
         let klass = class.as_mut();
         klass.write_fn = Some(stream_write::<T>);
         klass.close_fn = Some(stream_close::<T>);
         klass.flush = Some(stream_flush::<T>);
         klass.splice = Some(stream_splice::<T>);
+    }
+
+    fn instance_init(instance: &mut glib::subclass::InitializingObject<T>) {
+        <glib::Object as IsSubclassable<T>>::instance_init(instance);
     }
 }
 

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -272,8 +272,8 @@ pub mod prelude {
     pub use super::object::{ObjectClassSubclassExt, ObjectImpl, ObjectImplExt};
     pub use super::shared::{RefCounted, SharedType};
     pub use super::types::{
-        ClassStruct, InstanceStruct, IsImplementable, IsSubclassable, IsSubclassableExt,
-        ObjectSubclass, ObjectSubclassExt, ObjectSubclassType,
+        ClassStruct, InstanceStruct, IsImplementable, IsSubclassable, ObjectSubclass,
+        ObjectSubclassExt, ObjectSubclassType,
     };
 }
 

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -2,7 +2,7 @@
 
 //! Module that contains the basic infrastructure for subclassing `GObject`.
 
-use crate::object::{Cast, IsClass, ObjectSubclassIs, ObjectType, ParentClassIs};
+use crate::object::{Cast, ObjectSubclassIs, ObjectType};
 use crate::translate::*;
 use crate::{Closure, Object, StaticType, Type, Value};
 use std::marker;
@@ -115,75 +115,19 @@ pub unsafe trait ClassStruct: Sized + 'static {
 }
 
 /// Trait for subclassable class structs.
-pub unsafe trait IsSubclassable<T: ObjectSubclass>: IsSubclassableDefault<T> {
+pub unsafe trait IsSubclassable<T: ObjectSubclass>: crate::object::IsClass {
     /// Override the virtual methods of this class for the given subclass and do other class
     /// initialization.
     ///
     /// This is automatically called during type initialization and must call `class_init()` of the
     /// parent class.
-    fn class_init(class: &mut crate::Class<Self>) {
-        Self::default_class_init(class);
-    }
+    fn class_init(class: &mut crate::Class<Self>);
 
     /// Instance specific initialization.
     ///
     /// This is automatically called during instance initialization and must call `instance_init()`
     /// of the parent class.
-    fn instance_init(instance: &mut InitializingObject<T>) {
-        Self::default_instance_init(instance);
-    }
-}
-
-// FIXME: It should be possible to make implemented for all instances of `IsSubclassable<T>`
-// with specialization, and make it private.
-#[doc(hidden)]
-pub trait IsSubclassableDefault<T: ObjectSubclass>: IsClass {
-    fn default_class_init(class: &mut crate::Class<Self>);
-    fn default_instance_init(instance: &mut InitializingObject<T>);
-}
-
-impl<T: ObjectSubclass, U: IsSubclassable<T> + ParentClassIs> IsSubclassableDefault<T> for U
-where
-    U::Parent: IsSubclassable<T>,
-{
-    fn default_class_init(class: &mut crate::Class<Self>) {
-        U::Parent::class_init(class);
-    }
-
-    fn default_instance_init(instance: &mut InitializingObject<T>) {
-        U::Parent::instance_init(instance);
-    }
-}
-
-impl<T: ObjectSubclass> IsSubclassableDefault<T> for Object {
-    fn default_class_init(_class: &mut crate::Class<Self>) {}
-
-    fn default_instance_init(_instance: &mut InitializingObject<T>) {}
-}
-
-pub trait IsSubclassableExt: IsClass + ParentClassIs {
-    fn parent_class_init<T: ObjectSubclass>(class: &mut crate::Class<Self>)
-    where
-        Self::Parent: IsSubclassable<T>;
-    fn parent_instance_init<T: ObjectSubclass>(instance: &mut InitializingObject<T>)
-    where
-        Self::Parent: IsSubclassable<T>;
-}
-
-impl<U: IsClass + ParentClassIs> IsSubclassableExt for U {
-    fn parent_class_init<T: ObjectSubclass>(class: &mut crate::Class<Self>)
-    where
-        U::Parent: IsSubclassable<T>,
-    {
-        Self::Parent::class_init(class);
-    }
-
-    fn parent_instance_init<T: ObjectSubclass>(instance: &mut InitializingObject<T>)
-    where
-        U::Parent: IsSubclassable<T>,
-    {
-        Self::Parent::instance_init(instance);
-    }
+    fn instance_init(instance: &mut InitializingObject<T>);
 }
 
 /// Trait for implementable interfaces.


### PR DESCRIPTION
Reverts gtk-rs/gtk-rs-core#241

This needs PRs for gtk3-rs and gtk4-rs to keep them buildable.