### PR TITLE
Implement ToValue on signal::Inhibit

### DIFF
--- a/glib/src/signal.rs
+++ b/glib/src/signal.rs
@@ -82,6 +82,16 @@ impl IntoGlib for Inhibit {
     }
 }
 
+impl crate::ToValue for Inhibit {
+    fn to_value(&self) -> crate::Value {
+        self.0.to_value()
+    }
+
+    fn value_type(&self) -> crate::Type {
+        <bool as crate::StaticType>::static_type()
+    }
+}
+
 pub unsafe fn connect_raw<F>(
     receiver: *mut gobject_ffi::GObject,
     signal_name: *const c_char,


### PR DESCRIPTION
Not particularly sure if this is useful since it can't be a strict requirement for closures, but it can give some consistency with the auto generated `connect` methods.