### PR TITLE
boxed-inline: mark the phantom field as pub(crate)

### DIFF
--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -76,7 +76,7 @@ macro_rules! glib_boxed_inline_wrapper {
         #[repr(transparent)]
         $visibility struct $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? {
             pub(crate) inner: $ffi_name,
-            phantom: std::marker::PhantomData<($($($generic),+)?)>,
+            pub(crate) phantom: std::marker::PhantomData<($($($generic),+)?)>,
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? std::clone::Clone for $name $(<$($generic),+>)? {


### PR DESCRIPTION
otherwise bindings can't make use of it to create const like the GdkRGBA case.