### PR TITLE
glib: VariantTy tuple type iterator

### DIFF
--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -46,7 +46,7 @@ pub use self::variant::{
 };
 pub use self::variant_dict::VariantDict;
 pub use self::variant_iter::{VariantIter, VariantStrIter};
-pub use self::variant_type::{VariantTy, VariantType};
+pub use self::variant_type::{VariantTy, VariantTyIterator, VariantType};
 
 pub mod clone;
 #[macro_use]


### PR DESCRIPTION
Provide an Iterator over `VariantTy::first` and `VariantTy::next`.

It's a trivial implementation, but using the methods manually is silly and annoying.