### PR TITLE
impl `StaticType` and `{From,To}Value` for `gpointer`

### DIFF
--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -36,7 +36,7 @@ pub use self::signal::{
 };
 
 pub use self::enums::{EnumClass, EnumValue, FlagsBuilder, FlagsClass, FlagsValue, UserDirectory};
-pub use self::types::{ILong, StaticType, Type, ULong};
+pub use self::types::{ILong, Pointer, StaticType, Type, ULong};
 pub use self::value::{BoxedValue, SendValue, ToSendValue, ToValue, Value};
 pub use self::variant::{
     FixedSizeVariantArray, FixedSizeVariantType, FromVariant, StaticVariantType, ToVariant, Variant,

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -1268,6 +1268,21 @@ impl TryFromGlib<ffi::gpointer> for ptr::NonNull<Pointee> {
     }
 }
 
+impl FromGlib<ffi::gconstpointer> for Pointer {
+    #[inline]
+    unsafe fn from_glib(val: ffi::gconstpointer) -> Self {
+        val as ffi::gpointer
+    }
+}
+
+impl TryFromGlib<ffi::gconstpointer> for ptr::NonNull<Pointee> {
+    type Error = GlibNoneError;
+
+    unsafe fn try_from_glib(val: ffi::gconstpointer) -> Result<Self, Self::Error> {
+        ptr::NonNull::new(val as ffi::gpointer).ok_or(GlibNoneError)
+    }
+}
+
 impl FromGlib<ptr::NonNull<Pointee>> for Pointer {
     #[inline]
     unsafe fn from_glib(val: ptr::NonNull<Pointee>) -> Self {

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -2396,6 +2396,7 @@ mod tests {
     use super::*;
     use crate::GString;
     use std::collections::HashMap;
+    use std::ptr::NonNull;
 
     #[test]
     fn boolean() {
@@ -2404,6 +2405,21 @@ mod tests {
         assert!(unsafe { bool::from_glib(ffi::GTRUE) });
         assert!(!unsafe { bool::from_glib(ffi::GFALSE) });
         assert!(unsafe { bool::from_glib(42) });
+    }
+
+    #[test]
+    fn pointer() {
+        let null: Pointer = ptr::null_mut::<Pointee>();
+        let nonnull: Pointer = NonNull::dangling().as_ptr();
+
+        assert_eq!(null.into_glib(), None::<ptr::NonNull<Pointee>>.into_glib());
+        assert_eq!(
+            nonnull.into_glib(),
+            Some(NonNull::<Pointee>::dangling()).into_glib()
+        );
+
+        assert!(unsafe { Option::<NonNull<Pointee>>::from_glib(null).is_none() });
+        assert!(unsafe { Option::<NonNull<Pointee>>::from_glib(nonnull).is_some() });
     }
 
     #[test]

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -130,6 +130,8 @@
 //!     }
 //! ```
 
+use crate::types::{Pointee, Pointer};
+
 use libc::{c_char, size_t};
 use std::char;
 use std::cmp::{Eq, Ordering, PartialEq};
@@ -351,7 +353,7 @@ impl IntoGlib for Option<char> {
     }
 }
 
-impl IntoGlib for crate::Pointer {
+impl IntoGlib for Pointer {
     type GlibType = ffi::gpointer;
 
     #[inline]
@@ -360,7 +362,7 @@ impl IntoGlib for crate::Pointer {
     }
 }
 
-impl IntoGlib for ptr::NonNull<libc::c_void> {
+impl IntoGlib for ptr::NonNull<Pointee> {
     type GlibType = ffi::gpointer;
 
     #[inline]
@@ -369,7 +371,7 @@ impl IntoGlib for ptr::NonNull<libc::c_void> {
     }
 }
 
-impl OptionIntoGlib for ptr::NonNull<libc::c_void> {
+impl OptionIntoGlib for ptr::NonNull<Pointee> {
     const GLIB_NONE: Self::GlibType = ptr::null_mut();
 }
 
@@ -1251,14 +1253,14 @@ impl FromGlib<ffi::gboolean> for bool {
     }
 }
 
-impl FromGlib<ffi::gpointer> for crate::Pointer {
+impl FromGlib<ffi::gpointer> for Pointer {
     #[inline]
     unsafe fn from_glib(val: ffi::gpointer) -> Self {
         val
     }
 }
 
-impl TryFromGlib<ffi::gpointer> for ptr::NonNull<libc::c_void> {
+impl TryFromGlib<ffi::gpointer> for ptr::NonNull<Pointee> {
     type Error = GlibNoneError;
 
     unsafe fn try_from_glib(val: ffi::gpointer) -> Result<Self, Self::Error> {
@@ -1266,16 +1268,16 @@ impl TryFromGlib<ffi::gpointer> for ptr::NonNull<libc::c_void> {
     }
 }
 
-impl FromGlib<ptr::NonNull<libc::c_void>> for crate::Pointer {
+impl FromGlib<ptr::NonNull<Pointee>> for Pointer {
     #[inline]
-    unsafe fn from_glib(val: ptr::NonNull<libc::c_void>) -> Self {
+    unsafe fn from_glib(val: ptr::NonNull<Pointee>) -> Self {
         val.as_ptr()
     }
 }
 
-impl FromGlib<Option<ptr::NonNull<libc::c_void>>> for crate::Pointer {
+impl FromGlib<Option<ptr::NonNull<Pointee>>> for Pointer {
     #[inline]
-    unsafe fn from_glib(val: Option<ptr::NonNull<libc::c_void>>) -> Self {
+    unsafe fn from_glib(val: Option<ptr::NonNull<Pointee>>) -> Self {
         val.map(|p| p.as_ptr()).unwrap_or(ptr::null_mut())
     }
 }

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -351,6 +351,28 @@ impl IntoGlib for Option<char> {
     }
 }
 
+impl IntoGlib for crate::Pointer {
+    type GlibType = ffi::gpointer;
+
+    #[inline]
+    fn into_glib(self) -> Self::GlibType {
+        self
+    }
+}
+
+impl IntoGlib for ptr::NonNull<libc::c_void> {
+    type GlibType = ffi::gpointer;
+
+    #[inline]
+    fn into_glib(self) -> Self::GlibType {
+        self.as_ptr()
+    }
+}
+
+impl OptionIntoGlib for ptr::NonNull<libc::c_void> {
+    const GLIB_NONE: Self::GlibType = ptr::null_mut();
+}
+
 impl IntoGlib for Ordering {
     type GlibType = i32;
 
@@ -1226,6 +1248,35 @@ impl FromGlib<ffi::gboolean> for bool {
     #[inline]
     unsafe fn from_glib(val: ffi::gboolean) -> Self {
         val != ffi::GFALSE
+    }
+}
+
+impl FromGlib<ffi::gpointer> for crate::Pointer {
+    #[inline]
+    unsafe fn from_glib(val: ffi::gpointer) -> Self {
+        val
+    }
+}
+
+impl TryFromGlib<ffi::gpointer> for ptr::NonNull<libc::c_void> {
+    type Error = GlibNoneError;
+
+    unsafe fn try_from_glib(val: ffi::gpointer) -> Result<Self, Self::Error> {
+        ptr::NonNull::new(val).ok_or(GlibNoneError)
+    }
+}
+
+impl FromGlib<ptr::NonNull<libc::c_void>> for crate::Pointer {
+    #[inline]
+    unsafe fn from_glib(val: ptr::NonNull<libc::c_void>) -> Self {
+        val.as_ptr()
+    }
+}
+
+impl FromGlib<Option<ptr::NonNull<libc::c_void>>> for crate::Pointer {
+    #[inline]
+    unsafe fn from_glib(val: Option<ptr::NonNull<libc::c_void>>) -> Self {
+        val.map(|p| p.as_ptr()).unwrap_or(ptr::null_mut())
     }
 }
 

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -299,9 +299,26 @@ macro_rules! builtin {
 
 // rustdoc-stripper-ignore-next
 /// A GLib [pointer](ffi::gpointer)
-pub type Pointer = ffi::gpointer;
+pub type Pointer = *mut Pointee;
 
-impl StaticType for ptr::NonNull<libc::c_void> {
+// rustdoc-stripper-ignore-next
+/// The target of a [Pointer]
+///
+/// # Examples
+///
+/// ```
+/// use glib::prelude::*;
+/// use glib::types::{Pointee, Pointer};
+/// use std::ptr::NonNull;
+///
+/// let pointer = NonNull::<Pointee>::dangling();
+/// let value = pointer.to_value();
+/// assert!(value.is::<Pointer>());
+/// assert_eq!(value.get(), Ok(pointer.as_ptr()));
+/// ```
+pub type Pointee = libc::c_void;
+
+impl StaticType for ptr::NonNull<Pointee> {
     fn static_type() -> Type {
         Pointer::static_type()
     }

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -297,6 +297,16 @@ macro_rules! builtin {
     };
 }
 
+// rustdoc-stripper-ignore-next
+/// A GLib [pointer](ffi::gpointer)
+pub type Pointer = ffi::gpointer;
+
+impl StaticType for ptr::NonNull<libc::c_void> {
+    fn static_type() -> Type {
+        Pointer::static_type()
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ILong(pub libc::c_long);
 
@@ -416,6 +426,7 @@ builtin!(f32, F32);
 builtin!(f64, F64);
 builtin!(str, STRING);
 builtin!(String, STRING);
+builtin!(Pointer, POINTER);
 
 impl<'a> StaticType for [&'a str] {
     fn static_type() -> Type {

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -298,8 +298,10 @@ macro_rules! builtin {
 }
 
 // rustdoc-stripper-ignore-next
-/// A GLib [pointer](ffi::gpointer)
-pub type Pointer = *mut Pointee;
+/// A GLib pointer
+///
+/// A raw untyped pointer equivalent to [`*mut Pointee`](Pointee).
+pub type Pointer = ffi::gpointer;
 
 // rustdoc-stripper-ignore-next
 /// The target of a [Pointer]

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -838,7 +838,7 @@ unsafe impl<'a> FromValue<'a> for Pointer {
     type Checker = GenericValueTypeChecker<Self>;
 
     unsafe fn from_value(value: &'a Value) -> Self {
-        from_glib(gobject_ffi::g_value_get_pointer(value.to_glib_none().0))
+        gobject_ffi::g_value_get_pointer(value.to_glib_none().0)
     }
 }
 
@@ -846,7 +846,7 @@ impl ToValue for Pointer {
     fn to_value(&self) -> Value {
         let mut value = Value::for_value_type::<Self>();
         unsafe {
-            gobject_ffi::g_value_set_pointer(&mut value.inner, self.into_glib());
+            gobject_ffi::g_value_set_pointer(&mut value.inner, *self);
         }
         value
     }
@@ -880,7 +880,7 @@ impl ToValue for ptr::NonNull<Pointee> {
 
 impl ToValueOptional for ptr::NonNull<Pointee> {
     fn to_value_optional(p: Option<&Self>) -> Value {
-        unsafe { Pointer::from_glib(p.copied()).to_value() }
+        p.map(|p| p.as_ptr()).unwrap_or(ptr::null_mut()).to_value()
     }
 }
 

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -51,7 +51,7 @@ use std::ptr;
 
 use crate::gstring::GString;
 use crate::translate::*;
-use crate::types::{Pointer, StaticType, Type};
+use crate::types::{Pointee, Pointer, StaticType, Type};
 
 // rustdoc-stripper-ignore-next
 /// A type that can be stored in `Value`s.
@@ -856,11 +856,11 @@ impl ToValue for Pointer {
     }
 }
 
-impl ValueType for ptr::NonNull<libc::c_void> {
+impl ValueType for ptr::NonNull<Pointee> {
     type Type = Pointer;
 }
 
-unsafe impl<'a> FromValue<'a> for ptr::NonNull<libc::c_void> {
+unsafe impl<'a> FromValue<'a> for ptr::NonNull<Pointee> {
     type Checker = GenericValueTypeOrNoneChecker<Self>;
 
     unsafe fn from_value(value: &'a Value) -> Self {
@@ -868,7 +868,7 @@ unsafe impl<'a> FromValue<'a> for ptr::NonNull<libc::c_void> {
     }
 }
 
-impl ToValue for ptr::NonNull<libc::c_void> {
+impl ToValue for ptr::NonNull<Pointee> {
     fn to_value(&self) -> Value {
         self.as_ptr().to_value()
     }
@@ -878,7 +878,7 @@ impl ToValue for ptr::NonNull<libc::c_void> {
     }
 }
 
-impl ToValueOptional for ptr::NonNull<libc::c_void> {
+impl ToValueOptional for ptr::NonNull<Pointee> {
     fn to_value_optional(p: Option<&Self>) -> Value {
         unsafe { Pointer::from_glib(p.copied()).to_value() }
     }

--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -51,7 +51,7 @@ use std::ptr;
 
 use crate::gstring::GString;
 use crate::translate::*;
-use crate::types::{StaticType, Type};
+use crate::types::{Pointer, StaticType, Type};
 
 // rustdoc-stripper-ignore-next
 /// A type that can be stored in `Value`s.
@@ -827,6 +827,60 @@ impl ToValue for bool {
 
     fn value_type(&self) -> Type {
         Self::static_type()
+    }
+}
+
+impl ValueType for Pointer {
+    type Type = Self;
+}
+
+unsafe impl<'a> FromValue<'a> for Pointer {
+    type Checker = GenericValueTypeChecker<Self>;
+
+    unsafe fn from_value(value: &'a Value) -> Self {
+        from_glib(gobject_ffi::g_value_get_pointer(value.to_glib_none().0))
+    }
+}
+
+impl ToValue for Pointer {
+    fn to_value(&self) -> Value {
+        let mut value = Value::for_value_type::<Self>();
+        unsafe {
+            gobject_ffi::g_value_set_pointer(&mut value.inner, self.into_glib());
+        }
+        value
+    }
+
+    fn value_type(&self) -> Type {
+        <<Self as ValueType>::Type as StaticType>::static_type()
+    }
+}
+
+impl ValueType for ptr::NonNull<libc::c_void> {
+    type Type = Pointer;
+}
+
+unsafe impl<'a> FromValue<'a> for ptr::NonNull<libc::c_void> {
+    type Checker = GenericValueTypeOrNoneChecker<Self>;
+
+    unsafe fn from_value(value: &'a Value) -> Self {
+        ptr::NonNull::new_unchecked(Pointer::from_value(value))
+    }
+}
+
+impl ToValue for ptr::NonNull<libc::c_void> {
+    fn to_value(&self) -> Value {
+        self.as_ptr().to_value()
+    }
+
+    fn value_type(&self) -> Type {
+        <<Self as ValueType>::Type as StaticType>::static_type()
+    }
+}
+
+impl ToValueOptional for ptr::NonNull<libc::c_void> {
+    fn to_value_optional(p: Option<&Self>) -> Value {
+        unsafe { Pointer::from_glib(p.copied()).to_value() }
     }
 }
 


### PR DESCRIPTION
Resolves #508, enabling the storage and retrieval of pointers from a `Value`.

Integration with `g_pointer_type_register_static` mentioned in that issue is left for [a future expansion](https://github.com/arcnmx/gtk-rs-core/commit/pointer-subclass)