### PR TITLE
glib-macros: Use absolute paths in proc macros

### DIFF
--- a/glib-macros/src/boxed_derive.rs
+++ b/glib-macros/src/boxed_derive.rs
@@ -9,8 +9,8 @@ use crate::utils::{crate_ident_new, find_attribute_meta, find_nested_meta, parse
 fn gen_option_to_ptr() -> TokenStream {
     quote! {
         match s {
-            Some(s) => Box::into_raw(Box::new(s.clone())),
-            None => std::ptr::null_mut(),
+            Some(s) => ::std::boxed::Box::into_raw(::std::boxed::Box::new(s.clone())),
+            None => ::std::ptr::null_mut(),
         };
     }
 }
@@ -23,7 +23,7 @@ fn gen_impl_from_value_optional(name: &Ident, crate_ident: &TokenStream) -> Toke
             unsafe fn from_value(value: &'a #crate_ident::Value) -> Self {
                 let ptr = #crate_ident::gobject_ffi::g_value_dup_boxed(#crate_ident::translate::ToGlibPtr::to_glib_none(value).0);
                 assert!(!ptr.is_null());
-                *Box::from_raw(ptr as *mut #name)
+                *::std::boxed::Box::from_raw(ptr as *mut #name)
             }
         }
 
@@ -47,7 +47,7 @@ fn gen_impl_from_value(name: &Ident, crate_ident: &TokenStream) -> TokenStream {
             unsafe fn from_value(value: &'a #crate_ident::Value) -> Self {
                 let ptr = #crate_ident::gobject_ffi::g_value_dup_boxed(#crate_ident::translate::ToGlibPtr::to_glib_none(value).0);
                 assert!(!ptr.is_null());
-                *Box::from_raw(ptr as *mut #name)
+                *::std::boxed::Box::from_raw(ptr as *mut #name)
             }
         }
 
@@ -68,7 +68,7 @@ fn gen_impl_to_value_optional(name: &Ident, crate_ident: &TokenStream) -> TokenS
 
     quote! {
         impl #crate_ident::value::ToValueOptional for #name {
-            fn to_value_optional(s: Option<&Self>) -> #crate_ident::Value {
+            fn to_value_optional(s: ::core::option::Option<&Self>) -> #crate_ident::Value {
                 let mut value = #crate_ident::Value::for_value_type::<Self>();
                 unsafe {
                     let ptr: *mut #name = #option_to_ptr;
@@ -146,7 +146,7 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> TokenStream {
         impl #crate_ident::value::ToValue for #name {
             fn to_value(&self) -> #crate_ident::Value {
                 unsafe {
-                    let ptr: *mut #name = Box::into_raw(Box::new(self.clone()));
+                    let ptr: *mut #name = ::std::boxed::Box::into_raw(::std::boxed::Box::new(self.clone()));
                     let mut value = #crate_ident::Value::from_type(<#name as #crate_ident::StaticType>::static_type());
                     #crate_ident::gobject_ffi::g_value_take_boxed(
                         #crate_ident::translate::ToGlibPtrMut::to_glib_none_mut(&mut value).0,
@@ -184,7 +184,7 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> TokenStream {
             #[inline]
             unsafe fn from_glib_full(ptr: *mut #name) -> Self {
                 assert!(!ptr.is_null());
-                *Box::from_raw(ptr)
+                *::std::boxed::Box::from_raw(ptr)
             }
         }
 
@@ -198,7 +198,7 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> TokenStream {
 
             #[inline]
             fn to_glib_full(&self) -> *const #name {
-                Box::into_raw(Box::new(self.clone()))
+                ::std::boxed::Box::into_raw(::std::boxed::Box::new(self.clone()))
             }
         }
 
@@ -212,7 +212,7 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> TokenStream {
 
             #[inline]
             fn to_glib_full(&self) -> *mut #name {
-                Box::into_raw(Box::new(self.clone())) as *mut _
+                ::std::boxed::Box::into_raw(::std::boxed::Box::new(self.clone())) as *mut _
             }
         }
     }

--- a/glib-macros/src/downgrade_derive/enums.rs
+++ b/glib-macros/src/downgrade_derive/enums.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use super::fields::{derive_downgrade_fields, DowngradeStructParts};
+use crate::utils::crate_ident_new;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Generics, Ident};
@@ -68,6 +69,7 @@ pub fn derive_downgrade_for_enum(
     generics: Generics,
     data_enum: syn::DataEnum,
 ) -> TokenStream {
+    let glib = crate_ident_new();
     let weak_type = format_ident!("{}Weak", ident);
 
     let variants: Vec<(Ident, DowngradeStructParts)> = data_enum
@@ -113,7 +115,7 @@ pub fn derive_downgrade_for_enum(
             #weak_variants
         ),*}
 
-        impl #generics glib::clone::Downgrade for #ident #generics {
+        impl #generics #glib::clone::Downgrade for #ident #generics {
             type Weak = #weak_type #generics;
 
             fn downgrade(&self) -> Self::Weak {
@@ -123,10 +125,10 @@ pub fn derive_downgrade_for_enum(
             }
         }
 
-        impl #generics glib::clone::Upgrade for #weak_type #generics {
+        impl #generics #glib::clone::Upgrade for #weak_type #generics {
             type Strong = #ident #generics;
 
-            fn upgrade(&self) -> Option<Self::Strong> {
+            fn upgrade(&self) -> ::core::option::Option<Self::Strong> {
                 Some(match self {#(
                     #upgrade_variants
                 ),*})

--- a/glib-macros/src/downgrade_derive/fields.rs
+++ b/glib-macros/src/downgrade_derive/fields.rs
@@ -1,5 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::utils::crate_ident_new;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Fields, FieldsNamed, FieldsUnnamed, Ident, Type};
@@ -97,6 +98,7 @@ pub struct DowngradeStructParts {
 /// }
 /// ```
 pub fn derive_downgrade_fields(fields: syn::Fields) -> DowngradeStructParts {
+    let glib = crate_ident_new();
     match fields {
         Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
             let fields: Vec<Type> = unnamed
@@ -109,7 +111,7 @@ pub fn derive_downgrade_fields(fields: syn::Fields) -> DowngradeStructParts {
                 .iter()
                 .map(|ty| {
                     quote! {
-                        <#ty as glib::clone::Downgrade>::Weak
+                        <#ty as #glib::clone::Downgrade>::Weak
                     }
                 })
                 .collect();
@@ -131,12 +133,12 @@ pub fn derive_downgrade_fields(fields: syn::Fields) -> DowngradeStructParts {
                 },
                 downgrade: quote! {
                     (#(
-                        glib::clone::Downgrade::downgrade(#field_ident)
+                        #glib::clone::Downgrade::downgrade(#field_ident)
                     ),*)
                 },
                 upgrade: quote! {
                     (#(
-                        glib::clone::Upgrade::upgrade(#field_ident)?
+                        #glib::clone::Upgrade::upgrade(#field_ident)?
                     ),*)
                 },
             }
@@ -152,7 +154,7 @@ pub fn derive_downgrade_fields(fields: syn::Fields) -> DowngradeStructParts {
                 .iter()
                 .map(|(ident, ty)| {
                     quote! {
-                        #ident: <#ty as glib::clone::Downgrade>::Weak
+                        #ident: <#ty as #glib::clone::Downgrade>::Weak
                     }
                 })
                 .collect();
@@ -173,12 +175,12 @@ pub fn derive_downgrade_fields(fields: syn::Fields) -> DowngradeStructParts {
                 },
                 downgrade: quote! {
                     {#(
-                        #field_ident: glib::clone::Downgrade::downgrade(#field_ident)
+                        #field_ident: #glib::clone::Downgrade::downgrade(#field_ident)
                     ),*}
                 },
                 upgrade: quote! {
                     {#(
-                        #field_ident: glib::clone::Upgrade::upgrade(#field_ident)?
+                        #field_ident: #glib::clone::Upgrade::upgrade(#field_ident)?
                     ),*}
                 },
             }

--- a/glib-macros/src/downgrade_derive/structs.rs
+++ b/glib-macros/src/downgrade_derive/structs.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use super::fields::{derive_downgrade_fields, DowngradeStructParts};
+use crate::utils::crate_ident_new;
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Generics, Ident};
@@ -84,6 +85,7 @@ pub fn derive_downgrade_for_struct(
     generics: Generics,
     data_struct: syn::DataStruct,
 ) -> TokenStream {
+    let glib = crate_ident_new();
     let weak_type = format_ident!("{}Weak", ident);
 
     let DowngradeStructParts {
@@ -97,7 +99,7 @@ pub fn derive_downgrade_for_struct(
     let derived = quote! {
         pub struct #weak_type #generics #weak_fields #end_of_struct
 
-        impl #generics glib::clone::Downgrade for #ident #generics {
+        impl #generics #glib::clone::Downgrade for #ident #generics {
             type Weak = #weak_type #generics;
 
             fn downgrade(&self) -> Self::Weak {
@@ -106,10 +108,10 @@ pub fn derive_downgrade_for_struct(
             }
         }
 
-        impl #generics glib::clone::Upgrade for #weak_type #generics {
+        impl #generics #glib::clone::Upgrade for #weak_type #generics {
             type Strong = #ident #generics;
 
-            fn upgrade(&self) -> Option<Self::Strong> {
+            fn upgrade(&self) -> ::core::option::Option<Self::Strong> {
                 let Self #destruct = self;
                 Some(#ident #upgrade)
             }

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -98,7 +98,7 @@ pub fn impl_enum(input: &syn::DeriveInput) -> TokenStream {
         impl #crate_ident::translate::TryFromGlib<i32> for #name {
             type Error = i32;
 
-            unsafe fn try_from_glib(value: i32) -> Result<Self, i32> {
+            unsafe fn try_from_glib(value: i32) -> ::core::result::Result<Self, i32> {
                 let from_glib = || {
                     #from_glib
                 };
@@ -148,7 +148,7 @@ pub fn impl_enum(input: &syn::DeriveInput) -> TokenStream {
 
         impl #crate_ident::StaticType for #name {
             fn static_type() -> #crate_ident::Type {
-                static ONCE: std::sync::Once = std::sync::Once::new();
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
                 static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
 
                 ONCE.call_once(|| {
@@ -156,12 +156,12 @@ pub fn impl_enum(input: &syn::DeriveInput) -> TokenStream {
                         #enum_values
                         #crate_ident::gobject_ffi::GEnumValue {
                             value: 0,
-                            value_name: std::ptr::null(),
-                            value_nick: std::ptr::null(),
+                            value_name: ::std::ptr::null(),
+                            value_nick: ::std::ptr::null(),
                         },
                     ];
 
-                    let name = std::ffi::CString::new(#gtype_name).expect("CString::new failed");
+                    let name = ::std::ffi::CString::new(#gtype_name).expect("CString::new failed");
                     unsafe {
                         let type_ = #crate_ident::gobject_ffi::g_enum_register_static(name.as_ptr(), VALUES.as_ptr());
                         TYPE = #crate_ident::translate::from_glib(type_);

--- a/glib-macros/src/error_domain_derive.rs
+++ b/glib-macros/src/error_domain_derive.rs
@@ -43,7 +43,7 @@ pub fn impl_error_domain(input: &syn::DeriveInput) -> TokenStream {
                 self as i32
             }
 
-            fn from(value: i32) -> Option<Self>
+            fn from(value: i32) -> ::core::option::Option<Self>
             where
                 Self: Sized
             {

--- a/glib-macros/src/flags_attribute.rs
+++ b/glib-macros/src/flags_attribute.rs
@@ -176,7 +176,7 @@ pub fn impl_flags(attrs: &NestedMeta, input: &DeriveInput) -> TokenStream {
 
         impl #crate_ident::StaticType for #name {
             fn static_type() -> #crate_ident::Type {
-                static ONCE: std::sync::Once = std::sync::Once::new();
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
                 static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
 
                 ONCE.call_once(|| {
@@ -184,12 +184,12 @@ pub fn impl_flags(attrs: &NestedMeta, input: &DeriveInput) -> TokenStream {
                         #flags_values
                         #crate_ident::gobject_ffi::GFlagsValue {
                             value: 0,
-                            value_name: std::ptr::null(),
-                            value_nick: std::ptr::null(),
+                            value_name: ::std::ptr::null(),
+                            value_nick: ::std::ptr::null(),
                         },
                     ];
 
-                    let name = std::ffi::CString::new(#gtype_name).expect("CString::new failed");
+                    let name = ::std::ffi::CString::new(#gtype_name).expect("CString::new failed");
                     unsafe {
                         let type_ = #crate_ident::gobject_ffi::g_flags_register_static(name.as_ptr(), VALUES.as_ptr());
                         TYPE = #crate_ident::translate::from_glib(type_);

--- a/glib-macros/src/object_interface_attribute.rs
+++ b/glib-macros/src/object_interface_attribute.rs
@@ -52,7 +52,7 @@ pub fn impl_object_interface(input: &syn::ItemImpl) -> TokenStream {
 
         unsafe impl #crate_ident::subclass::interface::ObjectInterfaceType for #self_ty {
             fn type_() -> #crate_ident::Type {
-                static ONCE: std::sync::Once = std::sync::Once::new();
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
                 static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
 
                 ONCE.call_once(|| {

--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -69,7 +69,7 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
     } else {
         Some(quote! {
             fn new() -> Self {
-                std::default::Default::default()
+                ::std::default::Default::default()
             }
         })
     };
@@ -103,21 +103,21 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
         }
 
         unsafe impl #crate_ident::subclass::types::ObjectSubclassType for #self_ty {
-            fn type_data() -> std::ptr::NonNull<#crate_ident::subclass::TypeData> {
+            fn type_data() -> ::std::ptr::NonNull<#crate_ident::subclass::TypeData> {
                 static mut DATA: #crate_ident::subclass::TypeData = #crate_ident::subclass::TypeData {
                     type_: #crate_ident::Type::INVALID,
-                    parent_class: std::ptr::null_mut(),
+                    parent_class: ::std::ptr::null_mut(),
                     parent_ifaces: None,
                     class_data: None,
                     private_offset: 0,
                     private_imp_offset: 0,
                 };
 
-                unsafe { std::ptr::NonNull::new_unchecked(&mut DATA) }
+                unsafe { ::std::ptr::NonNull::new_unchecked(&mut DATA) }
             }
 
             fn type_() -> #crate_ident::Type {
-                static ONCE: std::sync::Once = std::sync::Once::new();
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
 
                 ONCE.call_once(|| {
                     #crate_ident::subclass::register_type::<Self>();

--- a/glib-macros/src/shared_boxed_derive.rs
+++ b/glib-macros/src/shared_boxed_derive.rs
@@ -11,12 +11,12 @@ fn gen_impl_to_value_optional(name: &Ident, crate_ident: &TokenStream) -> TokenS
 
     quote! {
         impl #crate_ident::value::ToValueOptional for #name {
-            fn to_value_optional(s: Option<&Self>) -> #crate_ident::Value {
+            fn to_value_optional(s: ::core::option::Option<&Self>) -> #crate_ident::Value {
                 let mut value = #crate_ident::Value::for_value_type::<Self>();
                 unsafe {
                     let ptr = match s {
                         Some(s) => #refcounted_type_prefix::into_raw(s.0.clone()),
-                        None => std::ptr::null(),
+                        None => ::std::ptr::null(),
                     };
 
                     #crate_ident::gobject_ffi::g_value_take_boxed(


### PR DESCRIPTION
Just some cleanup, also adds use of `crate_ident_new` in a few places where it's missing. Technically this should also be done on the method calls at some point.