### PR TITLE
remove problematic phantom in glib_shared_wrapper

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -33,7 +33,6 @@ macro_rules! glib_boxed_wrapper {
         #[repr(transparent)]
         $visibility struct $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? {
             inner: $crate::boxed::Boxed<$ffi_name, Self>,
-            phantom: std::marker::PhantomData<($($($generic),+)?)>,
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? std::clone::Clone for $name $(<$($generic),+>)? {
@@ -41,7 +40,6 @@ macro_rules! glib_boxed_wrapper {
             fn clone(&self) -> Self {
                 Self {
                     inner: std::clone::Clone::clone(&self.inner),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -145,7 +143,6 @@ macro_rules! glib_boxed_wrapper {
             unsafe fn from_glib_none(ptr: *mut $ffi_name) -> Self {
                 Self {
                     inner: $crate::translate::from_glib_none(ptr),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -156,7 +153,6 @@ macro_rules! glib_boxed_wrapper {
             unsafe fn from_glib_none(ptr: *const $ffi_name) -> Self {
                 Self {
                     inner: $crate::translate::from_glib_none(ptr),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -167,7 +163,6 @@ macro_rules! glib_boxed_wrapper {
             unsafe fn from_glib_full(ptr: *mut $ffi_name) -> Self {
                 Self {
                     inner: $crate::translate::from_glib_full(ptr),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -178,7 +173,6 @@ macro_rules! glib_boxed_wrapper {
             unsafe fn from_glib_full(ptr: *const $ffi_name) -> Self {
                 Self {
                     inner: $crate::translate::from_glib_full(ptr),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -190,7 +184,6 @@ macro_rules! glib_boxed_wrapper {
                 $crate::translate::Borrowed::new(
                     Self {
                         inner: $crate::translate::from_glib_borrow::<_, $crate::boxed::Boxed<_, _>>(ptr).into_inner(),
-                        phantom: std::marker::PhantomData,
                     }
                 )
             }

--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -13,7 +13,7 @@ macro_rules! glib_boxed_inline_wrapper {
         #[repr(transparent)]
         $visibility struct $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? {
             pub(crate) inner: $ffi_name,
-            pub(crate) phantom: std::marker::PhantomData<($($($generic),+)?)>,
+            $(pub(crate) phantom: std::marker::PhantomData<$($generic),+>,)?
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? std::clone::Clone for $name $(<$($generic),+>)? {
@@ -21,7 +21,7 @@ macro_rules! glib_boxed_inline_wrapper {
             fn clone(&self) -> Self {
                 Self {
                     inner: std::clone::Clone::clone(&self.inner),
-                    phantom: std::marker::PhantomData,
+                    $(phantom: std::marker::PhantomData::<$($generic),+>)?
                 }
             }
         }
@@ -45,7 +45,7 @@ macro_rules! glib_boxed_inline_wrapper {
         #[repr(transparent)]
         $visibility struct $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? {
             pub(crate) inner: $ffi_name,
-            pub(crate) phantom: std::marker::PhantomData<($($($generic),+)?)>,
+            $(pub(crate) phantom: std::marker::PhantomData<$($generic),+>,)?
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? std::clone::Clone for $name $(<$($generic),+>)? {
@@ -53,7 +53,7 @@ macro_rules! glib_boxed_inline_wrapper {
             fn clone(&self) -> Self {
                 Self {
                     inner: std::clone::Clone::clone(&self.inner),
-                    phantom: std::marker::PhantomData,
+                    $(phantom: std::marker::PhantomData::<$($generic),+>)?
                 }
             }
         }
@@ -76,7 +76,7 @@ macro_rules! glib_boxed_inline_wrapper {
         #[repr(transparent)]
         $visibility struct $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? {
             pub(crate) inner: $ffi_name,
-            pub(crate) phantom: std::marker::PhantomData<($($($generic),+)?)>,
+            $(pub(crate) phantom: std::marker::PhantomData<$($generic),+>,)?
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? std::clone::Clone for $name $(<$($generic),+>)? {
@@ -116,7 +116,7 @@ macro_rules! glib_boxed_inline_wrapper {
         #[repr(transparent)]
         $visibility struct $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? {
             pub(crate) inner: $ffi_name,
-            pub(crate) phantom: std::marker::PhantomData<($($($generic),+)?)>,
+            $(pub(crate) phantom: std::marker::PhantomData<$($generic),+>,)?
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? std::clone::Clone for $name $(<$($generic),+>)? {
@@ -164,7 +164,7 @@ macro_rules! glib_boxed_inline_wrapper {
                 init(v.as_mut_ptr());
                 Self {
                     inner: v.assume_init(),
-                    phantom: std::marker::PhantomData,
+                    $(phantom: std::marker::PhantomData::<$($generic),+>)?
                 }
             }
         }
@@ -174,7 +174,7 @@ macro_rules! glib_boxed_inline_wrapper {
             unsafe fn unsafe_from(t: $ffi_name) -> Self {
                 Self {
                     inner: t,
-                    phantom: std::marker::PhantomData,
+                    $(phantom: std::marker::PhantomData::<$($generic),+>)?
                 }
             }
         }
@@ -372,7 +372,7 @@ macro_rules! glib_boxed_inline_wrapper {
 
                 $crate::translate::Borrowed::new(Self {
                     inner: std::ptr::read(ptr),
-                    phantom: std::marker::PhantomData,
+                    $(phantom: std::marker::PhantomData::<$($generic),+>)?
                 })
             }
         }

--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -180,7 +180,7 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl<'a $(, $($generic $(: $bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibPtr<'a, *const $ffi_name> for $name $(<$($generic),+>)? {
+        impl<'a $(, $($generic: 'a + $($bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibPtr<'a, *const $ffi_name> for $name $(<$($generic),+>)? {
             type Storage = &'a Self;
 
             #[inline]
@@ -198,7 +198,7 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl<'a $(, $($generic $(: $bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibPtrMut<'a, *mut $ffi_name> for $name $(<$($generic),+>)? {
+        impl<'a $(, $($generic: 'a + $($bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibPtrMut<'a, *mut $ffi_name> for $name $(<$($generic),+>)? {
             type Storage = &'a mut Self;
 
             #[inline]
@@ -209,7 +209,7 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl<'a $(, $($generic $(: $bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *mut *const $ffi_name> for $name $(<$($generic),+>)? {
+        impl<'a $(, $($generic: 'a + $($bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *mut *const $ffi_name> for $name $(<$($generic),+>)? {
             type Storage = Option<Vec<*const $ffi_name>>;
 
             fn to_glib_none_from_slice(t: &'a [Self]) -> (*mut *const $ffi_name, Self::Storage) {
@@ -247,7 +247,7 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl<'a $(, $($generic $(: $bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *const *const $ffi_name> for $name $(<$($generic),+>)? {
+        impl<'a $(, $($generic: 'a + $($bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *const *const $ffi_name> for $name $(<$($generic),+>)? {
             type Storage = Option<Vec<*const $ffi_name>>;
 
             fn to_glib_none_from_slice(t: &'a [Self]) -> (*const *const $ffi_name, Self::Storage) {
@@ -267,7 +267,7 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl<'a $(, $($generic $(: $bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *mut $ffi_name> for $name $(<$($generic),+>)? {
+        impl<'a $(, $($generic: 'a + $($bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *mut $ffi_name> for $name $(<$($generic),+>)? {
             type Storage = Option<&'a [Self]>;
 
             fn to_glib_none_from_slice(t: &'a [Self]) -> (*mut $ffi_name, Self::Storage) {
@@ -298,7 +298,7 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl<'a $(, $($generic $(: $bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *const $ffi_name> for $name $(<$($generic),+>)? {
+        impl<'a $(, $($generic: 'a $($bound $(+ $bound2)*)?),+)?> $crate::translate::ToGlibContainerFromSlice<'a, *const $ffi_name> for $name $(<$($generic),+>)? {
             type Storage = Option<&'a [Self]>;
 
             fn to_glib_none_from_slice(t: &'a [Self]) -> (*const $ffi_name, Self::Storage) {
@@ -427,7 +427,7 @@ macro_rules! glib_boxed_inline_wrapper {
 
                 let mut res = Vec::with_capacity(num);
                 for i in 0..num {
-                    res.push(std::ptr::read(ptr.add(i) as *const $name));
+                    res.push(std::ptr::read(ptr.add(i) as *const $name $(<$($generic),+>)?));
                 }
                 $crate::ffi::g_free(ptr as *mut _);
                 res
@@ -495,15 +495,15 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::value::ValueType for $name $(<$($generic),+>)? {
+        impl$(<$($generic: 'static + $($bound $(+ $bound2)*)?),+>)? $crate::value::ValueType for $name $(<$($generic),+>)? {
             type Type = Self;
         }
 
         #[doc(hidden)]
-        unsafe impl<'a> $crate::value::FromValue<'a> for $name $(<$($generic),+>)? {
+        unsafe impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::value::FromValue<'_> for $name $(<$($generic),+>)? {
             type Checker = $crate::value::GenericValueTypeOrNoneChecker<Self>;
 
-            unsafe fn from_value(value: &'a $crate::Value) -> Self {
+            unsafe fn from_value(value: &'_ $crate::Value) -> Self {
                 let ptr = $crate::gobject_ffi::g_value_get_boxed($crate::translate::ToGlibPtr::to_glib_none(value).0);
                 assert!(!ptr.is_null());
                 <Self as $crate::translate::FromGlibPtrNone<*const $ffi_name>>::from_glib_none(ptr as *const $ffi_name)
@@ -511,10 +511,10 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        unsafe impl<'a> $crate::value::FromValue<'a> for &'a $name $(<$($generic),+>)? {
+        unsafe impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::value::FromValue<'_> for &'_ $name $(<$($generic),+>)? {
             type Checker = $crate::value::GenericValueTypeOrNoneChecker<Self>;
 
-            unsafe fn from_value(value: &'a $crate::Value) -> Self {
+            unsafe fn from_value(value: &'_ $crate::Value) -> Self {
                 let ptr = $crate::gobject_ffi::g_value_get_boxed($crate::translate::ToGlibPtr::to_glib_none(value).0);
                 assert!(!ptr.is_null());
                 &*(ptr as *const $ffi_name as *const $name $(<$($generic),+>)?)
@@ -540,7 +540,7 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
-        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::value::ToValueOptional for $name $(<$($generic),+>)? {
+        impl $(<$($generic: 'static + $($bound $(+ $bound2)*)?),+>)? $crate::value::ToValueOptional for $name $(<$($generic),+>)? {
             fn to_value_optional(s: Option<&Self>) -> $crate::Value {
                 let mut value = $crate::Value::for_value_type::<Self>();
                 unsafe {

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -31,7 +31,6 @@ macro_rules! glib_shared_wrapper {
         #[repr(transparent)]
         $visibility struct $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? {
             inner: $crate::shared::Shared<$ffi_name, Self>,
-            phantom: std::marker::PhantomData<($($($generic),+)?)>,
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? std::clone::Clone for $name $(<$($generic),+>)? {
@@ -39,7 +38,6 @@ macro_rules! glib_shared_wrapper {
             fn clone(&self) -> Self {
                 Self {
                     inner: std::clone::Clone::clone(&self.inner),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -146,7 +144,6 @@ macro_rules! glib_shared_wrapper {
             unsafe fn from_glib_none(ptr: *mut $ffi_name) -> Self {
                 Self {
                     inner: $crate::translate::from_glib_none(ptr),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -157,7 +154,6 @@ macro_rules! glib_shared_wrapper {
             unsafe fn from_glib_none(ptr: *const $ffi_name) -> Self {
                 Self {
                     inner: $crate::translate::from_glib_none(ptr),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -168,7 +164,6 @@ macro_rules! glib_shared_wrapper {
             unsafe fn from_glib_full(ptr: *mut $ffi_name) -> Self {
                 Self {
                     inner: $crate::translate::from_glib_full(ptr),
-                    phantom: std::marker::PhantomData,
                 }
             }
         }
@@ -180,7 +175,6 @@ macro_rules! glib_shared_wrapper {
                 $crate::translate::Borrowed::new(
                     Self {
                         inner: $crate::translate::from_glib_borrow::<_, $crate::shared::Shared<_, _>>(ptr).into_inner(),
-                        phantom: std::marker::PhantomData,
                     }
                 )
             }


### PR DESCRIPTION
While trying to use a generic shared wrapper I got this error:
```
warning: unnecessary parentheses around type                                                                           
   --> /home/lollo/gtk-rs-core/glib/src/shared.rs:34:47                                                           
    |                                                      
34  |               phantom: std::marker::PhantomData<($($($generic),+)?)>,                                            
    |                                                 ^                 ^        
```

But then I found out that field is useless anyway, because the generic type is already used in the field above, so I've removed the phantom field.