### PR TITLE
glib: Implement `FromValue` for references of object/shared/boxed types

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -250,6 +250,17 @@ macro_rules! glib_boxed_wrapper {
         }
 
         #[doc(hidden)]
+        unsafe impl<'a> $crate::value::FromValue<'a> for &'a $name {
+            type Checker = $crate::value::GenericValueTypeOrNoneChecker<Self>;
+
+            unsafe fn from_value(value: &'a $crate::Value) -> Self {
+                let ptr = $crate::gobject_ffi::g_value_get_boxed($crate::translate::ToGlibPtr::to_glib_none(value).0);
+                assert!(!ptr.is_null());
+                &*(ptr as *const $name)
+            }
+        }
+
+        #[doc(hidden)]
         impl $crate::value::ToValue for $name {
             fn to_value(&self) -> $crate::Value {
                 unsafe {

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -925,6 +925,18 @@ macro_rules! glib_object_wrapper {
         }
 
         #[doc(hidden)]
+        unsafe impl<'a> $crate::value::FromValue<'a> for &'a $name {
+            type Checker = $crate::value::GenericValueTypeOrNoneChecker<Self>;
+
+            unsafe fn from_value(value: &'a $crate::Value) -> Self {
+                let ptr = $crate::gobject_ffi::g_value_get_object($crate::translate::ToGlibPtr::to_glib_none(value).0);
+                assert!(!ptr.is_null());
+                assert_ne!((*ptr).ref_count, 0);
+                &*(ptr as *const $name)
+            }
+        }
+
+        #[doc(hidden)]
         impl $crate::value::ToValue for $name {
             fn to_value(&self) -> $crate::Value {
                 unsafe {

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -278,6 +278,17 @@ macro_rules! glib_shared_wrapper {
         }
 
         #[doc(hidden)]
+        unsafe impl<'a> $crate::value::FromValue<'a> for &'a $name {
+            type Checker = $crate::value::GenericValueTypeOrNoneChecker<Self>;
+
+            unsafe fn from_value(value: &'a $crate::Value) -> Self {
+                let ptr = $crate::gobject_ffi::g_value_dup_boxed($crate::translate::ToGlibPtr::to_glib_none(value).0);
+                assert!(!ptr.is_null());
+                &*(ptr as *const $name)
+            }
+        }
+
+        #[doc(hidden)]
         impl $crate::value::ToValue for $name {
             fn to_value(&self) -> $crate::Value {
                 unsafe {


### PR DESCRIPTION
Especially for boxed types this is useful as it avoids an unnecessary
copy of the underlying value.