### PR TITLE
pango: take a generic attr in AttrList methods

### DIFF
--- a/pango/src/attr_list.rs
+++ b/pango/src/attr_list.rs
@@ -1,14 +1,14 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::AttrList;
-use crate::Attribute;
+use crate::{AttrList, IsAttribute};
 use glib::translate::*;
 use std::mem;
 
 impl AttrList {
     #[doc(alias = "pango_attr_list_change")]
-    pub fn change(&self, attr: Attribute) {
+    pub fn change(&self, attr: impl IsAttribute) {
         unsafe {
+            let attr = attr.upcast();
             ffi::pango_attr_list_change(self.to_glib_none().0, attr.to_glib_none().0 as *mut _);
             mem::forget(attr); //As attr transferred fully
         }
@@ -27,16 +27,18 @@ impl AttrList {
     }
 
     #[doc(alias = "pango_attr_list_insert")]
-    pub fn insert(&self, attr: Attribute) {
+    pub fn insert(&self, attr: impl IsAttribute) {
         unsafe {
+            let attr = attr.upcast();
             ffi::pango_attr_list_insert(self.to_glib_none().0, attr.to_glib_none().0 as *mut _);
             mem::forget(attr); //As attr transferred fully
         }
     }
 
     #[doc(alias = "pango_attr_list_insert_before")]
-    pub fn insert_before(&self, attr: Attribute) {
+    pub fn insert_before(&self, attr: impl IsAttribute) {
         unsafe {
+            let attr = attr.upcast();
             ffi::pango_attr_list_insert_before(
                 self.to_glib_none().0,
                 attr.to_glib_none().0 as *mut _,


### PR DESCRIPTION
Noticed that when bumping librsvg to next gtk-rs stack https://gitlab.gnome.org/GNOME/librsvg/-/merge_requests/634