### PR TITLE
CI: publish docs directly to 0.15

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           command: doc
           args: -p cairo-rs -p cairo-sys-rs -p gdk-pixbuf -p gdk-pixbuf-sys -p gio -p gio-sys -p glib -p gobject-sys -p glib-sys -p glib-macros -p graphene-rs -p graphene-sys -p pango -p pango-sys -p pangocairo -p pangocairo-sys --features dox --no-deps
       - run: echo "RELEASE=$(echo '${{ github.event.release.tag_name }}' | grep -Po '(\d+)\.(\d+)')" >> ${GITHUB_ENV}
-      - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "release" ]; then echo 'stable/${{ env.RELEASE }}'; else echo 'git'; fi)" >> ${GITHUB_ENV}
+      - run: echo "DEST=stable/0.15" >> ${GITHUB_ENV}
       - name: Grab gtk-rs LOGO
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release' }}
         run: |


### PR DESCRIPTION
this is a workaround till we migrate the base image to something based on fedora