### PR TITLE
gtask: fix memory leak when calling g_task_return_value

### DIFF
--- a/gio/src/task.rs
+++ b/gio/src/task.rs
@@ -255,7 +255,7 @@ macro_rules! task_impl {
                     Ok(v) => unsafe {
                         ffi::g_task_return_value(
                             self.to_glib_none().0,
-                            v.to_value().to_glib_full() as *mut _,
+                            v.to_value().to_glib_none().0 as *mut _,
                         )
                     },
                     #[cfg(not(feature = "v2_64"))]


### PR DESCRIPTION
The g_task_return_value function does not take ownership of the input
GValue pointer, but just borrows it to make a copy:
https://developer-old.gnome.org/gio/unstable/GTask.html#g-task-return-value
The Rust caller should take care of the deallocation.