### PR TITLE
glib: Fix handling of closures that provide a return value pointer th…

### DIFF
--- a/glib/src/closure.rs
+++ b/glib/src/closure.rs
@@ -248,9 +248,10 @@ impl Closure {
                         );
                         *return_value = result;
                     }
+                    None if return_value.type_() == Type::INVALID => (),
                     None => {
                         panic!(
-                            "Closure return no value but the caller expected a value of type {}",
+                            "Closure returned no value but the caller expected a value of type {}",
                             return_value.type_()
                         );
                     }


### PR DESCRIPTION
…at is initialized to `G_TYPE_INVALID`

Fixes https://github.com/gtk-rs/gtk4-rs/issues/929