### PR TITLE
allow for the modifying GlyphInfo and GlyphGeometry

### DIFF
--- a/pango/src/glyph_geometry.rs
+++ b/pango/src/glyph_geometry.rs
@@ -12,12 +12,24 @@ impl GlyphGeometry {
         self.0.width
     }
 
+    pub fn set_width(&mut self, width: i32) {
+        self.0.width = width;
+    }
+
     pub fn x_offset(&self) -> i32 {
         self.0.x_offset
     }
 
+    pub fn set_x_offset(&mut self, x_offset: i32) {
+        self.0.x_offset = x_offset;
+    }
+
     pub fn y_offset(&self) -> i32 {
         self.0.y_offset
+    }
+
+    pub fn set_y_offset(&mut self, y_offset: i32) {
+        self.0.y_offset = y_offset;
     }
 }
 

--- a/pango/src/glyph_info.rs
+++ b/pango/src/glyph_info.rs
@@ -14,7 +14,11 @@ impl GlyphInfo {
     }
 
     pub fn geometry(&self) -> &GlyphGeometry {
-        unsafe { &*(&((self.0).geometry) as *const _ as *const GlyphGeometry) }
+        unsafe { &*(&self.0.geometry as *const _ as *const GlyphGeometry) }
+    }
+
+    pub fn geometry_mut(&mut self) -> &mut GlyphGeometry {
+        unsafe { &mut *(&mut self.0.geometry as *mut _ as *mut GlyphGeometry) }
     }
 }
 

--- a/pango/src/glyph_string.rs
+++ b/pango/src/glyph_string.rs
@@ -2,20 +2,34 @@
 
 use crate::{GlyphInfo, GlyphString};
 use glib::translate::*;
+use std::slice;
 
 impl GlyphString {
     pub fn num_glyphs(&self) -> i32 {
         unsafe { (*self.to_glib_none().0).num_glyphs }
     }
 
-    pub fn glyph_info(&self) -> Vec<GlyphInfo> {
-        if self.num_glyphs() < 0 {
-            return Vec::new();
-        }
-        let num_glyphs = self.num_glyphs() as usize;
+    pub fn glyph_info(&self) -> &[GlyphInfo] {
         unsafe {
-            let glyphs: *mut ffi::PangoGlyphInfo = (*self.to_glib_none().0).glyphs;
-            FromGlibContainer::from_glib_none_num(glyphs, num_glyphs)
+            let ptr = (*self.to_glib_none().0).glyphs as *const GlyphInfo;
+
+            if ptr.is_null() || self.num_glyphs() <= 0 {
+                &[]
+            } else {
+                slice::from_raw_parts(ptr, self.num_glyphs() as usize)
+            }
+        }
+    }
+
+    pub fn glyph_info_mut(&mut self) -> &mut [GlyphInfo] {
+        unsafe {
+            let ptr = (*self.to_glib_none().0).glyphs as *mut GlyphInfo;
+
+            if ptr.is_null() || self.num_glyphs() <= 0 {
+                &mut []
+            } else {
+                slice::from_raw_parts_mut(ptr, self.num_glyphs() as usize)
+            }
         }
     }
 }


### PR DESCRIPTION
From what I can understand about this API,  The GlyphGeometry objects inside of a GlyphString should be modifiable.

To make this work, its GlyphInfo's should not be a newly created vector, but rather a slice created from its internal pointer and length.

I believe this change brings it in line with how the API is meant to be used in C.