### PR TITLE
macros: make ParentType optional

### DIFF
--- a/examples/gio_task/file_size/imp.rs
+++ b/examples/gio_task/file_size/imp.rs
@@ -10,7 +10,6 @@ pub struct FileSize {
 #[glib::object_subclass]
 impl ObjectSubclass for FileSize {
     const NAME: &'static str = "FileSize";
-    type ParentType = glib::Object;
     type Type = super::FileSize;
 }
 

--- a/gio/src/subclass/initable.rs
+++ b/gio/src/subclass/initable.rs
@@ -106,7 +106,6 @@ mod tests {
         impl ObjectSubclass for InitableTestType {
             const NAME: &'static str = "InitableTestType";
             type Type = super::InitableTestType;
-            type ParentType = glib::Object;
             type Interfaces = (Initable,);
 
             fn new() -> Self {

--- a/gio/src/task.rs
+++ b/gio/src/task.rs
@@ -178,7 +178,6 @@ mod test {
         #[glib::object_subclass]
         impl ObjectSubclass for MySimpleObjectPrivate {
             const NAME: &'static str = "MySimpleObjectPrivate";
-            type ParentType = glib::Object;
             type Type = MySimpleObject;
 
             fn new() -> Self {

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -258,7 +258,6 @@ fn subclassable() {
             impl ObjectSubclass for Foo {
                 const NAME: &'static str = "MyFoo";
                 type Type = super::Foo;
-                type ParentType = glib::Object;
             }
 
             impl ObjectImpl for Foo {}

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -84,11 +84,14 @@
 //!         // This type name must be unique per process.
 //!         const NAME: &'static str = "SimpleObject";
 //!
-//!         // The parent type this one is inheriting from.
 //!         type Type = super::SimpleObject;
+//!
+//!         // The parent type this one is inheriting from.
+//!         // Optional, if not specified it defaults to `glib::Object`
 //!         type ParentType = glib::Object;
 //!
-//!         // Interfaces this type implements
+//!         // Interfaces this type implements.
+//!         // Optional, if not specified it defaults to `()`
 //!         type Interfaces = ();
 //!     }
 //!

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -245,7 +245,6 @@ mod test {
         impl ObjectSubclass for ChildObject {
             const NAME: &'static str = "ChildObject";
             type Type = super::ChildObject;
-            type ParentType = Object;
         }
 
         impl ObjectImpl for ChildObject {}
@@ -261,7 +260,6 @@ mod test {
         impl ObjectSubclass for SimpleObject {
             const NAME: &'static str = "SimpleObject";
             type Type = super::SimpleObject;
-            type ParentType = Object;
             type Interfaces = (super::Dummy,);
         }
 

--- a/tests/two-levels-glib-dependent/glib-dependent-dependent/src/lib.rs
+++ b/tests/two-levels-glib-dependent/glib-dependent-dependent/src/lib.rs
@@ -12,7 +12,6 @@ pub mod imp {
     impl ObjectSubclass for Foo {
         const NAME: &'static str = "MyFoo";
         type Type = super::Foo;
-        type ParentType = glib::Object;
     }
 
     impl ObjectImpl for Foo {}


### PR DESCRIPTION
Use glib::Object if not specified.
Fixes https://github.com/gtk-rs/gtk-rs-core/issues/350