### PR TITLE
boxed: implement UnsafeFrom trait

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -50,6 +50,16 @@ macro_rules! glib_boxed_wrapper {
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::GlibPtrDefault for $name $(<$($generic),+>)? {
             type GlibType = *mut $ffi_name;
         }
+        
+        #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::UnsafeFrom<$ffi_name> for $name $(<$($generic),+>)? {
+            unsafe fn unsafe_from(t: $ffi_name) -> Self {
+                Self {
+                    inner: t,
+                    phantom: std::marker::PhantomData,
+                }
+            }
+        }
 
         #[doc(hidden)]
         impl<'a $(, $($generic $(: $bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibPtr<'a, *const $ffi_name> for $name $(<$($generic),+>)? {


### PR DESCRIPTION
needed for gdk3 events, otherwise we would need to expose the phantom field for boxed as well
cc @pbor 