### PR TITLE
glib: specify it's a Variant struct not a derive macro

### DIFF
--- a/glib/README.md
+++ b/glib/README.md
@@ -24,7 +24,7 @@ Most types in the GLib family have [`Type`] identifiers.
 Their corresponding Rust types implement the [`StaticType`] trait.
 
 A dynamically typed [`Value`] can carry values of any [`StaticType`].
-[`Variant`]s can carry values of [`StaticVariantType`].
+[`Variant`](struct@Variant)s can carry values of [`StaticVariantType`].
 
 ## Errors
 


### PR DESCRIPTION
Along  with https://github.com/gtk-rs/gir/pull/1282, the warnings in the generated docs should be gone