### PR TITLE
dynamic type function variants for Variants and Values

### DIFF
--- a/glib/src/value.rs
+++ b/glib/src/value.rs
@@ -450,7 +450,15 @@ impl Value {
     /// or is a sub-type of `T`.
     #[inline]
     pub fn is<T: StaticType>(&self) -> bool {
-        self.type_().is_a(T::static_type())
+        self.is_type(T::static_type())
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Returns `true` if the type of the value corresponds to `type_`
+    /// or is a sub-type of `type_`.
+    #[inline]
+    pub fn is_type(&self, type_: Type) -> bool {
+        self.type_().is_a(type_)
     }
 
     // rustdoc-stripper-ignore-next
@@ -475,8 +483,15 @@ impl Value {
     /// Tries to transform the value into a value of the target type
     #[doc(alias = "g_value_transform")]
     pub fn transform<T: ValueType>(&self) -> Result<Value, crate::BoolError> {
+        self.transform_with_type(T::Type::static_type())
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Tries to transform the value into a value of the target type
+    #[doc(alias = "g_value_transform")]
+    pub fn transform_with_type(&self, type_: Type) -> Result<Value, crate::BoolError> {
         unsafe {
-            let mut dest = Value::for_value_type::<T>();
+            let mut dest = Value::from_type(type_);
             if from_glib(gobject_ffi::g_value_transform(
                 self.to_glib_none().0,
                 dest.to_glib_none_mut().0,
@@ -486,7 +501,7 @@ impl Value {
                 Err(crate::bool_error!(
                     "Can't transform value of type '{}' into '{}'",
                     self.type_(),
-                    T::Type::static_type()
+                    type_
                 ))
             }
         }

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -528,6 +528,21 @@ impl Variant {
     }
 
     // rustdoc-stripper-ignore-next
+    /// Extract the value of a maybe Variant.
+    ///
+    /// Returns the child value, or `None` if the value is Nothing.
+    ///
+    /// # Panics
+    ///
+    /// Panics if compiled with `debug_assertions` and the variant is not maybe-typed.
+    #[inline]
+    pub fn as_maybe(&self) -> Option<Variant> {
+        debug_assert!(self.type_().is_maybe());
+
+        unsafe { from_glib_full(ffi::g_variant_get_maybe(self.to_glib_none().0)) }
+    }
+
+    // rustdoc-stripper-ignore-next
     /// Constructs a new serialized-mode GVariant instance.
     #[doc(alias = "g_variant_new_from_bytes")]
     pub fn from_bytes<T: StaticVariantType>(bytes: &Bytes) -> Self {
@@ -1961,6 +1976,19 @@ mod tests {
         let a = ().to_variant();
         assert_eq!(a.type_().as_str(), "()");
         assert_eq!(a.get::<()>(), Some(()));
+    }
+
+    #[test]
+    fn test_maybe() {
+        assert!(<Option<()>>::static_variant_type().is_maybe());
+        let m1 = Some(()).to_variant();
+        assert_eq!(m1.type_().as_str(), "m()");
+
+        assert_eq!(m1.get::<Option<()>>(), Some(Some(())));
+        assert!(m1.as_maybe().is_some());
+
+        let m2 = None::<()>.to_variant();
+        assert!(m2.as_maybe().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Addresses the main part of #507 by providing explicit dynamic type variants of:
- `Variant::array_from_iter` -> `Variant::array_from_iter_with_type`
  (a mouthful but consistent with other existing functions like `from_data_with_type_trusted`)
- `Variant::from_maybe` becomes `Variant::from_none` and `Variant::from_some`
  - and adds an accessor: `Variant::as_maybe`
    (panicking, should there be a `try_as_maybe`? should it return an `Option<Option<Variant>>` to be more in line with `Variant::as_variant`?)
- `Variant::is` -> `Variant::is_type`
  (consider `is_of_type` instead?)
- `Value::is` -> `Value::is_type` (ditto)
- `Value::transform` -> `Value::transform_with_type`
  (consider `transform_into`/`transform_to_type` instead?)