### PR TITLE
glib: Fix bug in main context channel test that caused it to deadlock

### DIFF
--- a/glib/src/main_context_channel.rs
+++ b/glib/src/main_context_channel.rs
@@ -643,8 +643,7 @@ mod tests {
 
         let helper = Helper(l.clone());
         receiver.attach(Some(&c), move |_| {
-            let _ = helper;
-
+            let _helper = &helper;
             Continue(true)
         });
 


### PR DESCRIPTION
With edition 2021 the closures are only borrowing what they have to, so
here in this case it didn't actually borrow the helper as it was not
actually used inside the closure. With that, it was not dropped when the
main context channel was dropped and the main loop was never quit.