### PR TITLE
glib: Only auto-impl `Send+Sync` for subclasses if the parent type does

### DIFF
--- a/glib/src/wrapper.rs
+++ b/glib/src/wrapper.rs
@@ -363,7 +363,7 @@ macro_rules! wrapper {
         }
     ) => {
         $crate::glib_object_wrapper!(
-            @object [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, *mut std::os::raw::c_void, $ffi_name,
+            @object [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, *mut std::os::raw::c_void, (), $ffi_name,
             $( @ffi_class $ffi_class_name ,)?
             @type_ $get_type_expr,
             @extends [],
@@ -381,7 +381,7 @@ macro_rules! wrapper {
         }
     ) => {
         $crate::glib_object_wrapper!(
-            @object [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, *mut std::os::raw::c_void, $ffi_name,
+            @object [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, *mut std::os::raw::c_void, (), $ffi_name,
             $( @ffi_class $ffi_class_name ,)?
             @type_ $get_type_expr,
             @extends [$($extends),+],

--- a/glib/tests/subclass_compiletest.rs
+++ b/glib/tests/subclass_compiletest.rs
@@ -5,4 +5,9 @@ pub fn test() {
     t.pass("tests/subclass_compiletest/01-auto-send-sync.rs");
     t.compile_fail("tests/subclass_compiletest/02-no-auto-send-sync.rs");
     t.compile_fail("tests/subclass_compiletest/03-object-no-auto-send-sync.rs");
+    t.pass("tests/subclass_compiletest/04-auto-send-sync-with-send-sync-parent.rs");
+    t.compile_fail("tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs");
+    t.compile_fail(
+        "tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs",
+    );
 }

--- a/glib/tests/subclass_compiletest/01-auto-send-sync.rs
+++ b/glib/tests/subclass_compiletest/01-auto-send-sync.rs
@@ -12,7 +12,7 @@ mod imp {
         type Type = super::TestObject;
     }
 
-    impl ObjectImpl for TestObject { }
+    impl ObjectImpl for TestObject {}
 }
 
 glib::wrapper! {

--- a/glib/tests/subclass_compiletest/02-no-auto-send-sync.rs
+++ b/glib/tests/subclass_compiletest/02-no-auto-send-sync.rs
@@ -13,7 +13,7 @@ mod imp {
         type Type = super::TestObject;
     }
 
-    impl ObjectImpl for TestObject { }
+    impl ObjectImpl for TestObject {}
 }
 
 glib::wrapper! {

--- a/glib/tests/subclass_compiletest/02-no-auto-send-sync.stderr
+++ b/glib/tests/subclass_compiletest/02-no-auto-send-sync.stderr
@@ -12,7 +12,7 @@ note: required because it appears within the type `imp::TestObject`
    |
 6  |     pub struct TestObject {
    |                ^^^^^^^^^^
-   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<imp::TestObject>`
+   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<imp::TestObject, ()>`
 note: required because it appears within the type `TestObject`
   --> tests/subclass_compiletest/02-no-auto-send-sync.rs:20:16
    |

--- a/glib/tests/subclass_compiletest/03-object-no-auto-send-sync.stderr
+++ b/glib/tests/subclass_compiletest/03-object-no-auto-send-sync.stderr
@@ -7,7 +7,7 @@ error[E0277]: `*mut c_void` cannot be sent between threads safely
   |     required by a bound introduced by this call
   |
   = help: the trait `Send` is not implemented for `*mut c_void`
-  = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<*mut c_void>`
+  = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<*mut c_void, ()>`
   = note: required because it appears within the type `Object`
 note: required by a bound in `main::check`
  --> tests/subclass_compiletest/03-object-no-auto-send-sync.rs:2:17
@@ -24,7 +24,7 @@ error[E0277]: `*mut c_void` cannot be shared between threads safely
   |     required by a bound introduced by this call
   |
   = help: the trait `Sync` is not implemented for `*mut c_void`
-  = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<*mut c_void>`
+  = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<*mut c_void, ()>`
   = note: required because it appears within the type `Object`
 note: required by a bound in `main::check`
  --> tests/subclass_compiletest/03-object-no-auto-send-sync.rs:2:17

--- a/glib/tests/subclass_compiletest/04-auto-send-sync-with-send-sync-parent.rs
+++ b/glib/tests/subclass_compiletest/04-auto-send-sync-with-send-sync-parent.rs
@@ -1,0 +1,69 @@
+mod imp_parent {
+    use glib::subclass::prelude::*;
+
+    #[derive(Default)]
+    pub struct TestParent {
+        s: String,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for TestParent {
+        const NAME: &'static str = "TestParent";
+        type Type = super::TestParent;
+    }
+
+    impl ObjectImpl for TestParent {}
+}
+
+glib::wrapper! {
+    pub struct TestParent(ObjectSubclass<imp_parent::TestParent>);
+}
+
+pub trait TestParentImpl: glib::subclass::prelude::ObjectImpl + Send + Sync {}
+
+unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for TestParent {}
+
+impl Default for TestParent {
+    fn default() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+}
+
+mod imp_object {
+    use glib::subclass::prelude::*;
+
+    #[derive(Default)]
+    pub struct TestObject {
+        s: String,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for TestObject {
+        const NAME: &'static str = "TestObject";
+        type Type = super::TestObject;
+        type ParentType = super::TestParent;
+    }
+
+    impl ObjectImpl for TestObject {}
+    impl super::TestParentImpl for TestObject {}
+}
+
+glib::wrapper! {
+    pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends TestParent;
+}
+
+impl Default for TestObject {
+    fn default() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+}
+
+fn main() {
+    fn check<T: Send + Sync>(_obj: &T) {}
+
+    let obj = TestParent::default();
+    check(&obj);
+
+    let obj = TestObject::default();
+    check(&obj);
+}

--- a/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs
+++ b/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs
@@ -1,0 +1,67 @@
+mod imp_parent {
+    use glib::subclass::prelude::*;
+    use std::cell::RefCell;
+
+    #[derive(Default)]
+    pub struct TestParent {
+        s: RefCell<String>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for TestParent {
+        const NAME: &'static str = "TestParent";
+        type Type = super::TestParent;
+    }
+
+    impl ObjectImpl for TestParent {}
+}
+
+glib::wrapper! {
+    pub struct TestParent(ObjectSubclass<imp_parent::TestParent>);
+}
+
+pub trait TestParentImpl: glib::subclass::prelude::ObjectImpl {}
+
+unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for TestParent {}
+
+impl Default for TestParent {
+    fn default() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+}
+
+mod imp_object {
+    use glib::subclass::prelude::*;
+
+    #[derive(Default)]
+    pub struct TestObject {
+        s: String,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for TestObject {
+        const NAME: &'static str = "TestObject";
+        type Type = super::TestObject;
+        type ParentType = super::TestParent;
+    }
+
+    impl ObjectImpl for TestObject {}
+    impl super::TestParentImpl for TestObject {}
+}
+
+glib::wrapper! {
+    pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends TestParent;
+}
+
+impl Default for TestObject {
+    fn default() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+}
+
+fn main() {
+    fn check<T: Send + Sync>(_obj: &T) {}
+
+    let obj = TestObject::default();
+    check(&obj);
+}

--- a/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.stderr
+++ b/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.stderr
@@ -1,0 +1,31 @@
+error[E0277]: `RefCell<std::string::String>` cannot be shared between threads safely
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:66:11
+   |
+66 |     check(&obj);
+   |     ----- ^^^^ `RefCell<std::string::String>` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: within `imp_parent::TestParent`, the trait `Sync` is not implemented for `RefCell<std::string::String>`
+note: required because it appears within the type `imp_parent::TestParent`
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:6:16
+   |
+6  |     pub struct TestParent {
+   |                ^^^^^^^^^^
+   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<imp_parent::TestParent, ()>`
+note: required because it appears within the type `TestParent`
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:20:16
+   |
+20 |     pub struct TestParent(ObjectSubclass<imp_parent::TestParent>);
+   |                ^^^^^^^^^^
+   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<imp_object::TestObject, TestParent>`
+note: required because it appears within the type `TestObject`
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:53:16
+   |
+53 |     pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends TestParent;
+   |                ^^^^^^^^^^
+note: required by a bound in `main::check`
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:63:17
+   |
+63 |     fn check<T: Send + Sync>(_obj: &T) {}
+   |                 ^^^^ required by this bound in `main::check`

--- a/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs
+++ b/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs
@@ -1,0 +1,48 @@
+glib::wrapper! {
+    #[doc(alias = "GInitiallyUnowned")]
+    pub struct InitiallyUnowned(Object<glib::gobject_ffi::GInitiallyUnowned, glib::gobject_ffi::GInitiallyUnownedClass>);
+
+    match fn {
+        type_ => || glib::gobject_ffi::g_initially_unowned_get_type(),
+    }
+}
+
+pub trait InitiallyUnownedImpl: glib::subclass::prelude::ObjectImpl {}
+
+unsafe impl<T: InitiallyUnownedImpl> glib::subclass::prelude::IsSubclassable<T> for InitiallyUnowned {}
+
+mod imp_object {
+    use glib::subclass::prelude::*;
+
+    #[derive(Default)]
+    pub struct TestObject {
+        s: String,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for TestObject {
+        const NAME: &'static str = "TestObject";
+        type Type = super::TestObject;
+        type ParentType = super::InitiallyUnowned;
+    }
+
+    impl ObjectImpl for TestObject {}
+    impl super::InitiallyUnownedImpl for TestObject {}
+}
+
+glib::wrapper! {
+    pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends InitiallyUnowned;
+}
+
+impl Default for TestObject {
+    fn default() -> Self {
+        glib::Object::new(&[]).unwrap()
+    }
+}
+
+fn main() {
+    fn check<T: Send + Sync>(_obj: &T) {}
+
+    let obj = TestObject::default();
+    check(&obj);
+}

--- a/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.stderr
+++ b/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.stderr
@@ -1,0 +1,53 @@
+error[E0277]: `*mut c_void` cannot be sent between threads safely
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:47:11
+   |
+47 |     check(&obj);
+   |     ----- ^^^^ `*mut c_void` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Send` is not implemented for `*mut c_void`
+   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<*mut c_void, ()>`
+note: required because it appears within the type `InitiallyUnowned`
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:3:16
+   |
+3  |     pub struct InitiallyUnowned(Object<glib::gobject_ffi::GInitiallyUnowned, glib::gobject_ffi::GInitiallyUnownedClass>);
+   |                ^^^^^^^^^^^^^^^^
+   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<imp_object::TestObject, InitiallyUnowned>`
+note: required because it appears within the type `TestObject`
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:34:16
+   |
+34 |     pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends InitiallyUnowned;
+   |                ^^^^^^^^^^
+note: required by a bound in `main::check`
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:44:17
+   |
+44 |     fn check<T: Send + Sync>(_obj: &T) {}
+   |                 ^^^^ required by this bound in `main::check`
+
+error[E0277]: `*mut c_void` cannot be shared between threads safely
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:47:11
+   |
+47 |     check(&obj);
+   |     ----- ^^^^ `*mut c_void` cannot be shared between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Sync` is not implemented for `*mut c_void`
+   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<*mut c_void, ()>`
+note: required because it appears within the type `InitiallyUnowned`
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:3:16
+   |
+3  |     pub struct InitiallyUnowned(Object<glib::gobject_ffi::GInitiallyUnowned, glib::gobject_ffi::GInitiallyUnownedClass>);
+   |                ^^^^^^^^^^^^^^^^
+   = note: required because of the requirements on the impl of `Send` for `TypedObjectRef<imp_object::TestObject, InitiallyUnowned>`
+note: required because it appears within the type `TestObject`
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:34:16
+   |
+34 |     pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends InitiallyUnowned;
+   |                ^^^^^^^^^^
+note: required by a bound in `main::check`
+  --> tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs:44:17
+   |
+44 |     fn check<T: Send + Sync>(_obj: &T) {}
+   |                 ^^^^ required by this bound in `main::check`


### PR DESCRIPTION
Previously a `Send+Sync` subclass of a `gtk::Widget` would automatically
be `Send+Sync` too, which is obviously not allowed.

To avoid this, also add the parent type as `PhantomData` to the wrapper
struct so that this is considered too.

Handle `glib::Object` specially here because while it is not `Send+Sync`
itself, subclasses of it can be `Send+Sync` just fine. The only reason
why `glib::Object` is not is because there are some subclasses that are
not and otherwise this could be circumvented by upcasting.