### PR TITLE
Derive class name in glib::object_subclass

### DIFF
--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -13,6 +13,7 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
     let mut has_interfaces = false;
     let mut has_instance = false;
     let mut has_class = false;
+    let mut has_name = false;
     for item in &input.items {
         match item {
             syn::ImplItem::Method(method) => {
@@ -31,6 +32,12 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
                     has_instance = true;
                 } else if name == "Class" {
                     has_class = true;
+                }
+            }
+            syn::ImplItem::Const(constant) => {
+                let name = &constant.ident;
+                if name == "NAME" {
+                    has_name = true;
                 }
             }
             _ => {}
@@ -86,6 +93,16 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
         Some(quote!(type Instance = #crate_ident::subclass::basic::InstanceStruct<Self>;))
     };
 
+    let name_opt = if has_name {
+        None
+    } else {
+        base_type_name(&*input.self_ty).map(|name| {
+            quote!(
+                const NAME: &'static str = concat!(module_path!(), "_", stringify!(#name));
+            )
+        })
+    };
+
     let trait_path = match &trait_ {
         Some(path) => &path.1,
         None => abort_call_site!(WRONG_PLACE_MSG),
@@ -98,6 +115,7 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
             #interfaces_opt
             #class_opt
             #instance_opt
+            #name_opt
             #new_opt
             #(#items)*
         }
@@ -140,5 +158,12 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
                 <Self as #crate_ident::subclass::types::ObjectSubclassExt>::from_instance(obj)
             }
         }
+    }
+}
+
+fn base_type_name(ty: &syn::Type) -> Option<&syn::Ident> {
+    match ty {
+        syn::Type::Path(type_path) => type_path.path.segments.last().map(|seg| &seg.ident),
+        _ => None,
     }
 }

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -280,6 +280,59 @@ fn subclassable() {
 }
 
 #[test]
+fn subclass_derives_name() {
+    mod foo {
+        use glib::subclass::prelude::*;
+
+        mod imp {
+            use super::*;
+
+            #[derive(Default)]
+            pub struct Foo {}
+
+            #[glib::object_subclass]
+            impl ObjectSubclass for Foo {
+                type Type = super::Foo;
+            }
+
+            impl ObjectImpl for Foo {}
+        }
+
+        glib::wrapper! {
+            pub struct Foo(ObjectSubclass<imp::Foo>);
+        }
+    }
+
+    mod bar {
+        use glib::subclass::prelude::*;
+
+        mod imp {
+            use super::*;
+
+            #[derive(Default)]
+            pub struct Bar {}
+
+            #[glib::object_subclass]
+            impl ObjectSubclass for super::imp::Bar {
+                type Type = super::Bar;
+            }
+
+            impl ObjectImpl for Bar {}
+        }
+
+        glib::wrapper! {
+            pub struct Bar(ObjectSubclass<imp::Bar>);
+        }
+    }
+
+    let foo_obj: foo::Foo = glib::Object::new(&[]).unwrap();
+    assert_eq!(foo_obj.type_().name(), "test__foo__imp_Foo");
+
+    let bar_obj: bar::Bar = glib::Object::new(&[]).unwrap();
+    assert_eq!(bar_obj.type_().name(), "test__bar__imp_Bar");
+}
+
+#[test]
 fn derive_variant() {
     #[derive(Debug, PartialEq, Eq, glib::Variant)]
     struct Variant1 {

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -889,7 +889,18 @@ pub fn register_type<T: ObjectSubclass>() -> Type {
     unsafe {
         use std::ffi::CString;
 
-        let type_name = CString::new(T::NAME).unwrap();
+        let type_name: CString = CString::from_vec_unchecked(
+            T::NAME
+                .chars()
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() {
+                        c as u8
+                    } else {
+                        b'_'
+                    }
+                })
+                .collect(),
+        );
         assert_eq!(
             gobject_ffi::g_type_from_name(type_name.as_ptr()),
             gobject_ffi::G_TYPE_INVALID,


### PR DESCRIPTION
Derive boilerplate `const NAME: &'static str = ...;` in `glib::object_subclass` proc macro.