### PR TITLE
glib: Provide `ThreadGuard` and `thread_id()` as public API

### DIFF
--- a/glib/src/closure.rs
+++ b/glib/src/closure.rs
@@ -198,7 +198,7 @@ impl Closure {
     /// Invoking the closure from a different thread than this one will panic.
     #[doc(alias = "g_closure_new")]
     pub fn new_local<F: Fn(&[Value]) -> Option<Value> + 'static>(callback: F) -> Self {
-        let callback = crate::ThreadGuard::new(callback);
+        let callback = crate::thread_guard::ThreadGuard::new(callback);
 
         unsafe { Self::new_unsafe(move |values| (callback.get_ref())(values)) }
     }

--- a/glib/src/main_context_channel.rs
+++ b/glib/src/main_context_channel.rs
@@ -1,12 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::thread_guard::ThreadGuard;
 use crate::translate::*;
 use crate::Continue;
 use crate::MainContext;
 use crate::Priority;
 use crate::Source;
 use crate::SourceId;
-use crate::ThreadGuard;
 use std::collections::VecDeque;
 use std::fmt;
 use std::mem;

--- a/glib/src/main_context_futures.rs
+++ b/glib/src/main_context_futures.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::thread_guard::ThreadGuard;
 use crate::translate::*;
-use crate::ThreadGuard;
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -25,7 +25,7 @@ use crate::Type;
 use crate::Value;
 use crate::{Closure, RustClosure};
 
-use crate::thread_id;
+use crate::thread_guard::thread_id;
 
 #[doc(hidden)]
 pub use gobject_ffi::GObject;
@@ -2505,7 +2505,7 @@ impl<T: ObjectType> ObjectExt for T {
     where
         F: Fn(&[Value]) -> Option<Value> + 'static,
     {
-        let callback = crate::ThreadGuard::new(callback);
+        let callback = crate::thread_guard::ThreadGuard::new(callback);
 
         unsafe {
             self.try_connect_unsafe(signal_name, after, move |values| {
@@ -2532,7 +2532,7 @@ impl<T: ObjectType> ObjectExt for T {
     where
         F: Fn(&[Value]) -> Option<Value> + 'static,
     {
-        let callback = crate::ThreadGuard::new(callback);
+        let callback = crate::thread_guard::ThreadGuard::new(callback);
 
         unsafe {
             self.try_connect_unsafe_id(signal_id, details, after, move |values| {
@@ -3071,7 +3071,7 @@ impl<T: ObjectType> ObjectExt for T {
         name: Option<&str>,
         f: F,
     ) -> SignalHandlerId {
-        let f = crate::ThreadGuard::new(f);
+        let f = crate::thread_guard::ThreadGuard::new(f);
 
         unsafe {
             self.connect_notify_unsafe(name, move |s, pspec| {

--- a/glib/src/send_unique.rs
+++ b/glib/src/send_unique.rs
@@ -73,7 +73,7 @@ impl<T: SendUnique> SendUniqueCell<T> {
         // how often we borrowed it
         if self.obj.is_unique() {
             if *thread == None {
-                *thread = Some((crate::thread_id(), 1));
+                *thread = Some((crate::thread_guard::thread_id(), 1));
             } else {
                 thread.as_mut().unwrap().1 += 1;
             }
@@ -89,7 +89,7 @@ impl<T: SendUnique> SendUniqueCell<T> {
 
         // If the object is not unique, we can only borrow it
         // from the thread that currently has it borrowed
-        if thread.as_ref().unwrap().0 != crate::thread_id() {
+        if thread.as_ref().unwrap().0 != crate::thread_guard::thread_id() {
             return Err(BorrowError);
         }
 

--- a/glib/src/source.rs
+++ b/glib/src/source.rs
@@ -13,9 +13,9 @@ use std::num::NonZeroU32;
 use std::os::unix::io::RawFd;
 use std::time::Duration;
 
+use crate::thread_guard::ThreadGuard;
 use crate::MainContext;
 use crate::Source;
-use crate::ThreadGuard;
 
 // rustdoc-stripper-ignore-next
 /// The id of a source that is returned by `idle_add` and `timeout_add`.

--- a/glib/src/thread_guard.rs
+++ b/glib/src/thread_guard.rs
@@ -1,0 +1,105 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+fn next_thread_id() -> usize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+// rustdoc-stripper-ignore-next
+/// Returns a unique ID for the current thread.
+///
+/// Actual thread IDs can be reused by the OS once the old thread finished.
+/// This works around ambiguity created by ID reuse by using a separate TLS counter for threads.
+pub fn thread_id() -> usize {
+    thread_local!(static THREAD_ID: usize = next_thread_id());
+    THREAD_ID.with(|&x| x)
+}
+
+// rustdoc-stripper-ignore-next
+/// Thread guard that only gives access to the contained value on the thread it was created on.
+pub struct ThreadGuard<T> {
+    thread_id: usize,
+    value: Option<T>,
+}
+
+impl<T> ThreadGuard<T> {
+    // rustdoc-stripper-ignore-next
+    /// Create a new thread guard around `value`.
+    ///
+    /// The thread guard ensures that access to the value is only allowed from the thread it was
+    /// created on, and otherwise panics.
+    ///
+    /// The thread guard implements the `Send` trait even if the contained value does not.
+    pub fn new(value: T) -> Self {
+        Self {
+            thread_id: thread_id(),
+            value: Some(value),
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Return a reference to the contained value from the thread guard.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called from a different thread than where the thread guard was
+    /// created.
+    pub fn get_ref(&self) -> &T {
+        assert!(
+            self.thread_id == thread_id(),
+            "Value accessed from different thread than where it was created"
+        );
+
+        self.value.as_ref().unwrap()
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Return a mutable reference to the contained value from the thread guard.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called from a different thread than where the thread guard was
+    /// created.
+    pub fn get_mut(&mut self) -> &mut T {
+        assert!(
+            self.thread_id == thread_id(),
+            "Value accessed from different thread than where it was created"
+        );
+
+        self.value.as_mut().unwrap()
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Return the contained value from the thread guard.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called from a different thread than where the thread guard was
+    /// created.
+    pub fn into_inner(mut self) -> T {
+        assert!(
+            self.thread_id == thread_id(),
+            "Value accessed from different thread than where it was created"
+        );
+
+        self.value.take().expect("into_inner() called twice")
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Returns `true` if the current thread owns the value, i.e. it can be accessed safely.
+    pub fn is_owner(&self) -> bool {
+        self.thread_id == thread_id()
+    }
+}
+
+impl<T> Drop for ThreadGuard<T> {
+    fn drop(&mut self) {
+        assert!(
+            self.thread_id == thread_id(),
+            "Value dropped on a different thread than where it was created"
+        );
+    }
+}
+
+unsafe impl<T> Send for ThreadGuard<T> {}


### PR DESCRIPTION
This is a preparation for https://github.com/gtk-rs/gir/issues/1305