### PR TITLE
Generate bindings for markup_escape_text

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -102,7 +102,7 @@ status = "generate"
     pattern = "pattern_.*"
     ignore = true # use the ones from the std
     [[object.function]]
-    pattern = "markup_.*"
+    pattern = "(markup_collect_attributes|markup_printf_escaped|markup_vprintf_escaped)"
     ignore = true # they are supposed to be used with MarkupParser, which doesn't have safe bindings
     [[object.function]]
     pattern = "io_.*"

--- a/glib/src/auto/functions.rs
+++ b/glib/src/auto/functions.rs
@@ -463,6 +463,12 @@ pub fn main_depth() -> i32 {
     unsafe { ffi::g_main_depth() }
 }
 
+#[doc(alias = "g_markup_escape_text")]
+pub fn markup_escape_text(text: &str) -> crate::GString {
+    let length = text.len() as isize;
+    unsafe { from_glib_full(ffi::g_markup_escape_text(text.to_glib_none().0, length)) }
+}
+
 #[doc(alias = "g_mkdir_with_parents")]
 pub fn mkdir_with_parents(pathname: impl AsRef<std::path::Path>, mode: i32) -> i32 {
     unsafe { ffi::g_mkdir_with_parents(pathname.as_ref().to_glib_none().0, mode) }


### PR DESCRIPTION
Fixes: https://github.com/gtk-rs/gtk-rs-core/issues/489