### PR TITLE
Structured Logging

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -803,3 +803,20 @@ pub fn variant_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     variant_derive::impl_variant(input)
 }
+
+#[proc_macro]
+pub fn cstr_bytes(item: TokenStream) -> TokenStream {
+    syn::parse::Parser::parse2(
+        |stream: syn::parse::ParseStream<'_>| {
+            let literal = stream.parse::<syn::LitStr>()?;
+            stream.parse::<syn::parse::Nothing>()?;
+            let bytes = std::ffi::CString::new(literal.value())
+                .map_err(|e| syn::Error::new_spanned(&literal, format!("{}", e)))?
+                .into_bytes_with_nul();
+            let bytes = proc_macro2::Literal::byte_string(&bytes);
+            Ok(quote::quote! { #bytes }.into())
+        },
+        item.into(),
+    )
+    .unwrap_or_else(|e| e.into_compile_error().into())
+}

--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -20,6 +20,7 @@ generate = [
     "GLib.KeyFileError",
     "GLib.KeyFileFlags",
     "GLib.LogLevelFlags",
+    "GLib.LogWriterOutput",
     "GLib.MainContextFlags",
     "GLib.OptionArg",
     "GLib.OptionFlags",

--- a/glib/src/auto/enums.rs
+++ b/glib/src/auto/enums.rs
@@ -354,6 +354,64 @@ impl ErrorDomain for KeyFileError {
     }
 }
 
+#[cfg(any(feature = "v2_50", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v2_50")))]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+#[non_exhaustive]
+#[doc(alias = "GLogWriterOutput")]
+pub enum LogWriterOutput {
+    #[doc(alias = "G_LOG_WRITER_HANDLED")]
+    Handled,
+    #[doc(alias = "G_LOG_WRITER_UNHANDLED")]
+    Unhandled,
+    #[doc(hidden)]
+    __Unknown(i32),
+}
+
+#[cfg(any(feature = "v2_50", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v2_50")))]
+impl fmt::Display for LogWriterOutput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "LogWriterOutput::{}",
+            match *self {
+                Self::Handled => "Handled",
+                Self::Unhandled => "Unhandled",
+                _ => "Unknown",
+            }
+        )
+    }
+}
+
+#[cfg(any(feature = "v2_50", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v2_50")))]
+#[doc(hidden)]
+impl IntoGlib for LogWriterOutput {
+    type GlibType = ffi::GLogWriterOutput;
+
+    fn into_glib(self) -> ffi::GLogWriterOutput {
+        match self {
+            Self::Handled => ffi::G_LOG_WRITER_HANDLED,
+            Self::Unhandled => ffi::G_LOG_WRITER_UNHANDLED,
+            Self::__Unknown(value) => value,
+        }
+    }
+}
+
+#[cfg(any(feature = "v2_50", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v2_50")))]
+#[doc(hidden)]
+impl FromGlib<ffi::GLogWriterOutput> for LogWriterOutput {
+    unsafe fn from_glib(value: ffi::GLogWriterOutput) -> Self {
+        match value {
+            ffi::G_LOG_WRITER_HANDLED => Self::Handled,
+            ffi::G_LOG_WRITER_UNHANDLED => Self::Unhandled,
+            value => Self::__Unknown(value),
+        }
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
 #[non_exhaustive]
 #[doc(alias = "GOptionArg")]

--- a/glib/src/auto/mod.rs
+++ b/glib/src/auto/mod.rs
@@ -35,6 +35,9 @@ pub use self::enums::ChecksumType;
 pub use self::enums::DateMonth;
 pub use self::enums::DateWeekday;
 pub use self::enums::KeyFileError;
+#[cfg(any(feature = "v2_50", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v2_50")))]
+pub use self::enums::LogWriterOutput;
 pub use self::enums::OptionArg;
 pub use self::enums::SeekType;
 pub use self::enums::TimeType;

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -129,13 +129,23 @@ pub use self::quark::Quark;
 mod log;
 pub use self::log::log_set_handler;
 
-// #[cfg(any(feature = "v2_50", feature = "dox"))]
-// pub use log::log_variant;
 pub use self::log::{
     log_default_handler, log_remove_handler, log_set_always_fatal, log_set_default_handler,
     log_set_fatal_mask, log_unset_default_handler, set_print_handler, set_printerr_handler,
     unset_print_handler, unset_printerr_handler, LogHandlerId, LogLevel, LogLevels,
 };
+
+#[cfg(any(feature = "v2_50", feature = "dox"))]
+pub use self::log::{
+    log_set_writer_func, log_structured_array, log_variant, log_writer_default,
+    log_writer_format_fields, log_writer_journald, log_writer_standard_streams, LogField,
+};
+
+#[cfg(any(all(unix, feature = "v2_50"), feature = "dox"))]
+pub use self::log::{log_writer_is_journald, log_writer_supports_color};
+
+#[cfg(any(feature = "v2_68", feature = "dox"))]
+pub use self::log::{log_writer_default_set_use_stderr, log_writer_default_would_drop};
 
 #[doc(hidden)]
 #[cfg(any(feature = "dox", feature = "log_macros"))]

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -21,6 +21,9 @@ pub use glib_macros::{
     Enum, ErrorDomain, SharedBoxed, Variant,
 };
 
+#[doc(hidden)]
+pub use glib_macros::cstr_bytes;
+
 pub use self::byte_array::ByteArray;
 pub use self::bytes::Bytes;
 pub use self::closure::{Closure, RustClosure};
@@ -94,7 +97,7 @@ pub use self::source::*;
 #[macro_use]
 pub mod translate;
 mod gstring;
-pub use self::gstring::GString;
+pub use self::gstring::{GStr, GString};
 mod gstring_builder;
 pub use self::gstring_builder::GStringBuilder;
 pub mod types;

--- a/glib/tests/structured_log.rs
+++ b/glib/tests/structured_log.rs
@@ -1,0 +1,136 @@
+#[cfg(feature = "v2_50")]
+#[test]
+fn structured_log() {
+    use glib::*;
+    use std::sync::{Arc, Mutex};
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+    {
+        let log = log.clone();
+        // can only be called once per test file
+        log_set_writer_func(move |level, fields| {
+            let fields = fields
+                .iter()
+                .map(|f| {
+                    let value = if let Some(data) = f.user_data() {
+                        assert!(f.value_str().is_none());
+                        format!("USERDATA: {}", data)
+                    } else {
+                        f.value_str().unwrap().to_owned()
+                    };
+                    (f.key().to_owned(), value)
+                })
+                .collect::<Vec<_>>();
+            log.lock().unwrap().push((level, fields));
+            LogWriterOutput::Handled
+        });
+    }
+    log_structured!(
+        "test",
+        LogLevel::Message,
+        {
+            "MY_META" => "abc";
+            "MESSAGE" => "normal with meta";
+            "MY_META2" => "def";
+        }
+    );
+
+    log_structured!(
+        None,
+        LogLevel::Message,
+        {
+            "MY_META" => "abc";
+            "MESSAGE" => "formatted with meta: {} {}", 123, 456.0;
+            "MY_META2" => "def{}", "ghi";
+            "EMPTY" => b"";
+            GString::from("MY_META3") => b"bstring".to_owned();
+        }
+    );
+    log_structured_array(
+        LogLevel::Warning,
+        &[
+            LogField::new(
+                gstr!("MESSAGE_ID"),
+                "1e45a69523d3460680e2721d3072408f".as_bytes(),
+            ),
+            LogField::new(gstr!("PRIORITY"), "4".as_bytes()),
+            LogField::new(gstr!("MESSAGE"), "from array".as_bytes()),
+            LogField::new_user_data(gstr!("SOMEDATA"), 12345),
+        ],
+    );
+    let dict = VariantDict::new(None);
+    dict.insert_value(
+        "MESSAGE_ID",
+        &"9e093d0fac2f4d50838a649796ab154b".to_variant(),
+    );
+    dict.insert_value("RELEASE", &"true".to_variant());
+    dict.insert_value("MY_BYTES", &"123".as_bytes().to_variant());
+    dict.insert_value("MESSAGE", &"from variant".to_variant());
+    log_variant(Some("test"), LogLevel::Debug, &dict.end());
+
+    let log = std::mem::take(&mut *log.lock().unwrap());
+    let log = log
+        .iter()
+        .map(|(l, v)| {
+            (
+                *l,
+                v.iter()
+                    .map(|(k, v)| (k.as_str(), v.as_str()))
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        log[0],
+        (
+            LogLevel::Message,
+            vec![
+                ("PRIORITY", "5" as &str),
+                ("MY_META", "abc"),
+                ("MESSAGE", "normal with meta"),
+                ("MY_META2", "def"),
+                ("GLIB_DOMAIN", "test"),
+            ]
+        ),
+    );
+    assert_eq!(
+        log[1],
+        (
+            LogLevel::Message,
+            vec![
+                ("PRIORITY", "5" as &str),
+                ("MY_META", "abc"),
+                ("MESSAGE", "formatted with meta: 123 456"),
+                ("MY_META2", "defghi"),
+                ("EMPTY", ""),
+                ("MY_META3", "bstring"),
+            ]
+        )
+    );
+    assert_eq!(
+        log[2],
+        (
+            LogLevel::Warning,
+            vec![
+                ("MESSAGE_ID", "1e45a69523d3460680e2721d3072408f" as &str),
+                ("PRIORITY", "4"),
+                ("MESSAGE", "from array"),
+                ("SOMEDATA", "USERDATA: 12345"),
+            ]
+        )
+    );
+    assert_eq!(
+        log[3],
+        (
+            LogLevel::Debug,
+            vec![
+                ("PRIORITY", "7" as &str),
+                ("GLIB_DOMAIN", "test"),
+                ("MESSAGE_ID", "9e093d0fac2f4d50838a649796ab154b"),
+                ("MY_BYTES", "123"),
+                ("RELEASE", "true"),
+                ("MESSAGE", "from variant"),
+            ]
+        )
+    );
+}


### PR DESCRIPTION
Adds bindings for these functions:

- `glib::log_set_writer_func`
- `glib::log_structured_array`
  - Requires a new `GStr` wrapper for a borrowed `GString`, so we can avoid copying the log keys.
- `glib::log_variant`
- `glib::log_writer_default`
- `glib::log_writer_format_fields`
- `glib::log_writer_journald`
- `glib::log_writer_standard_streams`
- `glib::log_writer_is_journald` - unix only
- `glib::log_writer_supports_color` - unix only
- `glib::log_writer_default_set_use_stderr`
- `glib::log_writer_default_would_drop`

And some new macros:
- `glib::gstr` - Turns a string literal into a `&'static GStr`, by appending a nul byte at compile time
- `glib::log_structured` - The main interface. From the docs:

```rust
log_structured!(
    "test",
    LogLevel::Debug,
    {
        // a normal string field
        "MY_FIELD" => "123";
        // fields can also take format arguments
        "MY_FIELD2" => "abc {}", "def";
        // single argument can be a &str or a &[u8] or anything else satsfying AsRef<[u8]>
        "MY_FIELD3" => CString::new("my string").unwrap().to_bytes();
        // field names can also be dynamic, taking an AsRef<GStr>
        GString::from("MY_FIELD4") => b"a binary string".to_owned();
        // the main log message goes in the MESSAGE field
        "MESSAGE" => "test: {} {}", 1, 2, ;
    }
);
``` 