### PR TITLE
glib: Don't use `from_glib_full()` for the individual items of an arr…

### DIFF
--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -427,7 +427,7 @@ macro_rules! glib_boxed_inline_wrapper {
 
                 let mut res = Vec::with_capacity(num);
                 for i in 0..num {
-                    res.push($crate::translate::from_glib_full(ptr.add(i)));
+                    res.push(std::ptr::read(ptr.add(i) as *const $name));
                 }
                 $crate::ffi::g_free(ptr as *mut _);
                 res


### PR DESCRIPTION
…ay for boxed inline types

There is only a single allocation for the whole array and the individual
items should not be freed but just moved out of the array into the
`Vec`.

Only in the case of an array of pointers to boxed inline types
`from_glib_full()` should be used to free the individual allocations.

Fixes https://github.com/gtk-rs/gtk4-rs/issues/932