### PR TITLE
glib-macros: Add a `Variant` trait derive macro

### DIFF
--- a/glib-macros/src/gvariant_derive.rs
+++ b/glib-macros/src/gvariant_derive.rs
@@ -1,0 +1,208 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput};
+use syn::{Fields, FieldsNamed, FieldsUnnamed, Generics, Ident, Type};
+
+pub fn impl_variant(input: DeriveInput) -> TokenStream {
+    match input.data {
+        Data::Struct(data_struct) => {
+            derive_variant_for_struct(input.ident, input.generics, data_struct)
+        }
+        Data::Enum(_) => {
+            panic!("#[derive(Variant)] is not available for enums.");
+        }
+        Data::Union(..) => {
+            panic!("#[derive(Variant)] is not available for unions.");
+        }
+    }
+}
+
+pub fn derive_variant_for_struct(
+    ident: Ident,
+    generics: Generics,
+    data_struct: syn::DataStruct,
+) -> TokenStream {
+    let (static_variant_type, to_variant, from_variant) = match data_struct.fields {
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+            let types = unnamed
+                .into_pairs()
+                .map(|pair| pair.into_value())
+                .map(|field| field.ty)
+                .collect::<Vec<_>>();
+
+            let idents = (0..types.len()).map(syn::Index::from).collect::<Vec<_>>();
+
+            let static_variant_type = quote! {
+                impl #generics glib::StaticVariantType for #ident #generics {
+                    fn static_variant_type() -> std::borrow::Cow<'static, glib::VariantTy> {
+                        static TYP: glib::once_cell::sync::Lazy<glib::VariantType> = glib::once_cell::sync::Lazy::new(|| unsafe {
+                            let ptr = glib::ffi::g_string_sized_new(16);
+                            glib::ffi::g_string_append_c(ptr, b'(' as _);
+
+                            #(
+                                {
+                                    let typ = <#types as glib::StaticVariantType>::static_variant_type();
+                                    glib::ffi::g_string_append_len(
+                                        ptr,
+                                        typ.as_str().as_ptr() as *const _,
+                                        typ.as_str().len() as isize,
+                                    );
+                                }
+                            )*
+                            glib::ffi::g_string_append_c(ptr, b')' as _);
+
+                            glib::translate::from_glib_full(
+                                glib::ffi::g_string_free(ptr, glib::ffi::GFALSE) as *mut glib::ffi::GVariantType
+                            )
+                        });
+
+                        std::borrow::Cow::Borrowed(&*TYP)
+                    }
+                }
+            };
+
+            let to_variant = quote! {
+                impl #generics glib::ToVariant for #ident #generics {
+                    fn to_variant(&self) -> glib::Variant {
+                        glib::Variant::tuple_from_iter(std::array::IntoIter::new([
+                            #(
+                                glib::ToVariant::to_variant(&self.#idents)
+                            ),*
+                        ]))
+                    }
+                }
+            };
+
+            let from_variant = quote! {
+                impl #generics glib::FromVariant for #ident #generics {
+                    fn from_variant(variant: &glib::Variant) -> Option<Self> {
+                        if !variant.is_container() {
+                            return None;
+                        }
+                        Some(Self(
+                            #(
+                                match variant.try_child_get::<#types>(#idents) {
+                                    Ok(Some(field)) => field,
+                                    _ => return None,
+                                }
+                            ),*
+                        ))
+                    }
+                }
+            };
+
+            (static_variant_type, to_variant, from_variant)
+        }
+        Fields::Named(FieldsNamed { named, .. }) => {
+            let fields: Vec<(Ident, Type)> = named
+                .into_pairs()
+                .map(|pair| pair.into_value())
+                .map(|field| (field.ident.expect("Field ident is specified"), field.ty))
+                .collect();
+
+            let idents: Vec<_> = fields.iter().map(|(ident, _ty)| ident).collect();
+            let types: Vec<_> = fields.iter().map(|(_ident, ty)| ty).collect();
+            let counts = (0..types.len()).map(syn::Index::from).collect::<Vec<_>>();
+
+            let static_variant_type = quote! {
+                impl #generics glib::StaticVariantType for #ident #generics {
+                    fn static_variant_type() -> std::borrow::Cow<'static, glib::VariantTy> {
+                        static TYP: glib::once_cell::sync::Lazy<glib::VariantType> = glib::once_cell::sync::Lazy::new(|| unsafe {
+                            let ptr = glib::ffi::g_string_sized_new(16);
+                            glib::ffi::g_string_append_c(ptr, b'(' as _);
+
+                            #(
+                                {
+                                    let typ = <#types as glib::StaticVariantType>::static_variant_type();
+                                    glib::ffi::g_string_append_len(
+                                        ptr,
+                                        typ.as_str().as_ptr() as *const _,
+                                        typ.as_str().len() as isize,
+                                    );
+                                }
+                            )*
+                            glib::ffi::g_string_append_c(ptr, b')' as _);
+
+                            glib::translate::from_glib_full(
+                                glib::ffi::g_string_free(ptr, glib::ffi::GFALSE) as *mut glib::ffi::GVariantType
+                            )
+                        });
+
+                        std::borrow::Cow::Borrowed(&*TYP)
+                    }
+                }
+            };
+
+            let to_variant = quote! {
+                impl #generics glib::ToVariant for #ident #generics {
+                    fn to_variant(&self) -> glib::Variant {
+                        glib::Variant::tuple_from_iter(std::array::IntoIter::new([
+                            #(
+                                glib::ToVariant::to_variant(&self.#idents)
+                            ),*
+                        ]))
+                    }
+                }
+            };
+
+            let from_variant = quote! {
+                impl #generics glib::FromVariant for #ident #generics {
+                    fn from_variant(variant: &glib::Variant) -> Option<Self> {
+                        if !variant.is_container() {
+                            return None;
+                        }
+                        Some(Self {
+                            #(
+                                #idents: match variant.try_child_get::<#types>(#counts) {
+                                    Ok(Some(field)) => field,
+                                    _ => return None,
+                                }
+                            ),*
+                        })
+                    }
+                }
+            };
+
+            (static_variant_type, to_variant, from_variant)
+        }
+        Fields::Unit => {
+            let static_variant_type = quote! {
+                impl #generics glib::StaticVariantType for #ident #generics {
+                    fn static_variant_type() -> std::borrow::Cow<'static, glib::VariantTy> {
+                        std::borrow::Cow::Borrowed(glib::VariantTy::UNIT)
+                    }
+                }
+            };
+
+            let to_variant = quote! {
+                impl #generics glib::ToVariant for #ident #generics {
+                    fn to_variant(&self) -> glib::Variant {
+                        glib::ToVariant::to_variant(&())
+                    }
+                }
+            };
+
+            let from_variant = quote! {
+                impl #generics glib::FromVariant for #ident #generics {
+                    fn from_variant(variant: &glib::Variant) -> Option<Self> {
+                        Some(Self)
+                    }
+                }
+            };
+
+            (static_variant_type, to_variant, from_variant)
+        }
+    };
+
+    let derived = quote! {
+        #static_variant_type
+
+        #to_variant
+
+        #from_variant
+    };
+
+    derived.into()
+}

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -7,6 +7,7 @@ mod gboxed_shared_derive;
 mod genum_derive;
 mod gerror_domain_derive;
 mod gflags_attribute;
+mod gvariant_derive;
 mod object_interface_attribute;
 mod object_subclass_attribute;
 mod utils;
@@ -517,4 +518,29 @@ pub fn object_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn downgrade(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     downgrade_derive::impl_downgrade(input)
+}
+
+/// Derive macro for serializing/deserializing custom structs as [`glib::Variant`]s.
+///
+/// # Example
+///
+/// ```
+/// use glib::prelude::*;
+///
+/// #[derive(glib::GVariant, PartialEq, Eq, Debug)]
+/// struct Foo {
+///     some_string: String,
+///     some_int: i32,
+/// }
+///
+/// let v = Foo { some_string: String::from("bar"), some_int: 1 };
+/// let var = v.to_variant();
+/// assert_eq!(var.get::<Foo>(), Some(v));
+/// ```
+///
+/// [`glib::Variant`]: variant/struct.Variant.html
+#[proc_macro_derive(GVariant)]
+pub fn gvariant_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    gvariant_derive::impl_variant(input)
 }

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -2,7 +2,7 @@
 
 use glib::prelude::*;
 use glib::translate::{FromGlib, IntoGlib};
-use glib::{gflags, GBoxed, GEnum, GErrorDomain, GSharedBoxed};
+use glib::{gflags, GBoxed, GEnum, GErrorDomain, GSharedBoxed, GVariant};
 
 #[test]
 fn derive_gerror_domain() {
@@ -279,4 +279,64 @@ fn subclassable() {
             pub struct Foo(ObjectSubclass<imp::Foo>);
         }
     }
+}
+
+#[test]
+fn derive_variant() {
+    #[derive(GVariant, PartialEq, Eq, Debug)]
+    struct Variant1 {
+        some_string: String,
+        some_int: i32,
+    }
+
+    assert_eq!(Variant1::static_variant_type().as_str(), "(si)");
+    let v = Variant1 {
+        some_string: String::from("bar"),
+        some_int: 2,
+    };
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "(si)");
+    assert_eq!(var.get::<Variant1>(), Some(v));
+
+    #[derive(GVariant, PartialEq, Eq, Debug)]
+    struct Variant2 {
+        some_string: Option<String>,
+        some_int: i32,
+    }
+
+    assert_eq!(Variant2::static_variant_type().as_str(), "(msi)");
+    let v = Variant2 {
+        some_string: Some(String::from("bar")),
+        some_int: 2,
+    };
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "(msi)");
+    assert_eq!(var.get::<Variant2>(), Some(v));
+
+    #[derive(GVariant, PartialEq, Eq, Debug)]
+    struct Variant3(u32, String);
+
+    assert_eq!(Variant3::static_variant_type().as_str(), "(us)");
+    let v = Variant3(1, String::from("foo"));
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "(us)");
+    assert_eq!(var.get::<Variant3>(), Some(v));
+
+    #[derive(GVariant, PartialEq, Eq, Debug)]
+    struct Variant4;
+
+    assert_eq!(Variant4::static_variant_type().as_str(), "()");
+    let v = Variant4;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "()");
+    assert_eq!(var.get::<Variant4>(), Some(v));
+
+    #[derive(GVariant, PartialEq, Eq, Debug)]
+    struct Variant5();
+
+    assert_eq!(Variant5::static_variant_type().as_str(), "()");
+    let v = Variant5();
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "()");
+    assert_eq!(var.get::<Variant5>(), Some(v));
 }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -16,7 +16,7 @@ pub use once_cell;
 
 pub use glib_macros::{
     clone, gflags, object_interface, object_subclass, Downgrade, GBoxed, GEnum, GErrorDomain,
-    GSharedBoxed,
+    GSharedBoxed, GVariant,
 };
 
 pub use self::array::Array;

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -1252,18 +1252,7 @@ tuple_impls! {
 
 impl<T: ToVariant + StaticVariantType> FromIterator<T> for Variant {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let type_ = T::static_variant_type();
-
-        unsafe {
-            let mut builder = mem::MaybeUninit::uninit();
-            ffi::g_variant_builder_init(builder.as_mut_ptr(), type_.as_array().to_glib_none().0);
-            let mut builder = builder.assume_init();
-            for value in iter.into_iter() {
-                let value = value.to_variant();
-                ffi::g_variant_builder_add_value(&mut builder, value.to_glib_none().0);
-            }
-            from_glib_none(ffi::g_variant_builder_end(&mut builder))
-        }
+        Variant::array_from_iter::<T, _>(iter.into_iter().map(|v| v.to_variant()))
     }
 }
 

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -710,6 +710,28 @@ impl_numeric!(
     g_variant_get_double
 );
 
+impl StaticVariantType for () {
+    fn static_variant_type() -> Cow<'static, VariantTy> {
+        Cow::Borrowed(VariantTy::UNIT)
+    }
+}
+
+impl ToVariant for () {
+    fn to_variant(&self) -> Variant {
+        unsafe { from_glib_none(ffi::g_variant_new_tuple(ptr::null(), 0)) }
+    }
+}
+
+impl FromVariant for () {
+    fn from_variant(variant: &Variant) -> Option<Self> {
+        if variant.is::<Self>() {
+            Some(())
+        } else {
+            None
+        }
+    }
+}
+
 impl StaticVariantType for bool {
     fn static_variant_type() -> Cow<'static, VariantTy> {
         Cow::Borrowed(VariantTy::BOOLEAN)
@@ -1399,6 +1421,14 @@ mod tests {
         assert_eq!(a.try_child_get::<String>(0), Ok(Some(String::from("foo"))));
         assert_eq!(a.try_child_get::<u8>(1), Ok(Some(1u8)));
         assert_eq!(a.try_child_get::<i32>(2), Ok(Some(2i32)));
+    }
+
+    #[test]
+    fn test_empty() {
+        assert_eq!(<()>::static_variant_type().as_str(), "()");
+        let a = ().to_variant();
+        assert_eq!(a.type_().as_str(), "()");
+        assert_eq!(a.get::<()>(), Some(()));
     }
 
     #[test]


### PR DESCRIPTION
This allows storing arbitrary structs in `Variant`s as long as all their fields can be stored in `Variant`s.
