### PR TITLE
glib: Assert that the memory allocated by GLib for the private instan…

### DIFF
--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -741,6 +741,16 @@ unsafe extern "C" fn instance_init<T: ObjectSubclass>(
     let private_offset = (*data.as_mut()).private_offset;
     let ptr = obj as *mut u8;
     let priv_ptr = ptr.offset(private_offset);
+
+    assert!(
+        priv_ptr as usize & (mem::align_of::<PrivateStruct<T>>() - 1) == 0,
+        "Private instance data has higher alignment requirements ({}) than \
+         the allocation from GLib. If alignment of more than {} bytes \
+         is required, store the corresponding data separately on the heap.",
+        mem::align_of::<PrivateStruct<T>>(),
+        2 * mem::size_of::<usize>(),
+    );
+
     let priv_storage = priv_ptr as *mut PrivateStruct<T>;
 
     let klass = &*(klass as *const T::Class);


### PR DESCRIPTION
…ce data is aligned correctly

GLib only guarantees 8 byte alignment on 32 bit systems, and 16 byte
alignment on 64 bit systems. If more is required than this would
previously cause UB and now would panic.

To solve this, users should store anything that has higher alignment
requirements inside a separate heap allocation.

See also https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2321