### PR TITLE
Use glib 2.71 for minimum v2_72 pkg-config versions

### DIFF
--- a/gio/sys/Cargo.toml
+++ b/gio/sys/Cargo.toml
@@ -89,4 +89,4 @@ version = "2.68"
 version = "2.70"
 
 [package.metadata.system-deps.gio_2_0.v2_72]
-version = "2.72"
+version = "2.71"

--- a/glib/gobject-sys/Cargo.toml
+++ b/glib/gobject-sys/Cargo.toml
@@ -62,4 +62,4 @@ version = "2.68"
 version = "2.70"
 
 [package.metadata.system-deps.gobject_2_0.v2_72]
-version = "2.72"
+version = "2.71"

--- a/glib/sys/Cargo.toml
+++ b/glib/sys/Cargo.toml
@@ -78,7 +78,7 @@ version = "2.68"
 version = "2.70"
 
 [package.metadata.system-deps.glib_2_0.v2_72]
-version = "2.72"
+version = "2.71"
 
 [package.metadata.system-deps.gobject_2_0]
 name = "gobject-2.0"


### PR DESCRIPTION
Per https://github.com/gtk-rs/gtk-rs-core/pull/577#issuecomment-1058912597

Not sure this makes sense, we don't use odd version numbers for any of the other features?