### PR TITLE
glib: Mark `g_get_user_special_dir()` return value as `nullable`

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -175,6 +175,12 @@ status = "generate"
     #manual is_windows_utf8
     manual = true
     [[object.function]]
+    name = "get_user_special_dir"
+        # See https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2334
+        # Fixed in 2.72
+        [object.function.return]
+        nullable = true
+    [[object.function]]
     name = "mkstemp"
     #manual is_windows_utf8
     manual = true

--- a/glib/src/auto/functions.rs
+++ b/glib/src/auto/functions.rs
@@ -783,7 +783,7 @@ pub fn user_runtime_dir() -> std::path::PathBuf {
 
 #[doc(alias = "g_get_user_special_dir")]
 #[doc(alias = "get_user_special_dir")]
-pub fn user_special_dir(directory: UserDirectory) -> std::path::PathBuf {
+pub fn user_special_dir(directory: UserDirectory) -> Option<std::path::PathBuf> {
     unsafe { from_glib_none(ffi::g_get_user_special_dir(directory.into_glib())) }
 }
 


### PR DESCRIPTION
Fixes https://github.com/gtk-rs/gtk-rs-core/issues/368