### PR TITLE
gio: move Task::run_in_thread to an extension trait

### DIFF
--- a/examples/gio_task/file_size/ffi.rs
+++ b/examples/gio_task/file_size/ffi.rs
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn my_file_size_get_file_size_async(
             .imp();
 
         source_object.size.replace(Some(size));
-        task.return_value(&size.to_value());
+        task.return_value(&size);
     });
 }
 
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn my_file_size_get_file_size_finish(
         .unwrap()
         .propagate_value()
     {
-        Ok(v) => v.get::<i64>().unwrap(),
+        Ok(v) => v,
         Err(e) => {
             *error = e.into_raw();
             0

--- a/examples/gio_task/file_size/mod.rs
+++ b/examples/gio_task/file_size/mod.rs
@@ -27,8 +27,6 @@ impl FileSize {
                 .downcast_ref::<gio::Task>()
                 .unwrap()
                 .propagate_value()
-                .unwrap()
-                .get::<i64>()
                 .unwrap();
             let source_object = source_object.unwrap().downcast_ref::<FileSize>().unwrap();
             callback(value, source_object);
@@ -55,7 +53,7 @@ impl FileSize {
             let source_object = source_object.downcast_ref::<FileSize>().unwrap().imp();
 
             source_object.size.replace(Some(size));
-            task.return_value(&size.to_value());
+            task.return_value(&size);
         });
     }
 
@@ -69,8 +67,6 @@ impl FileSize {
                 .downcast_ref::<gio::Task>()
                 .unwrap()
                 .propagate_value()
-                .unwrap()
-                .get::<i64>()
                 .unwrap();
             let source_object = source_object.unwrap().downcast_ref::<FileSize>().unwrap();
             callback(value, source_object);
@@ -82,7 +78,7 @@ impl FileSize {
             closure,
         );
 
-        let task_func = move |task: &gio::Task,
+        let task_func = move |_task: &gio::Task,
                               source_object: Option<&glib::Object>,
                               cancellable: Option<&gio::Cancellable>| {
             let size = gio::File::for_path("Cargo.toml")
@@ -97,7 +93,8 @@ impl FileSize {
                 .imp();
 
             source_object.size.replace(Some(size));
-            task.return_value(&size.to_value());
+
+            Ok(size)
         };
 
         task.run_in_thread(task_func);

--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -1086,6 +1086,7 @@ status = "generate"
 [[object]]
 name = "Gio.Task"
 status = "generate"
+manual_traits = ["TaskExtManual", "TaskExtManualSend"]
     [[object.function]]
     name = "new"
     #wrong prototype
@@ -1110,10 +1111,6 @@ status = "generate"
     name = "set_task_data"
     #high level bindings should not manually touch task data
     ignore = true
-    [[object.function]]
-    name = "run_in_thread"
-    #needs custom impl for task func
-    manual = true
     [[object.function]]
     name = "return_boolean"
     #not needed
@@ -1142,10 +1139,17 @@ status = "generate"
     name = "return_value"
     #wrong mutability
     manual = true
+    doc_trait_name = "TaskExtManual"
     [[object.function]]
     name = "propagate_value"
     #wrong mutability
     manual = true
+    doc_trait_name = "TaskExtManual"
+    [[object.function]]
+    name = "run_in_thread"
+    #needs custom impl for task func
+    manual = true
+    doc_trait_name = "TaskExtManualSend"
 
 [[object]]
 name = "Gio.ThemedIcon"

--- a/gio/src/prelude.rs
+++ b/gio/src/prelude.rs
@@ -27,6 +27,7 @@ pub use crate::pollable_input_stream::PollableInputStreamExtManual;
 pub use crate::pollable_output_stream::PollableOutputStreamExtManual;
 pub use crate::settings::SettingsExtManual;
 pub use crate::socket::*;
+pub use crate::task::{TaskExtManual, TaskExtManualSend};
 pub use crate::tls_connection::TlsConnectionExtManual;
 #[cfg(any(unix, feature = "dox"))]
 pub use crate::unix_fd_list::UnixFDListExtManual;


### PR DESCRIPTION
The trait is implemented only when returning values that implement ToSendValue.