### PR TITLE
gio: add Initable::with_type

### DIFF
--- a/gio/src/initable.rs
+++ b/gio/src/initable.rs
@@ -6,9 +6,14 @@ use crate::Initable;
 use glib::object::IsA;
 use glib::object::IsClass;
 use glib::value::ToValue;
-use glib::Object;
+use glib::{Cast, Object, StaticType, Type};
 
 impl Initable {
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an initable object with the given properties.
+    ///
+    /// Similar to [`Object::new`] but can fail either because the object
+    /// creation failed or because `Initable::init` failed.
     #[allow(clippy::new_ret_no_self)]
     pub fn new<O: Sized + IsClass + IsA<Object> + IsA<Initable>, P: IsA<Cancellable>>(
         properties: &[(&str, &dyn ToValue)],
@@ -16,6 +21,27 @@ impl Initable {
     ) -> Result<O, InitableError> {
         let object = Object::new::<O>(properties)?;
         unsafe { object.init(cancellable)? };
+        Ok(object)
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an initable object of the given type with the given properties.
+    ///
+    /// Similar to [`Object::with_type`] but can fail either because the object
+    /// creation failed or because `Initable::init` failed.
+    pub fn with_type(
+        type_: Type,
+        properties: &[(&str, &dyn ToValue)],
+        cancellable: Option<&impl IsA<Cancellable>>,
+    ) -> Result<Object, InitableError> {
+        if !type_.is_a(Initable::static_type()) {
+            return Err(InitableError::NewObjectFailed(glib::bool_error!(
+                "Type '{}' is not initable",
+                type_
+            )));
+        }
+        let object = Object::with_type(type_, properties)?;
+        unsafe { object.unsafe_cast_ref::<Self>().init(cancellable)? };
         Ok(object)
     }
 }

--- a/gio/src/subclass/initable.rs
+++ b/gio/src/subclass/initable.rs
@@ -196,6 +196,19 @@ mod tests {
     }
 
     #[test]
+    fn test_initable_with_initable_with_type() {
+        let test = Initable::with_type(
+            InitableTestType::static_type(),
+            &[],
+            Option::<&Cancellable>::None,
+        )
+        .expect("Failed creation/initialization of InitableTestType object from type")
+        .downcast::<InitableTestType>()
+        .expect("Failed downcast of InitableTestType object");
+        assert_eq!(0x123456789abcdef, test.value());
+    }
+
+    #[test]
     fn test_initable_through_ffi() {
         unsafe {
             let test = InitableTestType::new_uninit();


### PR DESCRIPTION
This corresponds to Object::with_type and it is needed when
the type is available only at runtime.