### PR TITLE
glib-macros: Add support for enums to glib::Variant 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.56.0"
+          - "1.57.0"
         conf:
           - { name: "cairo", features: "png,pdf,svg,ps,use_glib,v1_16,freetype,script,xcb,xlib,win32-surface", nightly: "--features 'png,pdf,svg,ps,use_glib,v1_16,freetype,script,xcb,xlib,win32-surface'", test_sys: true }
           - { name: "gdk-pixbuf", features: "v2_40", nightly: "--all-features", test_sys: true }
@@ -96,7 +96,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.56.0"
+          - "1.57.0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ information about each crate, please refer to their `README.md` file in their di
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Documentation
 

--- a/cairo/Cargo.toml
+++ b/cairo/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.16.0"
 description = "Rust bindings for the Cairo library"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 name = "cairo"

--- a/cairo/README.md
+++ b/cairo/README.md
@@ -8,7 +8,7 @@ Cairo __1.14__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Default-on features
 

--- a/cairo/sys/Cargo.toml
+++ b/cairo/sys/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cairo", "ffi", "gtk-rs", "gnome"]
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 build = "build.rs"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [package.metadata.system-deps.cairo]
 name = "cairo"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@ name = "gtk-rs-examples"
 version = "0.0.1"
 authors = ["The gtk-rs Project Developers"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 futures = "0.3"

--- a/gdk-pixbuf/Cargo.toml
+++ b/gdk-pixbuf/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 name = "gdk_pixbuf"

--- a/gdk-pixbuf/README.md
+++ b/gdk-pixbuf/README.md
@@ -6,7 +6,7 @@ GDK-PixBuf __2.32__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Documentation
 

--- a/gdk-pixbuf/sys/Cargo.toml
+++ b/gdk-pixbuf/sys/Cargo.toml
@@ -41,7 +41,7 @@ name = "gdk-pixbuf-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.gdk_pixbuf_2_0]

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 build = "build.rs"
 
 [lib]

--- a/gio/README.md
+++ b/gio/README.md
@@ -6,7 +6,7 @@ GIO __2.48__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Documentation
 

--- a/gio/sys/Cargo.toml
+++ b/gio/sys/Cargo.toml
@@ -48,7 +48,7 @@ name = "gio-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.gio_2_0]

--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["glib", "gtk-rs", "gnome", "GUI"]
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1"

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -437,6 +437,8 @@ pub fn closure_local(item: TokenStream) -> TokenStream {
 ///     ValWithCustomNameAndNick,
 /// }
 /// ```
+///
+/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
 #[proc_macro_derive(Enum, attributes(enum_type, enum_value))]
 #[proc_macro_error]
 pub fn enum_derive(input: TokenStream) -> TokenStream {
@@ -474,7 +476,7 @@ pub fn enum_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`glib::Value`]: value/struct.Value.html
+/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn flags(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -501,7 +503,7 @@ pub fn flags(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`ErrorDomain`]: error/trait.ErrorDomain.html
+/// [`ErrorDomain`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/error/trait.ErrorDomain.html
 #[proc_macro_derive(ErrorDomain, attributes(error_domain))]
 #[proc_macro_error]
 pub fn error_domain_derive(input: TokenStream) -> TokenStream {
@@ -524,8 +526,8 @@ pub fn error_domain_derive(input: TokenStream) -> TokenStream {
 /// struct MyBoxed(String);
 /// ```
 ///
-/// [`BoxedType`]: subclass/boxed/trait.BoxedType.html
-/// [`glib::Value`]: value/struct.Value.html
+/// [`BoxedType`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/boxed/trait.BoxedType.html
+/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
 #[proc_macro_derive(Boxed, attributes(boxed_nullable, boxed_type))]
 #[proc_macro_error]
 pub fn boxed_derive(input: TokenStream) -> TokenStream {
@@ -552,8 +554,8 @@ pub fn boxed_derive(input: TokenStream) -> TokenStream {
 /// struct MyShared(std::sync::Arc<MySharedInner>);
 /// ```
 ///
-/// [`SharedType`]: subclass/shared/trait.SharedType.html
-/// [`glib::Value`]: value/struct.Value.html
+/// [`SharedType`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/shared/trait.SharedType.html
+/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
 #[proc_macro_derive(SharedBoxed, attributes(shared_boxed_nullable, shared_boxed_type))]
 #[proc_macro_error]
 pub fn shared_boxed_derive(input: TokenStream) -> TokenStream {
@@ -590,7 +592,7 @@ pub fn shared_boxed_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`ObjectSubclass`]: subclass/types/trait.ObjectSubclass.html
+/// [`ObjectSubclass`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/types/trait.ObjectSubclass.html
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn object_subclass(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -615,7 +617,7 @@ pub fn object_subclass(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// type Prerequisites = ();
 /// ```
 ///
-/// [`ObjectInterface`]: interface/types/trait.ObjectInterface.html
+/// [`ObjectInterface`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/interface/trait.ObjectInterface.html
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn object_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -683,8 +685,8 @@ pub fn object_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`glib::clone::Downgrade`]: clone/trait.Downgrade.html
-/// [`glib::clone::Upgrade`]: clone/trait.Upgrade.html
+/// [`glib::clone::Downgrade`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/clone/trait.Downgrade.html
+/// [`glib::clone::Upgrade`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/clone/trait.Upgrade.html
 #[proc_macro_derive(Downgrade)]
 pub fn downgrade(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -44,8 +44,8 @@ use syn::{parse_macro_input, DeriveInput, NestedMeta};
 /// environment variable when running your code (either in the code directly or when running the
 /// binary) to either "all" or [`CLONE_MACRO_LOG_DOMAIN`]:
 ///
-/// [`g_debug`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.g_debug.html
-/// [`CLONE_MACRO_LOG_DOMAIN`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/constant.CLONE_MACRO_LOG_DOMAIN.html
+/// [`g_debug`]: ../glib/macro.g_debug.html
+/// [`CLONE_MACRO_LOG_DOMAIN`]: ../glib/constant.CLONE_MACRO_LOG_DOMAIN.html
 ///
 /// ```rust,ignore
 /// use glib::CLONE_MACRO_LOG_DOMAIN;
@@ -292,16 +292,16 @@ pub fn clone(item: TokenStream) -> TokenStream {
 /// [`clone!`](crate::clone!), as is aliasing captures with the `as` keyword. Notably, these
 /// captures are able to reference `Rc` and `Arc` values in addition to `Object` values.
 ///
-/// [`Closure`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/closure/struct.Closure.html
-/// [`Closure::new`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/closure/struct.Closure.html#method.new
-/// [`Closure::new_local`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/closure/struct.Closure.html#method.new_local
-/// [`Closure::invoke`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/closure/struct.Closure.html#method.invoke
-/// [`Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
-/// [`FromValue`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/trait.FromValue.html
-/// [`ToValue`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/trait.ToValue.html
-/// [`Interface`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/object/struct.Interface.html
-/// [`Object`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/object/struct.Object.html
-/// [`Object::watch_closure`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/object/trait.ObjectExt.html#tymethod.watch_closure
+/// [`Closure`]: ../glib/closure/struct.Closure.html
+/// [`Closure::new`]: ../glib/closure/struct.Closure.html#method.new
+/// [`Closure::new_local`]: ../glib/closure/struct.Closure.html#method.new_local
+/// [`Closure::invoke`]: ../glib/closure/struct.Closure.html#method.invoke
+/// [`Value`]: ../glib/value/struct.Value.html
+/// [`FromValue`]: ../glib/value/trait.FromValue.html
+/// [`ToValue`]: ../glib/value/trait.ToValue.html
+/// [`Interface`]: ../glib/object/struct.Interface.html
+/// [`Object`]: ../glib/object/struct.Object.html
+/// [`Object::watch_closure`]: ../glib/object/trait.ObjectExt.html#tymethod.watch_closure
 /// **⚠️ IMPORTANT ⚠️**
 ///
 /// `glib` needs to be in scope, so unless it's one of the direct crate dependencies, you need to
@@ -411,7 +411,7 @@ pub fn closure(item: TokenStream) -> TokenStream {
 /// This is useful for closures which can't be sent across threads. See the documentation of
 /// [`closure!`](crate::closure!) for details.
 ///
-/// [`Closure::new_local`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/closure/struct.Closure.html#method.new_local
+/// [`Closure::new_local`]: ../glib/closure/struct.Closure.html#method.new_local
 #[proc_macro]
 #[proc_macro_error]
 pub fn closure_local(item: TokenStream) -> TokenStream {
@@ -438,7 +438,7 @@ pub fn closure_local(item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
+/// [`glib::Value`]: ../glib/value/struct.Value.html
 #[proc_macro_derive(Enum, attributes(enum_type, enum_value))]
 #[proc_macro_error]
 pub fn enum_derive(input: TokenStream) -> TokenStream {
@@ -476,7 +476,7 @@ pub fn enum_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
+/// [`glib::Value`]: ../glib/value/struct.Value.html
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn flags(attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -503,7 +503,7 @@ pub fn flags(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`ErrorDomain`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/error/trait.ErrorDomain.html
+/// [`ErrorDomain`]: ../glib/error/trait.ErrorDomain.html
 #[proc_macro_derive(ErrorDomain, attributes(error_domain))]
 #[proc_macro_error]
 pub fn error_domain_derive(input: TokenStream) -> TokenStream {
@@ -526,8 +526,8 @@ pub fn error_domain_derive(input: TokenStream) -> TokenStream {
 /// struct MyBoxed(String);
 /// ```
 ///
-/// [`BoxedType`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/boxed/trait.BoxedType.html
-/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
+/// [`BoxedType`]: ../glib/subclass/boxed/trait.BoxedType.html
+/// [`glib::Value`]: ../glib/value/struct.Value.html
 #[proc_macro_derive(Boxed, attributes(boxed_nullable, boxed_type))]
 #[proc_macro_error]
 pub fn boxed_derive(input: TokenStream) -> TokenStream {
@@ -554,8 +554,8 @@ pub fn boxed_derive(input: TokenStream) -> TokenStream {
 /// struct MyShared(std::sync::Arc<MySharedInner>);
 /// ```
 ///
-/// [`SharedType`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/shared/trait.SharedType.html
-/// [`glib::Value`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/value/struct.Value.html
+/// [`SharedType`]: ../glib/subclass/shared/trait.SharedType.html
+/// [`glib::Value`]: ../glib/value/struct.Value.html
 #[proc_macro_derive(SharedBoxed, attributes(shared_boxed_nullable, shared_boxed_type))]
 #[proc_macro_error]
 pub fn shared_boxed_derive(input: TokenStream) -> TokenStream {
@@ -592,7 +592,7 @@ pub fn shared_boxed_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`ObjectSubclass`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/types/trait.ObjectSubclass.html
+/// [`ObjectSubclass`]: ../glib/subclass/types/trait.ObjectSubclass.html
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn object_subclass(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -617,7 +617,7 @@ pub fn object_subclass(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// type Prerequisites = ();
 /// ```
 ///
-/// [`ObjectInterface`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/interface/trait.ObjectInterface.html
+/// [`ObjectInterface`]: ../glib/subclass/interface/trait.ObjectInterface.html
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn object_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -685,8 +685,8 @@ pub fn object_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`glib::clone::Downgrade`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/clone/trait.Downgrade.html
-/// [`glib::clone::Upgrade`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/clone/trait.Upgrade.html
+/// [`glib::clone::Downgrade`]: ../glib/clone/trait.Downgrade.html
+/// [`glib::clone::Upgrade`]: ../glib/clone/trait.Upgrade.html
 #[proc_macro_derive(Downgrade)]
 pub fn downgrade(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -793,9 +793,9 @@ pub fn downgrade(input: TokenStream) -> TokenStream {
 /// assert_eq!(var.get::<MyEnum>(), Some(v));
 /// ```
 ///
-/// [`glib::Variant`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/variant/struct.Variant.html
-/// [`EnumClass`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/struct.EnumClass.html
-/// [`FlagsClass`]: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/struct.FlagsClass.html
+/// [`glib::Variant`]: ../glib/variant/struct.Variant.html
+/// [`EnumClass`]: ../glib/struct.EnumClass.html
+/// [`FlagsClass`]: ../glib/struct.FlagsClass.html
 /// [kebab case]: https://docs.rs/heck/0.4.0/heck/trait.ToKebabCase.html
 #[proc_macro_derive(Variant, attributes(variant_enum))]
 #[proc_macro_error]

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -337,6 +337,165 @@ fn derive_variant() {
     let var = v.to_variant();
     assert_eq!(var.type_().as_str(), "()");
     assert_eq!(var.get::<Variant5>(), Some(v));
+
+    #[derive(Debug, PartialEq, Eq, glib::Variant)]
+    enum Variant6 {
+        Unit,
+        Tuple(i32, Variant1),
+        Struct { id: i64, data: Variant2 },
+    }
+
+    assert_eq!(Variant6::static_variant_type().as_str(), "(sv)");
+    let v = Variant6::Unit;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "(sv)");
+    assert_eq!(var.get::<Variant6>(), Some(v));
+    let v = Variant6::Tuple(
+        5,
+        Variant1 {
+            some_string: "abc".into(),
+            some_int: 77,
+        },
+    );
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "(sv)");
+    assert_eq!(var.get::<Variant6>(), Some(v));
+    let v = Variant6::Struct {
+        id: 299,
+        data: Variant2 {
+            some_string: Some("abcdef".into()),
+            some_int: 300,
+        },
+    };
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "(sv)");
+    assert_eq!(var.get::<Variant6>(), Some(v));
+
+    #[derive(Debug, PartialEq, Eq, glib::Variant)]
+    #[variant_enum(repr)]
+    #[repr(u32)]
+    enum Variant7 {
+        Unit,
+        Tuple(i32, String),
+        Struct { id: i64, data: Vec<u8> },
+    }
+
+    assert_eq!(Variant7::static_variant_type().as_str(), "(uv)");
+    let v = Variant7::Struct {
+        id: 299,
+        data: vec![55, 56, 57, 58],
+    };
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "(uv)");
+    assert_eq!(var.get::<Variant7>(), Some(v));
+
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, glib::Variant, glib::Enum)]
+    #[variant_enum(enum)]
+    #[repr(i32)]
+    #[enum_type(name = "Variant8")]
+    enum Variant8 {
+        Goat,
+        #[enum_value(name = "The Dog")]
+        Dog,
+        #[enum_value(name = "The Cat", nick = "chat")]
+        Cat = 5,
+        Badger,
+    }
+
+    assert_eq!(Variant8::static_variant_type().as_str(), "s");
+    let v = Variant8::Cat;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "s");
+    assert_eq!(var.to_string(), "'chat'");
+    assert_eq!(var.get::<Variant8>(), Some(v));
+
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, glib::Variant, glib::Enum)]
+    #[variant_enum(enum, repr)]
+    #[repr(i32)]
+    #[enum_type(name = "Variant9")]
+    enum Variant9 {
+        Goat,
+        #[enum_value(name = "The Dog")]
+        Dog,
+        #[enum_value(name = "The Cat", nick = "chat")]
+        Cat = 5,
+        Badger,
+    }
+
+    assert_eq!(Variant9::static_variant_type().as_str(), "i");
+    let v = Variant9::Badger;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "i");
+    assert_eq!(var.get::<Variant9>(), Some(v));
+
+    #[derive(glib::Variant)]
+    #[variant_enum(flags)]
+    #[glib::flags(name = "Variant10")]
+    enum Variant10 {
+        #[flags_value(name = "Flag A", nick = "nick-a")]
+        A = 0b00000001,
+        #[flags_value(name = "Flag B")]
+        B = 0b00000010,
+        #[flags_value(skip)]
+        AB = Self::A.bits() | Self::B.bits(),
+        C = 0b00000100,
+    }
+
+    assert_eq!(Variant10::static_variant_type().as_str(), "s");
+    let v = Variant10::AB;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "s");
+    assert_eq!(var.to_string(), "'nick-a|b'");
+    assert_eq!(var.get::<Variant10>(), Some(v));
+
+    #[derive(glib::Variant)]
+    #[variant_enum(flags, repr)]
+    #[glib::flags(name = "Variant11")]
+    enum Variant11 {
+        #[flags_value(name = "Flag A", nick = "nick-a")]
+        A = 0b00000001,
+        #[flags_value(name = "Flag B")]
+        B = 0b00000010,
+        #[flags_value(skip)]
+        AB = Self::A.bits() | Self::B.bits(),
+        C = 0b00000100,
+    }
+
+    assert_eq!(Variant11::static_variant_type().as_str(), "u");
+    let v = Variant11::A | Variant11::C;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "u");
+    assert_eq!(var.get::<Variant11>(), Some(v));
+
+    #[derive(Debug, PartialEq, Eq, glib::Variant)]
+    enum Variant12 {
+        Goat,
+        Dog,
+        Cat = 5,
+        Badger,
+    }
+
+    assert_eq!(Variant12::static_variant_type().as_str(), "s");
+    let v = Variant12::Dog;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "s");
+    assert_eq!(var.get::<Variant12>(), Some(v));
+
+    #[derive(Debug, PartialEq, Eq, Copy, Clone, glib::Variant)]
+    #[variant_enum(repr)]
+    #[repr(u8)]
+    enum Variant13 {
+        Goat,
+        Dog,
+        Cat = 5,
+        Badger,
+    }
+
+    assert_eq!(Variant13::static_variant_type().as_str(), "y");
+    let v = Variant13::Badger;
+    let var = v.to_variant();
+    assert_eq!(var.type_().as_str(), "y");
+    assert_eq!(var.get::<Variant13>(), Some(v));
 }
 
 #[test]

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 name = "glib"

--- a/glib/README.md
+++ b/glib/README.md
@@ -16,7 +16,7 @@ crates.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Dynamic typing
 

--- a/glib/gobject-sys/Cargo.toml
+++ b/glib/gobject-sys/Cargo.toml
@@ -36,7 +36,7 @@ name = "gobject-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.gobject_2_0]

--- a/glib/src/closure.rs
+++ b/glib/src/closure.rs
@@ -37,7 +37,8 @@ impl RustClosure {
     // rustdoc-stripper-ignore-next
     /// Creates a new closure around a Rust closure.
     ///
-    /// See [`glib::closure!`] for a way to create a closure with concrete types.
+    /// See [`glib::closure!`](macro@crate::closure) for a way to create a closure with concrete
+    /// types.
     ///
     /// # Panics
     ///
@@ -67,7 +68,8 @@ impl RustClosure {
     // rustdoc-stripper-ignore-next
     /// Creates a new closure around a Rust closure.
     ///
-    /// See [`glib::closure_local!`] for a way to create a closure with concrete types.
+    /// See [`glib::closure_local!`](crate::closure_local) for a way to create a closure with
+    /// concrete types.
     ///
     /// # Panics
     ///

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1896,7 +1896,8 @@ pub trait ObjectExt: ObjectType {
     /// Limits the lifetime of `closure` to the lifetime of the object. When
     /// the object's reference count drops to zero, the closure will be
     /// invalidated. An invalidated closure will ignore any calls to
-    /// [`Closure::invoke`](crate::Closure::invoke).
+    /// [`invoke_with_values`](crate::closure::Closure::invoke_with_values), or
+    /// [`invoke`](crate::closure::RustClosure::invoke) when using Rust closures.
     #[doc(alias = "g_object_watch_closure")]
     fn watch_closure(&self, closure: &impl AsRef<Closure>);
 

--- a/glib/sys/Cargo.toml
+++ b/glib/sys/Cargo.toml
@@ -37,7 +37,7 @@ name = "glib-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.glib_2_0]

--- a/graphene/Cargo.toml
+++ b/graphene/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 name = "graphene"

--- a/graphene/README.md
+++ b/graphene/README.md
@@ -6,7 +6,7 @@ Graphene __2.44__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Documentation
 

--- a/graphene/sys/Cargo.toml
+++ b/graphene/sys/Cargo.toml
@@ -30,7 +30,7 @@ name = "graphene-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.graphene_gobject_1_0]

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [features]
 v1_40 = []

--- a/pango/README.md
+++ b/pango/README.md
@@ -6,7 +6,7 @@ Pango __1.38__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Documentation
 

--- a/pango/sys/Cargo.toml
+++ b/pango/sys/Cargo.toml
@@ -39,7 +39,7 @@ name = "pango-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.pango]

--- a/pangocairo/Cargo.toml
+++ b/pangocairo/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [features]
 dox = ["glib/dox", "pango/dox", "cairo-rs/dox"]

--- a/pangocairo/README.md
+++ b/pangocairo/README.md
@@ -7,7 +7,7 @@ PangoCairo __1.38__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.56.0`.
+Currently, the minimum supported Rust version is `1.57.0`.
 
 ## Documentation
 

--- a/pangocairo/sys/Cargo.toml
+++ b/pangocairo/sys/Cargo.toml
@@ -37,7 +37,7 @@ name = "pangocairo-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.16.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 [package.metadata.docs.rs]
 features = ["dox"]
 [package.metadata.system-deps.pangocairo]

--- a/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
+++ b/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
@@ -6,7 +6,7 @@ description = "crate that depends on a glib-rs dependent crate for validation of
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 # Use `gstreamer` as a simulation of an identified crate re-exporting `glib`.

--- a/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
@@ -7,7 +7,7 @@ description = "gstreamer simulator as a glib dependent crate for validation of g
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 glib = { path = "../../../glib" }

--- a/tests/two-levels-glib-dependent/gtk/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gtk/Cargo.toml
@@ -7,7 +7,7 @@ description = "gtk simulator as a glib dependent crate for validation of glib re
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 glib = { path = "../../../glib" }


### PR DESCRIPTION
Fixes #394

Supports a few different serialization methods via a `variant_enum` attribute, which changes the variant type:

- Defaults:
  - `(sv)` for enums with data variants, where `s` is the kebab case tag for the variant and `v` is a tuple variant packed as the equivalent struct would be.
  - `s` for c-style enums, just the kebab case tag.
- `#[variant_enum(repr)]` to be used with `#[repr(u*)]` or `#[repr(i*)]`.
  - `(*v)` or `*` where `*` is the integer type corresponding to the integer type.
- `#[variant_enum(enum)]` to be used with `#[derive(glib::Enum)]`.
  - `s` for the nick string of the value. Equivalent to the GTK builder format.
- `#[variant_enum(flags)]` to be used with `#[glib::flags]`.
  - `s` for the nick strings of the value, separated with `|`. Equivalent to the GTK builder format.
- `#[variant_enum(enum, repr)]` to be used with `#[derive(glib::Enum)]`.
  - `i`, or always serializes as `i32`.
- `#[variant_enum(flags, repr)]` to be used with `#[glib::flags]`.
  - `u`, or always serializes as `u32`.