### PR TITLE
glib: Correctly validate signal argument types in `emit_with_details(…

### DIFF
--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -2903,7 +2903,7 @@ impl<T: ObjectType> ObjectExt for T {
             )
             .collect::<smallvec::SmallVec<[_; 10]>>();
 
-            validate_signal_arguments(type_, &signal_query, &mut args)?;
+            validate_signal_arguments(type_, &signal_query, &mut args[1..])?;
 
             let mut return_value = if signal_query.return_type() != Type::UNIT {
                 Value::from_type(signal_query.return_type().into())
@@ -2964,7 +2964,7 @@ impl<T: ObjectType> ObjectExt for T {
             let mut args = Iterator::chain(std::iter::once(self_v), args.iter().cloned())
                 .collect::<smallvec::SmallVec<[_; 10]>>();
 
-            validate_signal_arguments(type_, &signal_query, &mut args)?;
+            validate_signal_arguments(type_, &signal_query, &mut args[1..])?;
 
             let mut return_value = if signal_query.return_type() != Type::UNIT {
                 Value::from_type(signal_query.return_type().into())


### PR DESCRIPTION
…)` variants

Previously this would've always failed due to not skipping the instance
argument.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/460