### PR TITLE
translate: Pre-allocate Rust hashmap at correct size

### DIFF
--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -2202,7 +2202,7 @@ impl FromGlibPtrContainer<*const c_char, *mut ffi::GHashTable> for HashMap<Strin
                 &mut *(hash_map as *mut HashMap<String, String>);
             hash_map.insert(key, value);
         }
-        let mut map = HashMap::new();
+        let mut map = HashMap::with_capacity(ffi::g_hash_table_size(ptr) as usize);
         ffi::g_hash_table_foreach(
             ptr,
             Some(read_string_hash_table),


### PR DESCRIPTION
I am manually doing a hash table translation for
https://github.com/ostreedev/ostree/blob/4066b0ab4578add593c49448fb7553fdee656911/src/libostree/ostree-mutable-tree.c#L599
and went to look at this code and noticed it wasn't doing
the optimization I thought it would be.