### PR TITLE
glib: add a Value::get_owned

### DIFF
--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -622,10 +622,6 @@ impl<T: Send + ToValue + ?Sized> ToSendValue for T {
     }
 }
 
-impl ValueType for &'static str {
-    type Type = Self;
-}
-
 unsafe impl<'a> FromValue<'a> for &'a str {
     type Checker = GenericValueTypeOrNoneChecker<Self>;
 


### PR DESCRIPTION
The current FromValue trait can't handle the FromValue<'static>
case as that means having to borrow self for 'static.

Needed for having a generic ObjectExt::property that would return T instead of Value. See #323