### PR TITLE
Variant::from_dict_entry

### DIFF
--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -493,6 +493,20 @@ impl Variant {
     }
 
     // rustdoc-stripper-ignore-next
+    /// Creates a new dictionary entry Variant.
+    ///
+    /// [DictEntry] should be preferred over this when the types are known statically.
+    #[doc(alias = "g_variant_new_dict_entry")]
+    pub fn from_dict_entry(key: &Variant, value: &Variant) -> Self {
+        unsafe {
+            from_glib_none(ffi::g_variant_new_dict_entry(
+                key.to_glib_none().0,
+                value.to_glib_none().0,
+            ))
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
     /// Creates a new maybe Variant.
     #[doc(alias = "g_variant_new_maybe")]
     pub fn from_maybe<T: StaticVariantType>(child: Option<&Variant>) -> Self {
@@ -1514,12 +1528,7 @@ where
     V: StaticVariantType + ToVariant,
 {
     fn to_variant(&self) -> Variant {
-        unsafe {
-            from_glib_none(ffi::g_variant_new_dict_entry(
-                self.key.to_variant().to_glib_none().0,
-                self.value.to_variant().to_glib_none().0,
-            ))
-        }
+        Variant::from_dict_entry(&self.key.to_variant(), &self.value.to_variant())
     }
 }
 

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -1605,16 +1605,11 @@ macro_rules! tuple_impls {
                 $($name: StaticVariantType,)+
             {
                 fn static_variant_type() -> Cow<'static, VariantTy> {
-                    let mut builder = crate::GStringBuilder::new("(");
-
-                    $(
-                        let t = $name::static_variant_type();
-                        builder.append(t.as_str());
-                    )+
-
-                    builder.append_c(')');
-
-                    Cow::Owned(VariantType::from_string(builder.into_string()).unwrap())
+                    Cow::Owned(VariantType::new_tuple(&[
+                        $(
+                            $name::static_variant_type(),
+                        )+
+                    ]))
                 }
             }
 

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -1239,10 +1239,7 @@ impl ToVariant for std::ffi::OsStr {
 
 impl<T: StaticVariantType> StaticVariantType for Option<T> {
     fn static_variant_type() -> Cow<'static, VariantTy> {
-        unsafe {
-            let ptr = ffi::g_variant_type_new_maybe(T::static_variant_type().to_glib_none().0);
-            Cow::Owned(from_glib_full(ptr))
-        }
+        Cow::Owned(VariantType::new_maybe(&T::static_variant_type()))
     }
 }
 

--- a/glib/src/variant.rs
+++ b/glib/src/variant.rs
@@ -1546,13 +1546,10 @@ impl FromVariant for Variant {
 
 impl<K: StaticVariantType, V: StaticVariantType> StaticVariantType for DictEntry<K, V> {
     fn static_variant_type() -> Cow<'static, VariantTy> {
-        unsafe {
-            let ptr = ffi::g_variant_type_new_dict_entry(
-                K::static_variant_type().to_glib_none().0,
-                V::static_variant_type().to_glib_none().0,
-            );
-            Cow::Owned(from_glib_full(ptr))
-        }
+        Cow::Owned(VariantType::new_dict_entry(
+            &K::static_variant_type(),
+            &V::static_variant_type(),
+        ))
     }
 }
 

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -51,6 +51,13 @@ impl VariantType {
     }
 
     // rustdoc-stripper-ignore-next
+    /// Creates a `VariantType` from an array element type.
+    #[doc(alias = "g_variant_type_new_array")]
+    pub fn new_array(elem_type: &VariantTy) -> VariantType {
+        unsafe { from_glib_full(ffi::g_variant_type_new_array(elem_type.to_glib_none().0)) }
+    }
+
+    // rustdoc-stripper-ignore-next
     /// Tries to create a `VariantType` from an owned string.
     ///
     /// Returns `Ok` if the string is a valid type string, `Err` otherwise.
@@ -589,10 +596,7 @@ impl VariantTy {
         } else if self == VariantTy::DICT_ENTRY {
             Cow::Borrowed(VariantTy::DICTIONARY)
         } else {
-            unsafe {
-                let ptr = ffi::g_variant_type_new_array(self.to_glib_none().0);
-                Cow::Owned(VariantType::from_glib_full(ptr))
-            }
+            Cow::Owned(VariantType::new_array(self))
         }
     }
 }

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -65,6 +65,21 @@ impl VariantType {
     }
 
     // rustdoc-stripper-ignore-next
+    /// Creates a `VariantType` from a maybe element type.
+    #[doc(alias = "g_variant_type_new_tuple")]
+    pub fn new_tuple<T: AsRef<VariantTy>, I: IntoIterator<Item = T>>(items: I) -> VariantType {
+        let mut builder = crate::GStringBuilder::new("(");
+
+        for ty in items {
+            builder.append(ty.as_ref().as_str());
+        }
+
+        builder.append_c(')');
+
+        VariantType::from_string(builder.into_string()).unwrap()
+    }
+
+    // rustdoc-stripper-ignore-next
     /// Tries to create a `VariantType` from an owned string.
     ///
     /// Returns `Ok` if the string is a valid type string, `Err` otherwise.
@@ -88,6 +103,12 @@ unsafe impl Sync for VariantType {}
 impl Drop for VariantType {
     fn drop(&mut self) {
         unsafe { ffi::g_variant_type_free(self.ptr) }
+    }
+}
+
+impl AsRef<VariantTy> for VariantType {
+    fn as_ref(&self) -> &VariantTy {
+        self
     }
 }
 
@@ -628,6 +649,12 @@ impl fmt::Display for VariantTy {
 impl<'a> From<&'a VariantTy> for Cow<'a, VariantTy> {
     fn from(ty: &'a VariantTy) -> Cow<'a, VariantTy> {
         Cow::Borrowed(ty)
+    }
+}
+
+impl AsRef<VariantTy> for VariantTy {
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -58,6 +58,13 @@ impl VariantType {
     }
 
     // rustdoc-stripper-ignore-next
+    /// Creates a `VariantType` from a maybe element type.
+    #[doc(alias = "g_variant_type_new_maybe")]
+    pub fn new_maybe(child_type: &VariantTy) -> VariantType {
+        unsafe { from_glib_full(ffi::g_variant_type_new_maybe(child_type.to_glib_none().0)) }
+    }
+
+    // rustdoc-stripper-ignore-next
     /// Tries to create a `VariantType` from an owned string.
     ///
     /// Returns `Ok` if the string is a valid type string, `Err` otherwise.

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -39,6 +39,18 @@ impl VariantType {
     }
 
     // rustdoc-stripper-ignore-next
+    /// Creates a `VariantType` from a key and value type.
+    #[doc(alias = "g_variant_type_new_dict_entry")]
+    pub fn new_dict_entry(key_type: &VariantTy, value_type: &VariantTy) -> VariantType {
+        unsafe {
+            from_glib_full(ffi::g_variant_type_new_dict_entry(
+                key_type.to_glib_none().0,
+                value_type.to_glib_none().0,
+            ))
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
     /// Tries to create a `VariantType` from an owned string.
     ///
     /// Returns `Ok` if the string is a valid type string, `Err` otherwise.


### PR DESCRIPTION
This is a continuation of #519 (addressing #507) for creating a `DictEntry`-typed variant without static types (I missed it in my initial bug report, [even though it was present in the example](https://github.com/jf2048/glib-serde/blob/19e307a86786d385e655183c99212605e866d3dd/src/variant/mod.rs#L89)). The `VariantType` constructor is useful when working with these variants (for example in combination with `Variant::array_from_iter_with_type` to construct a vardict manually), so I included it along with the others.