### PR TITLE
add AutoObjectProps and AutoObjectSignals

### DIFF
--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -266,7 +266,10 @@ pub mod prelude {
     //! Prelude that re-exports all important traits from this crate.
     pub use super::boxed::BoxedType;
     pub use super::interface::{ObjectInterface, ObjectInterfaceExt, ObjectInterfaceType};
-    pub use super::object::{ObjectClassSubclassExt, ObjectImpl, ObjectImplExt};
+    pub use super::object::{
+        DerivedObjectProperties, DerivedObjectSignals, ObjectClassSubclassExt, ObjectImpl,
+        ObjectImplExt,
+    };
     pub use super::shared::{RefCounted, SharedType};
     pub use super::types::{
         ClassStruct, InstanceStruct, IsImplementable, IsSubclassable, IsSubclassableExt,


### PR DESCRIPTION
Different take on #546.
These traits are not going to be implemented by the user. These are going to be implemented by macros. The user will then delegate the `ObjectImpl` functions to the ones in these traits