### PR TITLE
#[doc(html_root_url)]

### DIFF
--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::wrong_self_convention)]
 #![allow(clippy::non_send_fields_in_send_ty)]
+#![doc(html_root_url = "https://gtk-rs.org/gtk-rs-core/git/docs/")]
 #![doc = include_str!("../README.md")]
 
 pub use ffi;

--- a/gdk-pixbuf/src/lib.rs
+++ b/gdk-pixbuf/src/lib.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
+#![doc(html_root_url = "https://gtk-rs.org/gtk-rs-core/git/docs/")]
 #![doc = include_str!("../README.md")]
 
 pub use ffi;

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::non_send_fields_in_send_ty)]
+#![doc(html_root_url = "https://gtk-rs.org/gtk-rs-core/git/docs/")]
 #![doc = include_str!("../README.md")]
 
 pub use ffi;

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::wrong_self_convention)]
 #![allow(clippy::non_send_fields_in_send_ty)]
+#![doc(html_root_url = "https://gtk-rs.org/gtk-rs-core/git/docs/")]
 #![doc = include_str!("../README.md")]
 
 pub use ffi;

--- a/graphene/src/lib.rs
+++ b/graphene/src/lib.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
+#![doc(html_root_url = "https://gtk-rs.org/gtk-rs-core/git/docs/")]
 #![doc = include_str!("../README.md")]
 
 pub use ffi;

--- a/pango/src/lib.rs
+++ b/pango/src/lib.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
+#![doc(html_root_url = "https://gtk-rs.org/gtk-rs-core/git/docs/")]
 #![doc = include_str!("../README.md")]
 #![allow(clippy::missing_safety_doc)]
 

--- a/pangocairo/src/lib.rs
+++ b/pangocairo/src/lib.rs
@@ -1,6 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 #![cfg_attr(feature = "dox", feature(doc_cfg))]
+#![doc(html_root_url = "https://gtk-rs.org/gtk-rs-core/git/docs/")]
 #![doc = include_str!("../README.md")]
 
 pub use cairo;


### PR DESCRIPTION
This can fix up `cargo doc --no-deps` URLs, which is nice for anyone hosting their own crate's docs online in the same way glib does - particularly if it targets the development git branch.

There are a few things to address here:

- If this is merged, there should be an associated/backported PR targeting stable `0.15` branch with a different URL root (`https://gtk-rs.org/gtk-rs-core/stable/0.xx/docs/`)
- Whenever a release is made, these URLs would need to be updated after branching off but before tagging a release.
    - I believe it's common practice to add a reminder comment to `Cargo.toml` as a prompt for anyone manually updating the version number when a major release occurs
    - Another approach might be to encode the requirement directly into CI using something like [version-sync](https://crates.io/crates/version-sync)
    - I'm not sure if this is the current deployment practice or if master is tagged directly before branching off instead?
- I'd like to also include the same change to the `sys` crates, but since they're auto-generated by `gir` I'm not entirely sure how to approach that? I've had this problem with gir before, and am not sure if it provides any ability to customize the `sys/lib.rs` generation?