### PR TITLE
glib/gir: ignore g_clear_error

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -51,6 +51,10 @@ manual = [
 name = "GLib.*"
 status = "generate"
     [[object.function]]
+    name = "clear_error"
+    #unusable
+    ignore = true
+    [[object.function]]
     name = "propagate_error"
     #empty first parameter
     ignore = true

--- a/glib/src/auto/functions.rs
+++ b/glib/src/auto/functions.rs
@@ -209,19 +209,6 @@ pub fn check_version(
     }
 }
 
-#[doc(alias = "g_clear_error")]
-pub fn clear_error() -> Result<(), crate::Error> {
-    unsafe {
-        let mut error = ptr::null_mut();
-        let _ = ffi::g_clear_error(&mut error);
-        if error.is_null() {
-            Ok(())
-        } else {
-            Err(from_glib_full(error))
-        }
-    }
-}
-
 //#[cfg(any(feature = "v2_56", feature = "dox"))]
 //#[cfg_attr(feature = "dox", doc(cfg(feature = "v2_56")))]
 //#[doc(alias = "g_clear_handle_id")]


### PR DESCRIPTION
This avoids auto-generating a safe wrapper for `g_clear_error`.
Its NULL resetting logic isn't really useful in a safe Rust context.