### PR TITLE
GString refactor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.63.0"
+          - "1.64.0"
         conf:
           - { name: "cairo", features: "png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface", nightly: "--features 'png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface'", test_sys: true }
           - { name: "gdk-pixbuf", features: "v2_42", nightly: "--all-features", test_sys: true }
@@ -100,7 +100,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.63.0"
+          - "1.64.0"
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -34,6 +34,7 @@ rs-log = { package = "log", version = "0.4", optional = true }
 smallvec = "1.0"
 thiserror = "1"
 gio_ffi = { package = "gio-sys", path = "../gio/sys", optional = true }
+memchr = "2.5.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [lib]
 name = "glib"

--- a/glib/src/functions.rs
+++ b/glib/src/functions.rs
@@ -14,8 +14,7 @@ use std::ptr;
 // #[cfg(windows)]
 // #[cfg(any(feature = "v2_58", feature = "dox"))]
 // use std::os::windows::io::AsRawHandle;
-use crate::translate::*;
-use crate::GString;
+use crate::{translate::*, GStr};
 #[cfg(not(windows))]
 use crate::{Error, Pid, SpawnFlags};
 
@@ -213,7 +212,7 @@ pub fn spawn_async_with_pipes<
 /// charset if available.
 #[doc(alias = "g_get_charset")]
 #[doc(alias = "get_charset")]
-pub fn charset() -> (bool, Option<GString>) {
+pub fn charset() -> (bool, Option<&'static GStr>) {
     unsafe {
         let mut out_charset = ptr::null();
         let is_utf8 = from_glib(ffi::g_get_charset(&mut out_charset));

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -186,13 +186,13 @@ impl PartialEq<str> for GStr {
     }
 }
 
-impl<'a> PartialEq<&'a str> for GStr {
-    fn eq(&self, other: &&'a str) -> bool {
+impl PartialEq<&str> for GStr {
+    fn eq(&self, other: &&str) -> bool {
         self.as_str() == *other
     }
 }
 
-impl<'a> PartialEq<GStr> for &'a str {
+impl PartialEq<GStr> for &str {
     fn eq(&self, other: &GStr) -> bool {
         *self == other.as_str()
     }
@@ -485,18 +485,21 @@ impl IntoGlibPtr<*mut c_char> for GString {
 }
 
 impl Clone for GString {
+    #[inline]
     fn clone(&self) -> GString {
         self.as_str().into()
     }
 }
 
 impl fmt::Debug for GString {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <&str as fmt::Debug>::fmt(&self.as_str(), f)
     }
 }
 
 impl Drop for GString {
+    #[inline]
     fn drop(&mut self) {
         if let Inner::Foreign { ptr, .. } = self.0 {
             unsafe {
@@ -507,138 +510,161 @@ impl Drop for GString {
 }
 
 impl fmt::Display for GString {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
 impl hash::Hash for GString {
+    #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state)
     }
 }
 
 impl Borrow<GStr> for GString {
+    #[inline]
     fn borrow(&self) -> &GStr {
         self.as_gstr()
     }
 }
 
 impl Borrow<str> for GString {
+    #[inline]
     fn borrow(&self) -> &str {
         self.as_str()
     }
 }
 
 impl Ord for GString {
+    #[inline]
     fn cmp(&self, other: &GString) -> Ordering {
         self.as_str().cmp(other.as_str())
     }
 }
 
 impl PartialOrd for GString {
+    #[inline]
     fn partial_cmp(&self, other: &GString) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl PartialEq for GString {
+    #[inline]
     fn eq(&self, other: &GString) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
 impl PartialEq<GString> for String {
+    #[inline]
     fn eq(&self, other: &GString) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
 impl PartialEq<GStr> for GString {
+    #[inline]
     fn eq(&self, other: &GStr) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
 impl PartialEq<&GStr> for GString {
+    #[inline]
     fn eq(&self, other: &&GStr) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
 impl PartialEq<str> for GString {
+    #[inline]
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
     }
 }
 
 impl PartialEq<&str> for GString {
+    #[inline]
     fn eq(&self, other: &&str) -> bool {
         self.as_str() == *other
     }
 }
 
 impl PartialEq<GString> for &GStr {
+    #[inline]
     fn eq(&self, other: &GString) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
 impl PartialEq<GString> for &str {
+    #[inline]
     fn eq(&self, other: &GString) -> bool {
         *self == other.as_str()
     }
 }
 
 impl PartialEq<String> for GString {
+    #[inline]
     fn eq(&self, other: &String) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
 impl PartialEq<GString> for str {
+    #[inline]
     fn eq(&self, other: &GString) -> bool {
         self == other.as_str()
     }
 }
 
 impl PartialEq<GString> for GStr {
+    #[inline]
     fn eq(&self, other: &GString) -> bool {
         self.as_str() == other.as_str()
     }
 }
 
 impl PartialOrd<GString> for String {
+    #[inline]
     fn partial_cmp(&self, other: &GString) -> Option<Ordering> {
         Some(self.cmp(&String::from(other.as_str())))
     }
 }
 
 impl PartialOrd<String> for GString {
+    #[inline]
     fn partial_cmp(&self, other: &String) -> Option<Ordering> {
         Some(self.as_str().cmp(other.as_str()))
     }
 }
 
 impl PartialOrd<GString> for GStr {
+    #[inline]
     fn partial_cmp(&self, other: &GString) -> Option<Ordering> {
         Some(self.as_str().cmp(other))
     }
 }
 
 impl PartialOrd<GStr> for GString {
+    #[inline]
     fn partial_cmp(&self, other: &GStr) -> Option<Ordering> {
         Some(self.as_str().cmp(other.as_str()))
     }
 }
 
 impl PartialOrd<GString> for str {
+    #[inline]
     fn partial_cmp(&self, other: &GString) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl PartialOrd<str> for GString {
+    #[inline]
     fn partial_cmp(&self, other: &str) -> Option<Ordering> {
         Some(self.as_str().cmp(other))
     }
@@ -647,12 +673,14 @@ impl PartialOrd<str> for GString {
 impl Eq for GString {}
 
 impl AsRef<GStr> for GString {
+    #[inline]
     fn as_ref(&self) -> &GStr {
         self.as_gstr()
     }
 }
 
 impl AsRef<str> for GString {
+    #[inline]
     fn as_ref(&self) -> &str {
         self.as_str()
     }
@@ -665,18 +693,21 @@ impl AsRef<CStr> for GString {
 }
 
 impl AsRef<OsStr> for GString {
+    #[inline]
     fn as_ref(&self) -> &OsStr {
         OsStr::new(self.as_str())
     }
 }
 
 impl AsRef<Path> for GString {
+    #[inline]
     fn as_ref(&self) -> &Path {
         Path::new(self.as_str())
     }
 }
 
 impl AsRef<[u8]> for GString {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_str().as_bytes()
     }
@@ -685,6 +716,7 @@ impl AsRef<[u8]> for GString {
 impl Deref for GString {
     type Target = str;
 
+    #[inline]
     fn deref(&self) -> &str {
         self.as_str()
     }
@@ -1070,6 +1102,7 @@ impl GlibPtrDefault for GString {
 }
 
 impl StaticType for GString {
+    #[inline]
     fn static_type() -> Type {
         String::static_type()
     }
@@ -1084,22 +1117,26 @@ impl crate::value::ValueTypeOptional for GString {}
 unsafe impl<'a> crate::value::FromValue<'a> for GString {
     type Checker = crate::value::GenericValueTypeOrNoneChecker<Self>;
 
+    #[inline]
     unsafe fn from_value(value: &'a Value) -> Self {
         Self::from(<&str>::from_value(value))
     }
 }
 
 impl crate::value::ToValue for GString {
+    #[inline]
     fn to_value(&self) -> Value {
         <&str>::to_value(&self.as_str())
     }
 
+    #[inline]
     fn value_type(&self) -> Type {
         String::static_type()
     }
 }
 
 impl crate::value::ToValueOptional for GString {
+    #[inline]
     fn to_value_optional(s: Option<&Self>) -> Value {
         <str>::to_value_optional(s.as_ref().map(|s| s.as_str()))
     }
@@ -1116,6 +1153,7 @@ impl From<GString> for Value {
 }
 
 impl StaticType for Vec<GString> {
+    #[inline]
     fn static_type() -> Type {
         <Vec<String>>::static_type()
     }
@@ -1144,6 +1182,7 @@ impl ToValue for Vec<GString> {
         }
     }
 
+    #[inline]
     fn value_type(&self) -> Type {
         <Vec<GString>>::static_type()
     }

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -83,7 +83,7 @@ impl GStr {
     /// This function is the equivalent of [`GStr::to_bytes`] except that it will retain the
     /// trailing nul terminator instead of chopping it off.
     #[inline]
-    pub fn to_bytes_with_nul(&self) -> &[u8] {
+    pub fn as_bytes_with_nul(&self) -> &[u8] {
         self.0.as_bytes()
     }
     // rustdoc-stripper-ignore-next
@@ -92,7 +92,7 @@ impl GStr {
     /// The returned slice will **not** contain the trailing nul terminator that this GLib
     /// string has.
     #[inline]
-    pub fn to_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         self.as_str().as_bytes()
     }
     // rustdoc-stripper-ignore-next
@@ -121,7 +121,7 @@ impl GStr {
     /// Converts this GLib string to a C string slice.
     #[inline]
     pub fn as_c_str(&self) -> &CStr {
-        unsafe { CStr::from_bytes_with_nul_unchecked(self.to_bytes_with_nul()) }
+        unsafe { CStr::from_bytes_with_nul_unchecked(self.as_bytes_with_nul()) }
     }
 
     #[doc(alias = "g_utf8_collate")]
@@ -144,7 +144,7 @@ impl GStr {
 /// use glib::{gstr, GStr, GString};
 ///
 /// const MY_STRING: &GStr = gstr!("Hello");
-/// assert_eq!(MY_STRING.to_bytes_with_nul()[5], 0u8);
+/// assert_eq!(MY_STRING.as_bytes_with_nul()[5], 0u8);
 /// let owned: GString = MY_STRING.to_owned();
 /// assert_eq!(MY_STRING, owned);
 /// # }
@@ -273,7 +273,7 @@ impl AsRef<Path> for GStr {
 
 impl AsRef<[u8]> for GStr {
     fn as_ref(&self) -> &[u8] {
-        self.to_bytes()
+        self.as_bytes()
     }
 }
 

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -238,8 +238,10 @@ impl GStr {
 
     #[doc(alias = "g_utf8_collate")]
     #[doc(alias = "utf8_collate")]
-    pub fn collate(&self, other: impl AsRef<GStr>) -> Ordering {
-        unsafe { ffi::g_utf8_collate(self.as_ptr(), other.as_ref().as_ptr()) }.cmp(&0)
+    pub fn collate(&self, other: impl IntoGStr) -> Ordering {
+        other.run_with_gstr(|other| {
+            unsafe { ffi::g_utf8_collate(self.to_glib_none().0, other.to_glib_none().0) }.cmp(&0)
+        })
     }
 
     fn check_nuls(s: impl AsRef<[u8]>) -> Result<(), GStrError> {

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -165,6 +165,13 @@ impl Default for &GStr {
     }
 }
 
+impl fmt::Display for GStr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl<'a> TryFrom<&'a CStr> for &'a GStr {
     type Error = std::str::Utf8Error;
     #[inline]

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -138,7 +138,7 @@ pub use self::source::*;
 #[macro_use]
 pub mod translate;
 mod gstring;
-pub use self::gstring::{GStr, GString};
+pub use self::gstring::*;
 mod gstring_builder;
 pub use self::gstring_builder::GStringBuilder;
 pub mod types;


### PR DESCRIPTION
Update: See comment https://github.com/gtk-rs/gtk-rs-core/pull/600#issuecomment-1302872708 for the general status of this PR. 

Original comment: All of these `TryFrom` are panicking when they don't really need to. This is probably going to break some other things, I'd like to check this against gtk-rs and gstreamer-rs at least. Another option is to leave the panicking `From` traits in and also support `TryFrom`.

Also makes `GString` deref as a `GStr`