### PR TITLE
glib: Add a helper trait for getting an object from a wrapper or subclass

### DIFF
--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -132,5 +132,13 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
                 }
             }
         }
+
+        #[doc(hidden)]
+        impl #crate_ident::subclass::types::FromObject for #self_ty {
+            type FromObjectType = <Self as #crate_ident::subclass::types::ObjectSubclass>::Type;
+            fn from_object(obj: &Self::FromObjectType) -> &Self {
+                <Self as #crate_ident::subclass::types::ObjectSubclassExt>::from_instance(obj)
+            }
+        }
     }
 }

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -675,6 +675,14 @@ macro_rules! glib_object_wrapper {
         unsafe impl $crate::object::IsA<$name> for $name { }
 
         #[doc(hidden)]
+        impl $crate::subclass::types::FromObject for $name {
+            type FromObjectType = $name;
+            fn from_object(obj: &Self::FromObjectType) -> &Self {
+                obj
+            }
+        }
+
+        #[doc(hidden)]
         impl<'a> $crate::translate::ToGlibPtr<'a, *const $ffi_name> for $name {
             type Storage = <$crate::object::ObjectRef as
                 $crate::translate::ToGlibPtr<'a, *mut $crate::object::GObject>>::Storage;

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -695,6 +695,13 @@ impl<T: ObjectSubclass> ObjectSubclassExt for T {
 }
 
 // rustdoc-stripper-ignore-next
+/// Helper trait for macros to access a subclass or its wrapper.
+pub trait FromObject {
+    type FromObjectType;
+    fn from_object(obj: &Self::FromObjectType) -> &Self;
+}
+
+// rustdoc-stripper-ignore-next
 /// An object that is currently being initialized.
 ///
 /// Binding crates should use traits for adding methods to this struct. Only methods explicitly safe


### PR DESCRIPTION
This could also be implemented by pulling `from_instance` out into a new trait, although that may break some uses of it