### PR TITLE
impl FromStr for VariantType

### DIFF
--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -11,6 +11,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::ptr;
 use std::slice;
+use std::str::FromStr;
 
 // rustdoc-stripper-ignore-next
 /// Describes `Variant` types.
@@ -149,6 +150,14 @@ impl fmt::Debug for VariantType {
 impl fmt::Display for VariantType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for VariantType {
+    type Err = BoolError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
     }
 }
 

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -542,7 +542,7 @@ impl VariantTy {
     ///
     /// # Panics
     ///
-    /// This function panics if not called with an array or dictionary type.
+    /// This function panics if not called with a tuple or dictionary entry type.
     #[doc(alias = "g_variant_type_first")]
     pub fn first(&self) -> Option<&VariantTy> {
         assert!(self.as_str().starts_with('(') || self.as_str().starts_with('{'));
@@ -583,7 +583,7 @@ impl VariantTy {
     ///
     /// # Panics
     ///
-    /// This function panics if not called with an dictionary type.
+    /// This function panics if not called with a dictionary entry type.
     #[doc(alias = "g_variant_type_key")]
     pub fn key(&self) -> &VariantTy {
         assert!(self.as_str().starts_with('{'));
@@ -599,7 +599,7 @@ impl VariantTy {
     ///
     /// # Panics
     ///
-    /// This function panics if not called with an dictionary type.
+    /// This function panics if not called with a dictionary entry type.
     #[doc(alias = "g_variant_type_value")]
     pub fn value(&self) -> &VariantTy {
         assert!(self.as_str().starts_with('{'));


### PR DESCRIPTION
It already impl's `Display` and has a `new` constructor that parses the type description string, seems like a perfect fit!

Doc fixes also included because some of the fn descriptions were wrong.