### PR TITLE
glib: add ObjectSubclassIsExt trait with impl_ method

### DIFF
--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -86,12 +86,13 @@ pub unsafe trait InstanceStruct: Sized + 'static {
     }
 }
 
-/// Trait implemented by `ObjectSubclassIs` to return the private rust struct
+/// Trait implemented by any type implementing `ObjectSubclassIs` to return the implementation, private Rust struct.
 pub trait ObjectSubclassIsExt: ObjectSubclassIs {
     fn impl_(&self) -> &Self::Subclass;
 }
 
 impl<T: ObjectSubclassIs<Subclass = S>, S: ObjectSubclass<Type = Self>> ObjectSubclassIsExt for T {
+    /// Returns the implementation (the private Rust struct) of this class instance
     fn impl_(&self) -> &T::Subclass {
         T::Subclass::from_instance(self)
     }

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -88,11 +88,11 @@ pub unsafe trait InstanceStruct: Sized + 'static {
 
 /// Trait implemented by any type implementing `ObjectSubclassIs` to return the implementation, private Rust struct.
 pub trait ObjectSubclassIsExt: ObjectSubclassIs {
+    /// Returns the implementation (the private Rust struct) of this class instance
     fn impl_(&self) -> &Self::Subclass;
 }
 
 impl<T: ObjectSubclassIs<Subclass = S>, S: ObjectSubclass<Type = Self>> ObjectSubclassIsExt for T {
-    /// Returns the implementation (the private Rust struct) of this class instance
     fn impl_(&self) -> &T::Subclass {
         T::Subclass::from_instance(self)
     }

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -86,6 +86,17 @@ pub unsafe trait InstanceStruct: Sized + 'static {
     }
 }
 
+/// Trait implemented by `ObjectSubclassIs` to return the private rust struct
+pub trait ObjectSubclassIsExt: ObjectSubclassIs {
+    fn impl_(&self) -> &Self::Subclass;
+}
+
+impl<T: ObjectSubclassIs<Subclass = S>, S: ObjectSubclass<Type = Self>> ObjectSubclassIsExt for T {
+    fn impl_(&self) -> &T::Subclass {
+        T::Subclass::from_instance(self)
+    }
+}
+
 /// Trait implemented by structs that implement a `GObject` C class struct.
 ///
 /// The struct must be `#[repr(C)]` and have the parent type's class struct


### PR DESCRIPTION
So, I haven't tested it, but it doesn't use `unsafe` and it compiles, so I'm _pretty_ sure this just works