### PR TITLE
pango: re-add FromGlibContainerAsVec for GlyphInfo

### DIFF
--- a/pango/src/glyph_info.rs
+++ b/pango/src/glyph_info.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::GlyphGeometry;
+use glib::translate::*;
 use std::fmt;
 
 glib::wrapper! {
@@ -24,5 +25,57 @@ impl fmt::Debug for GlyphInfo {
             .field("glyph", &self.glyph())
             .field("geometry", &self.geometry())
             .finish()
+    }
+}
+
+impl FromGlibContainerAsVec<*mut ffi::PangoGlyphInfo, *mut ffi::PangoGlyphInfo> for GlyphInfo {
+    unsafe fn from_glib_none_num_as_vec(ptr: *mut ffi::PangoGlyphInfo, num: usize) -> Vec<Self> {
+        if num == 0 || ptr.is_null() {
+            return Vec::new();
+        }
+        let mut res = Vec::with_capacity(num);
+        for x in 0..num {
+            res.push(from_glib_none(ptr.add(x)));
+        }
+        res
+    }
+
+    unsafe fn from_glib_container_num_as_vec(
+        ptr: *mut ffi::PangoGlyphInfo,
+        num: usize,
+    ) -> Vec<Self> {
+        let res = FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr, num);
+        glib::ffi::g_free(ptr as *mut _);
+        res
+    }
+
+    unsafe fn from_glib_full_num_as_vec(ptr: *mut ffi::PangoGlyphInfo, num: usize) -> Vec<Self> {
+        FromGlibContainerAsVec::from_glib_container_num_as_vec(ptr, num)
+    }
+}
+
+impl FromGlibContainerAsVec<*mut ffi::PangoGlyphInfo, *const ffi::PangoGlyphInfo> for GlyphInfo {
+    unsafe fn from_glib_none_num_as_vec(ptr: *const ffi::PangoGlyphInfo, num: usize) -> Vec<Self> {
+        if num == 0 || ptr.is_null() {
+            return Vec::new();
+        }
+        let mut res = Vec::with_capacity(num);
+        for x in 0..num {
+            res.push(from_glib_none(ptr.add(x)));
+        }
+        res
+    }
+
+    unsafe fn from_glib_container_num_as_vec(
+        ptr: *const ffi::PangoGlyphInfo,
+        num: usize,
+    ) -> Vec<Self> {
+        let res = FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr, num);
+        glib::ffi::g_free(ptr as *mut _);
+        res
+    }
+
+    unsafe fn from_glib_full_num_as_vec(ptr: *const ffi::PangoGlyphInfo, num: usize) -> Vec<Self> {
+        FromGlibContainerAsVec::from_glib_container_num_as_vec(ptr, num)
     }
 }


### PR DESCRIPTION
was unintentionally dropped from https://github.com/gtk-rs/gtk-rs-core/pull/308
but it's needed for gtk4-rs