### PR TITLE
add param_spec_builder macro

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -9,6 +9,7 @@ mod error_domain_derive;
 mod flags_attribute;
 mod object_interface_attribute;
 mod object_subclass_attribute;
+mod param_spec_builder;
 mod shared_boxed_derive;
 mod variant_derive;
 
@@ -733,4 +734,27 @@ pub fn downgrade(input: TokenStream) -> TokenStream {
 pub fn variant_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     variant_derive::impl_variant(input)
+}
+
+/// # Example
+/// Geneterates a builder with default `nick` and `blurb`
+/// ```ignore
+/// #[param_spec_builder(nick = self.name, blurb = self.name)]
+/// impl ParamSpecInt {
+///      fn new(name: &str, nick: &str, blurb: &str, minimum: i8) -> ParamSpec {...};
+/// }
+/// ```
+///
+/// Usable as
+/// ```ignore
+/// ParamSpecInt::builder()
+///   .name("name")
+///   .nick("nick").
+///   .blurb("blurb")
+///   .minimum(0i8)
+///   .build()
+/// ```
+#[proc_macro_attribute]
+pub fn param_spec_builder(args: TokenStream, input: TokenStream) -> TokenStream {
+    param_spec_builder::impl_builder(args, input)
 }

--- a/glib-macros/src/param_spec_builder.rs
+++ b/glib-macros/src/param_spec_builder.rs
@@ -1,3 +1,5 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;

--- a/glib-macros/src/param_spec_builder.rs
+++ b/glib-macros/src/param_spec_builder.rs
@@ -1,0 +1,134 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use std::borrow::Cow;
+use syn::parse::{Parse, Parser};
+use syn::punctuated::Punctuated;
+use syn::{parse_macro_input, Token};
+
+struct Attr {
+    name: syn::Ident,
+    _eq: Token![=],
+    expr: syn::Expr,
+}
+impl Parse for Attr {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            name: input.parse()?,
+            _eq: input.parse()?,
+            expr: input.parse()?,
+        })
+    }
+}
+
+fn adjusted_lifetime<'a>(symbol: &str, ty: &'a syn::Type) -> Cow<'a, syn::Type> {
+    match ty {
+        syn::Type::Reference(r) => {
+            let mut r = r.to_owned();
+            r.lifetime = Some(syn::Lifetime::new(symbol, Span::call_site()));
+            Cow::Owned(syn::Type::Reference(r))
+        }
+        syn::Type::Path(p) => (match &p.path.segments.last().unwrap().arguments {
+            syn::PathArguments::AngleBracketed(bracketed) => {
+                let generic_arg = bracketed.args.first().unwrap();
+                match generic_arg {
+                    syn::GenericArgument::Type(ty) => adjusted_lifetime(symbol, ty),
+                    _ => panic!("Can't parse this generic argument"),
+                }
+            }
+            _ => Cow::Borrowed(ty),
+        }),
+        _ => Cow::Borrowed(ty),
+    }
+}
+pub fn impl_builder(args: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::ItemImpl);
+    let new_fn = input
+        .items
+        .iter()
+        .find_map(|x| match x {
+            syn::ImplItem::Method(m) if m.sig.ident == "new" => Some(m),
+            _ => None,
+        })
+        .expect("Missing function 'new'");
+    let target_ident = match &*input.self_ty {
+        syn::Type::Path(p) => p
+            .path
+            .get_ident()
+            .expect("param_spec_builder can only be applied to an `impl Ident`"),
+        _ => panic!("Missign target type of impl block"),
+    };
+    let builder_ident = syn::Ident::new(&format!("{}Builder", target_ident), Span::call_site());
+
+    let args_parser = Punctuated::<Attr, Token![,]>::parse_terminated;
+    let default_vals = args_parser.parse(args).unwrap();
+
+    let params: Vec<_> = new_fn
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|input| match input {
+            syn::FnArg::Typed(arg) => {
+                let ident = match &*arg.pat {
+                    syn::Pat::Ident(ident) => Some(ident),
+                    _ => None,
+                };
+                ident.map(|id| (id, &arg.ty))
+            }
+            _ => None,
+        })
+        .map(|(id, ty)| {
+            let default_val = default_vals.iter().find_map(|attr| {
+                if attr.name == id.ident {
+                    Some(&attr.expr)
+                } else {
+                    None
+                }
+            });
+            (id, ty, default_val)
+        })
+        .collect();
+
+    let builder_struct_fields = params.iter().map(|(ident, ty, _)| {
+        let ty = adjusted_lifetime("'a", &ty);
+        quote!(#ident: Option<#ty>)
+    });
+    let builder_setters = params.iter().map(|(ident, ty, _)| {
+        let ty = adjusted_lifetime("'a", &ty);
+        quote!(pub fn #ident(mut self, value: #ty) -> Self {
+            self.#ident = Some(value);
+            self
+        })
+    });
+    let spec_new_call_params = params.iter().map(|(ident, _, default_val)| {
+        let missing_err = format!("Missing parameter {}", ident.ident);
+        let default_val_quote = default_val.map(|v| quote!(.or_else(|| #v.into())));
+        quote!(
+            (self.#ident
+                #default_val_quote)
+                .expect(#missing_err)
+                .into()
+        )
+    });
+
+    quote!(
+        #input
+
+        #[derive(Default)]
+        pub struct #builder_ident<'a> {
+            #(#builder_struct_fields,)*
+        }
+        impl<'a> #builder_ident<'a> {
+            pub fn new() -> Self {
+                Self::default()
+            }
+
+            #(#builder_setters)*
+
+            pub fn build(self) -> glib::ParamSpec {
+                #target_ident::new(#(#spec_new_call_params,)*)
+            }
+        }
+    )
+    .into()
+}

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -12,6 +12,7 @@ use crate::{
     Object,
 };
 
+use glib_macros::param_spec_builder;
 use std::char::CharTryFromError;
 use std::convert::TryFrom;
 use std::ffi::CStr;
@@ -393,6 +394,15 @@ define_param_spec_numeric!(
     |x| x
 );
 
+use crate as glib;
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = i8::MIN,
+  maximum = i8::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecChar {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_char")]
@@ -433,6 +443,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = u8::MIN,
+  maximum = u8::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecUChar {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_uchar")]
@@ -473,6 +491,12 @@ define_param_spec!(
 
 define_param_spec_default!(ParamSpecBoolean, bool, |x| from_glib(x));
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  default_value = false,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecBoolean {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_boolean")]
@@ -509,6 +533,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = i32::MIN,
+  maximum = i32::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecInt {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_int")]
@@ -549,6 +581,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = u32::MIN,
+  maximum = u32::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecUInt {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_uint")]
@@ -589,6 +629,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = libc::c_long::MIN,
+  maximum = libc::c_long::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecLong {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_long")]
@@ -629,6 +677,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = libc::c_ulong::MIN,
+  maximum = libc::c_ulong::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecULong {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_ulong")]
@@ -669,6 +725,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = i64::MIN,
+  maximum = i64::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecInt64 {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_int64")]
@@ -709,6 +773,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = u64::MIN,
+  maximum = u64::MAX,
+  default_value = 0,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecUInt64 {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_uint64")]
@@ -749,6 +821,11 @@ define_param_spec!(
 
 define_param_spec_default!(ParamSpecUnichar, Result<char, CharTryFromError>, TryFrom::try_from);
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecUnichar {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_unichar")]
@@ -785,6 +862,11 @@ define_param_spec!(
 
 define_param_spec_default!(ParamSpecEnum, i32, |x| x);
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecEnum {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_enum")]
@@ -835,6 +917,11 @@ define_param_spec!(
 
 define_param_spec_default!(ParamSpecFlags, u32, |x| x);
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecFlags {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_flags")]
@@ -885,6 +972,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = f32::MIN,
+  maximum = f32::MAX,
+  default_value = 0f32,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecFloat {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_float")]
@@ -925,6 +1020,14 @@ define_param_spec_numeric!(
     |x| x
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  minimum = f64::MIN,
+  maximum = f64::MAX,
+  default_value = 0f64,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecDouble {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_double")]
@@ -973,6 +1076,12 @@ define_param_spec_default!(ParamSpecString, Option<&str>, |x: *mut libc::c_char|
     }
 });
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  default_value = "",
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecString {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_string")]
@@ -1008,6 +1117,11 @@ define_param_spec!(
     15
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecParam {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_param")]
@@ -1042,6 +1156,11 @@ define_param_spec!(
     16
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecBoxed {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_boxed")]
@@ -1076,6 +1195,11 @@ define_param_spec!(
     17
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecPointer {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_pointer")]
@@ -1103,6 +1227,11 @@ define_param_spec!(
     18
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecValueArray {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_value_array")]
@@ -1155,6 +1284,11 @@ define_param_spec!(
     19
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecObject {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_object")]
@@ -1189,6 +1323,9 @@ define_param_spec!(
     20
 );
 
+#[param_spec_builder(
+  nick = self.name,
+)]
 impl ParamSpecOverride {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_override")]
@@ -1288,6 +1425,11 @@ define_param_spec!(
     21
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecGType {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_gtype")]
@@ -1328,6 +1470,12 @@ define_param_spec_default!(
     |x: *mut ffi::GVariant| from_glib_none(x)
 );
 
+#[param_spec_builder(
+  nick = self.name,
+  blurb = self.name,
+  default_value = None,
+  flags = glib::ParamFlags::READWRITE,
+)]
 impl ParamSpecVariant {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_variant")]

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -1323,9 +1323,6 @@ define_param_spec!(
     20
 );
 
-#[param_spec_builder(
-  nick = self.name,
-)]
 impl ParamSpecOverride {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_override")]

--- a/glib/tests/param_spec.rs
+++ b/glib/tests/param_spec.rs
@@ -1,0 +1,7 @@
+#[test]
+fn generated_builder() {
+    let spec = glib::ParamSpecCharBuilder::new()
+        .name("custom-char")
+        .build();
+    assert_eq!(spec.nick(), "custom-char");
+}

--- a/glib/tests/param_spec.rs
+++ b/glib/tests/param_spec.rs
@@ -1,7 +1,11 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
 #[test]
 fn generated_builder() {
     let spec = glib::ParamSpecCharBuilder::new()
         .name("custom-char")
+        .flags(glib::ParamFlags::READABLE)
         .build();
     assert_eq!(spec.nick(), "custom-char");
+    assert_eq!(spec.flags(), glib::ParamFlags::READABLE);
 }


### PR DESCRIPTION
## Motivation
Creating a `Builder` for `ParamSpec*` makes implementing #494 drastically easier.
Also, users will finally be able to create a `ParamSpec*` with some default options, without having to specify `min`, `max` et all...

## About the macro
This PR adds a really powerful macro, capable of generating a Builder from any `impl` block containing a `new` function.

The macro looks for the `new` function, reads the function's parameters and creates a corresponding `Builder` struct containing each of the parameters.

The macro is currently built for `ParamSpec*` but in the future this could be used to make `Builder`s for other types: for example, this should also work for `glib::SimpleAction`.
With enough generalization I could pull this in a new crate. But this is not a priority of mine.

