### PR TITLE
glib: Add new trait for allowing to unwrap the return value of `Closu…

### DIFF
--- a/glib-macros/src/closure.rs
+++ b/glib-macros/src/closure.rs
@@ -232,6 +232,7 @@ impl ToTokens for Closure {
             }
         });
         let arg_names = &self.args;
+        let args_len = self.args.len();
         let closure = &self.closure;
         let constructor = Ident::new(self.constructor, Span::call_site());
 
@@ -239,7 +240,8 @@ impl ToTokens for Closure {
             {
                 let #closure_ident = {
                     #(#outer_before)*
-                    #crate_ident::closure::Closure::#constructor(move |#values_ident| {
+                    #crate_ident::closure::RustClosure::#constructor(move |#values_ident| {
+                        assert_eq!(#values_ident.len(), #args_len);
                         #(#inner_before)*
                         #(#arg_values)*
                         #crate_ident::closure::ToClosureReturnValue::to_closure_return_value(

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -316,7 +316,7 @@ pub fn clone(item: TokenStream) -> TokenStream {
 /// use glib_macros::closure;
 ///
 /// let concat_str = closure!(|s: &str| s.to_owned() + " World");
-/// let result = concat_str.invoke(&[&"Hello"]).unwrap().get::<String>().unwrap();
+/// let result = concat_str.invoke::<String>(&[&"Hello"]);
 /// assert_eq!(result, "Hello World");
 /// ```
 ///
@@ -351,14 +351,11 @@ pub fn clone(item: TokenStream) -> TokenStream {
 ///     let closure = closure_local!(@watch obj => move || {
 ///         obj.type_().name()
 ///     });
-///     assert_eq!(
-///         closure.invoke(&[]).unwrap().get::<String>().unwrap(),
-///         "GObject"
-///     );
+///     assert_eq!(closure.invoke::<String>(&[]), "GObject");
 ///     closure
 /// };
 /// // `obj` is dropped, closure invalidated so it always does nothing and returns None
-/// assert!(closure.invoke(&[]).is_none());
+/// closure.invoke::<()>(&[]);
 /// ```
 ///
 /// `@watch` has special behavior when connected to a signal:
@@ -397,17 +394,11 @@ pub fn clone(item: TokenStream) -> TokenStream {
 ///         // `a` is Arc<String>, `b` is Option<Arc<String>>
 ///         format!("{} {}", a, b.as_ref().map(|b| b.as_str()).unwrap_or_else(|| "Moon"))
 ///     });
-///     assert_eq!(
-///         closure.invoke(&[]).unwrap().get::<String>().unwrap(),
-///         "Hello World"
-///     );
+///     assert_eq!(closure.invoke::<String>(&[]), "Hello World");
 ///     closure
 /// };
 /// // `a` still kept alive, `b` is dropped
-/// assert_eq!(
-///     closure.invoke(&[]).unwrap().get::<String>().unwrap(),
-///     "Hello Moon"
-/// );
+/// assert_eq!(closure.invoke::<String>(&[]), "Hello Moon");
 /// ```
 #[proc_macro]
 #[proc_macro_error]

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -343,23 +343,16 @@ fn derive_variant() {
 #[test]
 fn closure() {
     let empty = glib::closure!(|| {});
-    assert!(empty.invoke(&[]).is_none());
+    empty.invoke::<()>(&[]);
 
     let no_arg = glib::closure!(|| 2i32);
-    assert_eq!(no_arg.invoke(&[]).unwrap().get::<i32>().unwrap(), 2);
+    assert_eq!(no_arg.invoke::<i32>(&[]), 2);
 
     let add_1 = glib::closure!(|x: i32| x + 1);
-    assert_eq!(add_1.invoke(&[&3i32]).unwrap().get::<i32>().unwrap(), 4);
+    assert_eq!(add_1.invoke::<i32>(&[&3i32]), 4);
 
     let concat_str = glib::closure!(|s: &str| s.to_owned() + " World");
-    assert_eq!(
-        concat_str
-            .invoke(&[&"Hello"])
-            .unwrap()
-            .get::<String>()
-            .unwrap(),
-        "Hello World"
-    );
+    assert_eq!(concat_str.invoke::<String>(&[&"Hello"]), "Hello World");
 
     let weak_test = {
         let obj = glib::Object::new::<glib::Object>(&[]).unwrap();
@@ -367,12 +360,12 @@ fn closure() {
         assert_eq!(obj.ref_count(), 1);
         let weak_test = glib::closure_local!(@watch obj => move || obj.ref_count());
         assert_eq!(obj.ref_count(), 1);
-        assert_eq!(weak_test.invoke(&[]).unwrap().get::<u32>().unwrap(), 3);
+        assert_eq!(weak_test.invoke::<u32>(&[]), 3);
         assert_eq!(obj.ref_count(), 1);
 
         weak_test
     };
-    assert!(weak_test.invoke(&[]).is_none());
+    weak_test.invoke::<()>(&[]);
 
     {
         trait TestExt {
@@ -382,7 +375,7 @@ fn closure() {
         impl TestExt for glib::Object {
             fn ref_count_in_closure(&self) -> u32 {
                 let closure = glib::closure_local!(@watch self as obj => move || obj.ref_count());
-                closure.invoke(&[]).unwrap().get::<u32>().unwrap()
+                closure.invoke::<u32>(&[])
             }
         }
 
@@ -399,7 +392,7 @@ fn closure() {
             fn ref_count_in_closure(&self) -> u32 {
                 let closure =
                     glib::closure_local!(@watch self.obj as obj => move || obj.ref_count());
-                closure.invoke(&[]).unwrap().get::<u32>().unwrap()
+                closure.invoke::<u32>(&[])
             }
         }
 
@@ -413,11 +406,11 @@ fn closure() {
         let obj = glib::Object::new::<glib::Object>(&[]).unwrap();
 
         let strong_test = glib::closure_local!(@strong obj => move || obj.ref_count());
-        assert_eq!(strong_test.invoke(&[]).unwrap().get::<u32>().unwrap(), 2);
+        assert_eq!(strong_test.invoke::<u32>(&[]), 2);
 
         strong_test
     };
-    assert_eq!(strong_test.invoke(&[]).unwrap().get::<u32>().unwrap(), 1);
+    assert_eq!(strong_test.invoke::<u32>(&[]), 1);
 
     let weak_none_test = {
         let obj = glib::Object::new::<glib::Object>(&[]).unwrap();
@@ -425,11 +418,11 @@ fn closure() {
         let weak_none_test = glib::closure_local!(@weak-allow-none obj => move || {
             obj.map(|o| o.ref_count()).unwrap_or_default()
         });
-        assert_eq!(weak_none_test.invoke(&[]).unwrap().get::<u32>().unwrap(), 2);
+        assert_eq!(weak_none_test.invoke::<u32>(&[]), 2);
 
         weak_none_test
     };
-    assert_eq!(weak_none_test.invoke(&[]).unwrap().get::<u32>().unwrap(), 0);
+    assert_eq!(weak_none_test.invoke::<u32>(&[]), 0);
 
     {
         let obj1 = glib::Object::new::<glib::Object>(&[]).unwrap();
@@ -437,17 +430,13 @@ fn closure() {
 
         let obj_arg_test =
             glib::closure!(|a: glib::Object, b: glib::Object| { a.ref_count() + b.ref_count() });
-        let rc = obj_arg_test
-            .invoke(&[&obj1, &obj2])
-            .unwrap()
-            .get::<u32>()
-            .unwrap();
+        let rc = obj_arg_test.invoke::<u32>(&[&obj1, &obj2]);
         assert_eq!(rc, 6);
 
         let alias_test = glib::closure_local!(@strong obj1 as a, @strong obj2 => move || {
             a.ref_count() + obj2.ref_count()
         });
-        assert_eq!(alias_test.invoke(&[]).unwrap().get::<u32>().unwrap(), 4);
+        assert_eq!(alias_test.invoke::<u32>(&[]), 4);
     }
 
     {
@@ -460,6 +449,6 @@ fn closure() {
         let struct_test = glib::closure_local!(@strong a_struct.a as a => move || {
             a.ref_count()
         });
-        assert_eq!(struct_test.invoke(&[]).unwrap().get::<u32>().unwrap(), 2);
+        assert_eq!(struct_test.invoke::<u32>(&[]), 2);
     }
 }

--- a/glib/src/closure.rs
+++ b/glib/src/closure.rs
@@ -12,6 +12,7 @@ use crate::translate::{from_glib_none, mut_override, ToGlibPtr, ToGlibPtrMut, Un
 use crate::value::FromValue;
 use crate::StaticType;
 use crate::ToValue;
+use crate::Type;
 use crate::Value;
 
 wrapper! {
@@ -29,17 +30,180 @@ wrapper! {
     }
 }
 
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct RustClosure(Closure);
+
+impl RustClosure {
+    /// Creates a new closure around a Rust closure.
+    ///
+    /// See [`glib::closure!`] for a way to create a closure with concrete types.
+    ///
+    /// # Panics
+    ///
+    /// Invoking the closure with wrong argument types or returning the wrong return value type
+    /// will panic.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use glib::prelude::*;
+    ///
+    /// let closure = glib::RustClosure::new(|values| {
+    ///     let x = values[0].get::<i32>().unwrap();
+    ///     Some((x + 1).to_value())
+    /// });
+    ///
+    /// assert_eq!(
+    ///     closure.invoke::<i32>(&[&1i32]),
+    ///     2,
+    /// );
+    /// ```
+    #[doc(alias = "g_closure_new")]
+    pub fn new<F: Fn(&[Value]) -> Option<Value> + Send + Sync + 'static>(callback: F) -> Self {
+        Self(Closure::new(callback))
+    }
+
+    /// Creates a new closure around a Rust closure.
+    ///
+    /// See [`glib::closure_local!`] for a way to create a closure with concrete types.
+    ///
+    /// # Panics
+    ///
+    /// Invoking the closure with wrong argument types or returning the wrong return value type
+    /// will panic.
+    ///
+    /// Invoking the closure from a different thread than this one will panic.
+    #[doc(alias = "g_closure_new")]
+    pub fn new_local<F: Fn(&[Value]) -> Option<Value> + 'static>(callback: F) -> Self {
+        Self(Closure::new_local(callback))
+    }
+
+    /// Invokes the closure with the given arguments.
+    ///
+    /// For invalidated closures this returns the "default" value of the return type. For nullable
+    /// types this is `None`, which means that e.g. requesting `R = String` will panic will `R =
+    /// Option<String>` will return `None`.
+    ///
+    /// # Panics
+    ///
+    /// The argument types and return value type must match the ones expected by the closure or
+    /// otherwise this function panics.
+    #[doc(alias = "g_closure_invoke")]
+    pub fn invoke<R: TryFromClosureReturnValue>(&self, values: &[&dyn ToValue]) -> R {
+        let values = values
+            .iter()
+            .copied()
+            .map(ToValue::to_value)
+            .collect::<smallvec::SmallVec<[_; 10]>>();
+
+        R::try_from_closure_return_value(self.invoke_with_values(R::static_type(), &values))
+            .expect("Invalid return value")
+    }
+
+    /// Invokes the closure with the given arguments.
+    ///
+    /// For invalidated closures this returns the "default" value of the return type.
+    ///
+    /// # Panics
+    ///
+    /// The argument types and return value type must match the ones expected by the closure or
+    /// otherwise this function panics.
+    #[doc(alias = "g_closure_invoke")]
+    pub fn invoke_with_values(&self, return_type: Type, values: &[Value]) -> Option<Value> {
+        unsafe { self.0.invoke_with_values(return_type, values) }
+    }
+
+    /// Invalidates the closure.
+    ///
+    /// Invoking an invalidated closure has no effect.
+    #[doc(alias = "g_closure_invalidate")]
+    pub fn invalidate(&self) {
+        self.0.invalidate();
+    }
+}
+
+impl From<RustClosure> for Closure {
+    fn from(c: RustClosure) -> Self {
+        c.0
+    }
+}
+
+impl AsRef<Closure> for RustClosure {
+    fn as_ref(&self) -> &Closure {
+        &self.0
+    }
+}
+
+impl AsRef<Closure> for Closure {
+    fn as_ref(&self) -> &Closure {
+        self
+    }
+}
+
 impl Closure {
+    /// Creates a new closure around a Rust closure.
+    ///
+    /// Note that [`RustClosure`] provides more convenient and non-unsafe API for invoking
+    /// closures. This type mostly exists for FFI interop.
+    ///
+    /// # Panics
+    ///
+    /// Invoking the closure with wrong argument types or returning the wrong return value type
+    /// will panic.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use glib::prelude::*;
+    ///
+    /// let closure = glib::Closure::new(|values| {
+    ///     let x = values[0].get::<i32>().unwrap();
+    ///     Some((x + 1).to_value())
+    /// });
+    ///
+    /// // Invoking non-Rust closures is unsafe because of possibly missing
+    /// // argument and return value type checks.
+    /// let res = unsafe {
+    ///     closure
+    ///         .invoke_with_values(glib::Type::I32, &[1i32.to_value()])
+    ///         .and_then(|v| v.get::<i32>().ok())
+    ///         .expect("Invalid return value")
+    /// };
+    ///
+    /// assert_eq!(res, 2);
+    /// ```
+    #[doc(alias = "g_closure_new")]
     pub fn new<F: Fn(&[Value]) -> Option<Value> + Send + Sync + 'static>(callback: F) -> Self {
         unsafe { Self::new_unsafe(callback) }
     }
 
+    /// Creates a new closure around a Rust closure.
+    ///
+    /// Note that [`RustClosure`] provides more convenient and non-unsafe API for invoking
+    /// closures. This type mostly exists for FFI interop.
+    ///
+    /// # Panics
+    ///
+    /// Invoking the closure with wrong argument types or returning the wrong return value type
+    /// will panic.
+    ///
+    /// Invoking the closure from a different thread than this one will panic.
+    #[doc(alias = "g_closure_new")]
     pub fn new_local<F: Fn(&[Value]) -> Option<Value> + 'static>(callback: F) -> Self {
         let callback = crate::ThreadGuard::new(callback);
 
         unsafe { Self::new_unsafe(move |values| (callback.get_ref())(values)) }
     }
 
+    /// Creates a new closure around a Rust closure.
+    ///
+    /// # Safety
+    ///
+    /// The captured variables of the closure must stay valid as long as the return value of this
+    /// constructor does, and it must be valid to call the closure from any thread that is used by
+    /// callers.
+    #[doc(alias = "g_closure_new")]
     pub unsafe fn new_unsafe<F: Fn(&[Value]) -> Option<Value>>(callback: F) -> Self {
         unsafe extern "C" fn marshal<F>(
             _closure: *mut gobject_ffi::GClosure,
@@ -54,12 +218,29 @@ impl Closure {
             let values = slice::from_raw_parts(param_values as *const _, n_param_values as usize);
             let callback: &F = &*(marshal_data as *mut _);
             let result = callback(values);
-            if !return_value.is_null() {
+
+            if return_value.is_null() {
+                assert!(
+                    result.is_none(),
+                    "Closure returned a return value but the caller did not expect one"
+                );
+            } else {
+                let return_value = &mut *(return_value as *mut Value);
                 match result {
-                    Some(result) => *return_value = result.into_raw(),
+                    Some(result) => {
+                        assert!(
+                            result.type_().is_a(return_value.type_()),
+                            "Closure returned a value of type {} but caller expected {}",
+                            result.type_(),
+                            return_value.type_()
+                        );
+                        *return_value = result;
+                    }
                     None => {
-                        let result = Value::uninitialized();
-                        *return_value = result.into_raw();
+                        panic!(
+                            "Closure return no value but the caller expected a value of type {}",
+                            return_value.type_()
+                        );
                     }
                 }
             }
@@ -92,32 +273,53 @@ impl Closure {
         from_glib_none(closure)
     }
 
-    pub fn invoke<R: TryFromClosureReturnValue>(&self, values: &[&dyn ToValue]) -> R {
-        let values = values
-            .iter()
-            .copied()
-            .map(ToValue::to_value)
-            .collect::<smallvec::SmallVec<[_; 10]>>();
-
-        R::try_from_closure_return_value(self.invoke_with_values(&values))
-            .expect("Invalid return value")
-    }
-
-    pub fn invoke_with_values(&self, values: &[Value]) -> Option<Value> {
-        let result = unsafe {
-            let mut result = Value::uninitialized();
-            gobject_ffi::g_closure_invoke(
-                self.to_glib_none().0 as *mut _,
-                result.to_glib_none_mut().0,
-                values.len() as u32,
-                mut_override(values.as_ptr()) as *mut gobject_ffi::GValue,
-                ptr::null_mut(),
-            );
-
-            result
+    /// Invokes the closure with the given arguments.
+    ///
+    /// For invalidated closures this returns the "default" value of the return type.
+    ///
+    /// # Safety
+    ///
+    /// The argument types and return value type must match the ones expected by the closure or
+    /// otherwise the behaviour is undefined.
+    ///
+    /// Closures created from Rust via e.g. [`Closure::new`] will panic on type mismatches but
+    /// this is not guaranteed for closures created from other languages.
+    #[doc(alias = "g_closure_invoke")]
+    pub unsafe fn invoke_with_values(&self, return_type: Type, values: &[Value]) -> Option<Value> {
+        let mut result = if return_type == Type::UNIT {
+            Value::uninitialized()
+        } else {
+            Value::from_type(return_type)
+        };
+        let result_ptr = if return_type == Type::UNIT {
+            ptr::null_mut()
+        } else {
+            result.to_glib_none_mut().0
         };
 
-        Some(result).filter(|r| r.type_().is_valid())
+        gobject_ffi::g_closure_invoke(
+            self.to_glib_none().0 as *mut _,
+            result_ptr,
+            values.len() as u32,
+            mut_override(values.as_ptr()) as *mut gobject_ffi::GValue,
+            ptr::null_mut(),
+        );
+
+        if return_type == Type::UNIT {
+            None
+        } else {
+            Some(result)
+        }
+    }
+
+    /// Invalidates the closure.
+    ///
+    /// Invoking an invalidated closure has no effect.
+    #[doc(alias = "g_closure_invalidate")]
+    pub fn invalidate(&self) {
+        unsafe {
+            gobject_ffi::g_closure_invalidate(self.to_glib_none().0);
+        }
     }
 }
 
@@ -137,7 +339,7 @@ impl<T: ToValue> ToClosureReturnValue for T {
     }
 }
 
-pub trait TryFromClosureReturnValue: Sized + 'static {
+pub trait TryFromClosureReturnValue: StaticType + Sized + 'static {
     fn try_from_closure_return_value(v: Option<Value>) -> Result<Self, crate::BoolError>;
 }
 
@@ -181,8 +383,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    use super::Closure;
-    use crate::{ToValue, Value};
+    use super::*;
 
     #[allow(clippy::unnecessary_wraps)]
     fn closure_fn(values: &[Value]) -> Option<Value> {
@@ -199,7 +400,7 @@ mod tests {
         let call_count = Arc::new(AtomicUsize::new(0));
 
         let count = call_count.clone();
-        let closure = Closure::new(move |values| {
+        let closure = RustClosure::new(move |values| {
             count.fetch_add(1, Ordering::Relaxed);
             assert_eq!(values.len(), 2);
             let string_arg = values[0].get::<&str>();
@@ -214,8 +415,15 @@ mod tests {
         closure.invoke::<()>(&[&"test", &42]);
         assert_eq!(call_count.load(Ordering::Relaxed), 2);
 
-        let closure = Closure::new(closure_fn);
+        closure.invalidate();
+        closure.invoke::<()>(&[&"test", &42]);
+        assert_eq!(call_count.load(Ordering::Relaxed), 2);
+
+        let closure = RustClosure::new(closure_fn);
         let result = closure.invoke::<i32>(&[&"test", &42]);
         assert_eq!(result, 24);
+        closure.invalidate();
+        let result = closure.invoke::<i32>(&[&"test", &42]);
+        assert_eq!(result, 0);
     }
 }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -21,7 +21,7 @@ pub use glib_macros::{
 
 pub use self::byte_array::ByteArray;
 pub use self::bytes::Bytes;
-pub use self::closure::Closure;
+pub use self::closure::{Closure, RustClosure};
 pub use self::error::{BoolError, Error};
 pub use self::file_error::FileError;
 pub use self::object::{

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -330,7 +330,7 @@ mod test {
                             let old_name = imp.name.borrow_mut().take();
                             *imp.name.borrow_mut() = Some(new_name);
 
-                            obj.emit_by_name("name-changed", &[&*imp.name.borrow()]);
+                            obj.emit_by_name::<()>("name-changed", &[&*imp.name.borrow()]);
 
                             Some(old_name.to_value())
                         })
@@ -362,7 +362,7 @@ mod test {
                             .get()
                             .expect("type conformity checked by 'Object::set_property'");
                         self.name.replace(name);
-                        obj.emit_by_name("name-changed", &[&*self.name.borrow()]);
+                        obj.emit_by_name::<()>("name-changed", &[&*self.name.borrow()]);
                     }
                     "construct-name" => {
                         let name = value
@@ -557,10 +557,7 @@ mod test {
         assert!(!name_changed_triggered.load(Ordering::Relaxed));
 
         assert_eq!(
-            obj.emit_by_name("change-name", &[&"new-name"])
-                .unwrap()
-                .get::<&str>()
-                .expect("Failed to get str from emit"),
+            obj.emit_by_name::<String>("change-name", &[&"new-name"]),
             "old-name"
         );
         assert!(name_changed_triggered.load(Ordering::Relaxed));
@@ -576,8 +573,8 @@ mod test {
 
         let signal_id = imp::SimpleObject::signals()[2].signal_id();
 
-        let value = obj.emit(signal_id, &[]).unwrap();
-        assert_eq!(value.get::<&str>(), Ok("return value"));
+        let value = obj.emit::<String>(signal_id, &[]);
+        assert_eq!(value, "return value");
     }
 
     #[test]
@@ -612,7 +609,7 @@ mod test {
                     .to_value(),
             )
         });
-        let value = obj.emit_by_name("create-child-object", &[]).unwrap();
+        let value: glib::Object = obj.emit_by_name("create-child-object", &[]);
         assert!(value.type_().is_a(ChildObject::static_type()));
     }
 }


### PR DESCRIPTION
…re::emit()` directly instead of working with a `glib::Value`

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/337