### PR TITLE
cairo: Fix up reference counting in Surface::map_to_image()

### DIFF
--- a/cairo/src/surface.rs
+++ b/cairo/src/surface.rs
@@ -250,7 +250,7 @@ impl Surface {
     #[doc(alias = "cairo_surface_map_to_image")]
     pub fn map_to_image(&self, extents: Option<RectangleInt>) -> Result<MappedImageSurface, Error> {
         unsafe {
-            ImageSurface::from_raw_full(match extents {
+            ImageSurface::from_raw_none(match extents {
                 Some(ref e) => ffi::cairo_surface_map_to_image(self.to_raw_none(), e.to_raw_none()),
                 None => ffi::cairo_surface_map_to_image(self.to_raw_none(), std::ptr::null()),
             })
@@ -392,7 +392,6 @@ impl Drop for MappedImageSurface {
                 self.original_surface.to_raw_none(),
                 self.image_surface.to_raw_none(),
             );
-            ffi::cairo_surface_reference(self.image_surface.to_raw_none());
         }
     }
 }

--- a/cairo/src/surface_macros.rs
+++ b/cairo/src/surface_macros.rs
@@ -25,6 +25,13 @@ macro_rules! declare_surface {
                 let surface = Surface::from_raw_full(ptr)?;
                 Self::try_from(surface).map_err(|_| crate::error::Error::SurfaceTypeMismatch)
             }
+
+            pub unsafe fn from_raw_none(
+                ptr: *mut ffi::cairo_surface_t,
+            ) -> Result<$surf_name, crate::error::Error> {
+                let surface = Surface::from_raw_none(ptr);
+                Self::try_from(surface).map_err(|_| crate::error::Error::SurfaceTypeMismatch)
+            }
         }
 
         #[cfg(feature = "use_glib")]


### PR DESCRIPTION
The C function is technically (transfer none) as one must not call
destroy() on it to unreference it but instead
cairo_surface_unmap_image().

This was tried to be avoided in the Drop impl of MappedImageSurface but
not correctly, leading to assertions.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/265