### PR TITLE
gio: mark creating Task as unsafe and add public documentation

### DIFF
--- a/examples/gio_task/file_size/mod.rs
+++ b/examples/gio_task/file_size/mod.rs
@@ -31,11 +31,13 @@ impl FileSize {
             callback(value, source_object);
         };
 
-        let task = gio::LocalTask::new(
-            Some(self.upcast_ref::<glib::Object>()),
-            cancellable,
-            closure,
-        );
+        let task = unsafe {
+            gio::LocalTask::new(
+                Some(self.upcast_ref::<glib::Object>()),
+                cancellable,
+                closure,
+            )
+        };
 
         glib::MainContext::default().spawn_local(async move {
             let size = gio::File::for_path("Cargo.toml")
@@ -68,7 +70,7 @@ impl FileSize {
             callback(value, source_object);
         };
 
-        let task = gio::Task::new(Some(self), cancellable, closure);
+        let task = unsafe { gio::Task::new(Some(self), cancellable, closure) };
 
         let task_func = move |task: gio::Task<i64>,
                               source_object: Option<&FileSize>,


### PR DESCRIPTION
Even with all the reccent improvements to the Task API, it is
still possible to bypass the requirements, for example by
casting LocalTask to Task, since they have the same underlying
GType.

At this point mark the constructors as unsafe and document
which invariants need to be manually esured by the callers.

The goal of this API is to enable callers to implement in
Rust APIs exposed to the C ffi which follow the glib
convention for async calls. Pure Rust applications should
probably use better abstractions to dispatch asynchronous
tasks.