### PR TITLE
Allow to change visibility in glib::wrapper macro

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -13,10 +13,10 @@ use std::ptr;
 /// Wrapper implementations for Boxed types. See `wrapper!`.
 #[macro_export]
 macro_rules! glib_boxed_wrapper {
-    ([$($attr:meta)*] $name:ident, $ffi_name:ty,
+    ([$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty,
      @copy $copy_arg:ident $copy_expr:expr, @free $free_arg:ident $free_expr:expr
      $(, @type_ $get_type_expr:expr)?) => {
-        $crate::glib_boxed_wrapper!(@generic_impl [$($attr)*] $name, $ffi_name);
+        $crate::glib_boxed_wrapper!(@generic_impl [$($attr)*] $visibility $name, $ffi_name);
         $crate::glib_boxed_wrapper!(
             @memory_manager_impl $name, $ffi_name,
             @copy $copy_arg $copy_expr, @free $free_arg $free_expr
@@ -24,10 +24,10 @@ macro_rules! glib_boxed_wrapper {
         $($crate::glib_boxed_wrapper!(@value_impl $name, $ffi_name, @type_ $get_type_expr);)?
     };
 
-    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:ty) => {
+    (@generic_impl [$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty) => {
         $(#[$attr])*
         #[derive(Clone)]
-        pub struct $name($crate::boxed::Boxed<$ffi_name, $name>);
+        $visibility struct $name($crate::boxed::Boxed<$ffi_name, $name>);
 
         #[doc(hidden)]
         impl $crate::translate::GlibPtrDefault for $name {

--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -5,12 +5,12 @@
 /// Wrapper implementations for BoxedInline types. See `wrapper!`.
 #[macro_export]
 macro_rules! glib_boxed_inline_wrapper {
-    ([$($attr:meta)*] $name:ident, $ffi_name:ty
+    ([$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty
      $(, @type_ $get_type_expr:expr)?) => {
         $(#[$attr])*
         #[derive(Copy, Clone)]
         #[repr(transparent)]
-        pub struct $name(pub(crate) $ffi_name);
+        $visibility struct $name(pub(crate) $ffi_name);
 
         $crate::glib_boxed_inline_wrapper!(
             @generic_impl [$($attr)*] $name, $ffi_name,
@@ -21,13 +21,13 @@ macro_rules! glib_boxed_inline_wrapper {
         $($crate::glib_boxed_inline_wrapper!(@value_impl $name, $ffi_name, @type_ $get_type_expr);)?
     };
 
-    ([$($attr:meta)*] $name:ident, $ffi_name:ty,
+    ([$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty,
      @copy $copy_arg:ident $copy_expr:expr, @free $free_arg:ident $free_expr:expr
      $(, @type_ $get_type_expr:expr)?) => {
         $(#[$attr])*
         #[derive(Copy, Clone)]
         #[repr(transparent)]
-        pub struct $name(pub(crate) $ffi_name);
+        $visibility struct $name(pub(crate) $ffi_name);
 
         $crate::glib_boxed_inline_wrapper!(
             @generic_impl [$($attr)*] $name, $ffi_name,
@@ -37,12 +37,12 @@ macro_rules! glib_boxed_inline_wrapper {
         $($crate::glib_boxed_inline_wrapper!(@value_impl $name, $ffi_name, @type_ $get_type_expr);)?
     };
 
-    ([$($attr:meta)*] $name:ident, $ffi_name:ty,
+    ([$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty,
      @init $init_arg:ident $init_expr:expr, @copy_into $copy_into_arg_dest:ident $copy_into_arg_src:ident $copy_into_expr:expr, @clear $clear_arg:ident $clear_expr:expr
      $(, @type_ $get_type_expr:expr)?) => {
         $(#[$attr])*
         #[repr(transparent)]
-        pub struct $name(pub(crate) $ffi_name);
+        $visibility struct $name(pub(crate) $ffi_name);
 
         impl Clone for $name {
             fn clone(&self) -> $name {
@@ -71,13 +71,13 @@ macro_rules! glib_boxed_inline_wrapper {
     };
 
 
-    ([$($attr:meta)*] $name:ident, $ffi_name:ty,
+    ([$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty,
      @copy $copy_arg:ident $copy_expr:expr, @free $free_arg:ident $free_expr:expr,
      @init $init_arg:ident $init_expr:expr, @copy_into $copy_into_arg_dest:ident $copy_into_arg_src:ident $copy_into_expr:expr, @clear $clear_arg:ident $clear_expr:expr
      $(, @type_ $get_type_expr:expr)?) => {
         $(#[$attr])*
         #[repr(transparent)]
-        pub struct $name(pub(crate) $ffi_name);
+        $visibility struct $name(pub(crate) $ffi_name);
 
         impl Clone for $name {
             fn clone(&self) -> $name {

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -12,21 +12,21 @@ use std::ptr;
 /// Wrapper implementations for shared types. See `wrapper!`.
 #[macro_export]
 macro_rules! glib_shared_wrapper {
-    ([$($attr:meta)*] $name:ident, $ffi_name:ty,
+    ([$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty,
      @ref $ref_arg:ident $ref_expr:expr, @unref $unref_arg:ident $unref_expr:expr
      $(, @type_ $get_type_expr:expr)?) => {
         $crate::glib_shared_wrapper!(
-            @generic_impl [$($attr)*] $name, $ffi_name,
+            @generic_impl [$($attr)*] $visibility $name, $ffi_name,
             @ref $ref_arg $ref_expr, @unref $unref_arg $unref_expr
         );
         $($crate::glib_shared_wrapper!(@value_impl $name, $ffi_name, @type_ $get_type_expr);)?
     };
 
-    (@generic_impl [$($attr:meta)*] $name:ident, $ffi_name:ty,
+    (@generic_impl [$($attr:meta)*] $visibility:vis $name:ident, $ffi_name:ty,
      @ref $ref_arg:ident $ref_expr:expr, @unref $unref_arg:ident $unref_expr:expr) => {
         $(#[$attr])*
         #[derive(Clone)]
-        pub struct $name($crate::shared::Shared<$ffi_name, $name>);
+        $visibility struct $name($crate::shared::Shared<$ffi_name, $name>);
 
         #[doc(hidden)]
         impl $crate::shared::SharedMemoryManager<$ffi_name> for $name {

--- a/glib/src/wrapper.rs
+++ b/glib/src/wrapper.rs
@@ -276,7 +276,7 @@ macro_rules! wrapper {
     // Boxed
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Boxed<$ffi_name:ty>);
+        $visibility:vis struct $name:ident(Boxed<$ffi_name:ty>);
 
         match fn {
             copy => |$copy_arg:ident| $copy_expr:expr,
@@ -287,7 +287,7 @@ macro_rules! wrapper {
         }
     ) => {
         $crate::glib_boxed_wrapper!(
-            [$($attr)*] $name, $ffi_name,
+            [$($attr)*] $visibility $name, $ffi_name,
             @copy $copy_arg $copy_expr, @free $free_arg $free_expr
             $(, @type_ $get_type_expr)?
         );
@@ -296,7 +296,7 @@ macro_rules! wrapper {
     // BoxedInline
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(BoxedInline<$ffi_name:ty>);
+        $visibility:vis struct $name:ident(BoxedInline<$ffi_name:ty>);
 
         match fn {
             $(
@@ -314,7 +314,7 @@ macro_rules! wrapper {
         }
     ) => {
         $crate::glib_boxed_inline_wrapper!(
-            [$($attr)*] $name, $ffi_name
+            [$($attr)*] $visibility $name, $ffi_name
             $(, @copy $copy_arg $copy_expr, @free $free_arg $free_expr)?
             $(, @init $init_arg $init_expr, @copy_into $copy_into_arg_dest $copy_into_arg_src $copy_into_expr, @clear $clear_arg $clear_expr)?
             $(, @type_ $get_type_expr)?
@@ -324,17 +324,17 @@ macro_rules! wrapper {
     // BoxedInline
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(BoxedInline<$ffi_name:ty>);
+        $visibility:vis struct $name:ident(BoxedInline<$ffi_name:ty>);
     ) => {
         $crate::glib_boxed_inline_wrapper!(
-            [$($attr)*] $name, $ffi_name
+            [$($attr)*] $visibility $name, $ffi_name
         );
     };
 
     // Shared
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Shared<$ffi_name:ty>);
+        $visibility:vis struct $name:ident(Shared<$ffi_name:ty>);
 
         match fn {
             ref => |$ref_arg:ident| $ref_expr:expr,
@@ -345,7 +345,7 @@ macro_rules! wrapper {
         }
     ) => {
         $crate::glib_shared_wrapper!(
-            [$($attr)*] $name, $ffi_name,
+            [$($attr)*] $visibility $name, $ffi_name,
             @ref $ref_arg $ref_expr, @unref $unref_arg $unref_expr
             $(, @type_ $get_type_expr)?
         );
@@ -354,14 +354,14 @@ macro_rules! wrapper {
     // Object, no parents
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty $(, $ffi_class_name:ty)?>) $(@implements $($implements:path),+)?;
+        $visibility:vis struct $name:ident(Object<$ffi_name:ty $(, $ffi_class_name:ty)?>) $(@implements $($implements:path),+)?;
 
         match fn {
             type_ => || $get_type_expr:expr,
         }
     ) => {
         $crate::glib_object_wrapper!(
-            @object [$($attr)*] $name, $ffi_name,
+            @object [$($attr)*] $visibility $name, $ffi_name,
             $( @ffi_class $ffi_class_name ,)?
             @type_ $get_type_expr,
             @extends [],
@@ -372,14 +372,14 @@ macro_rules! wrapper {
     // Object, parents
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Object<$ffi_name:ty $(, $ffi_class_name:ty)?>) @extends $($extends:path),+ $(, @implements $($implements:path),+)?;
+        $visibility:vis struct $name:ident(Object<$ffi_name:ty $(, $ffi_class_name:ty)?>) @extends $($extends:path),+ $(, @implements $($implements:path),+)?;
 
         match fn {
             type_ => || $get_type_expr:expr,
         }
     ) => {
         $crate::glib_object_wrapper!(
-            @object [$($attr)*] $name, $ffi_name,
+            @object [$($attr)*] $visibility $name, $ffi_name,
             $( @ffi_class $ffi_class_name ,)?
             @type_ $get_type_expr,
             @extends [$($extends),+],
@@ -390,10 +390,10 @@ macro_rules! wrapper {
     // ObjectSubclass, no parents
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(ObjectSubclass<$subclass:ty>) $(@implements $($implements:path),+)?;
+        $visibility:vis struct $name:ident(ObjectSubclass<$subclass:ty>) $(@implements $($implements:path),+)?;
     ) => {
         $crate::glib_object_wrapper!(
-            @object_subclass [$($attr)*] $name, $subclass,
+            @object_subclass [$($attr)*] $visibility $name, $subclass,
             @extends [],
             @implements [$($($implements),+)?]
         );
@@ -402,10 +402,10 @@ macro_rules! wrapper {
     // ObjectSubclass, parents
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(ObjectSubclass<$subclass:ty>) @extends $($extends:path),+ $(, @implements $($implements:path),+)?;
+        $visibility:vis struct $name:ident(ObjectSubclass<$subclass:ty>) @extends $($extends:path),+ $(, @implements $($implements:path),+)?;
     ) => {
         $crate::glib_object_wrapper!(
-            @object_subclass [$($attr)*] $name, $subclass,
+            @object_subclass [$($attr)*] $visibility $name, $subclass,
             @extends [$($extends),+],
             @implements [$($($implements),+)?]
         );
@@ -414,14 +414,14 @@ macro_rules! wrapper {
     // Interface
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(Interface<$ffi_name:ty $(, $ffi_class_name:ty)?>) $(@requires $($requires:path),+)?;
+        $visibility:vis struct $name:ident(Interface<$ffi_name:ty $(, $ffi_class_name:ty)?>) $(@requires $($requires:path),+)?;
 
         match fn {
             type_ => || $get_type_expr:expr,
         }
     ) => {
         $crate::glib_object_wrapper!(
-            @interface [$($attr)*] $name, $ffi_name,
+            @interface [$($attr)*] $visibility $name, $ffi_name,
             $( @ffi_class $ffi_class_name ,)?
             @type_ $get_type_expr,
             @requires [$( $($requires),+ )?]
@@ -431,10 +431,10 @@ macro_rules! wrapper {
     // ObjectInterface
     (
         $(#[$attr:meta])*
-        pub struct $name:ident(ObjectInterface<$iface_name:ty>) $(@requires $($requires:path),+)?;
+        $visibility:vis struct $name:ident(ObjectInterface<$iface_name:ty>) $(@requires $($requires:path),+)?;
     ) => {
         $crate::glib_object_wrapper!(
-            @interface [$($attr)*] $name, std::os::raw::c_void,
+            @interface [$($attr)*] $visibility $name, std::os::raw::c_void,
             @ffi_class $iface_name,
             @type_ $crate::translate::IntoGlib::into_glib(<$iface_name as $crate::subclass::interface::ObjectInterfaceType>::type_()),
             @requires [$( $($requires),+ )?]


### PR DESCRIPTION
The only big difference is that now struct declared in `glib_object_wrapper` need to add `pub` if they want to be declared as such.