### PR TITLE
glib: Don't serialize 0 value flags as variants

### DIFF
--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -432,6 +432,7 @@ fn derive_variant() {
     #[variant_enum(flags)]
     #[glib::flags(name = "Variant10")]
     enum Variant10 {
+        EMPTY = 0,
         #[flags_value(name = "Flag A", nick = "nick-a")]
         A = 0b00000001,
         #[flags_value(name = "Flag B")]

--- a/glib/src/enums.rs
+++ b/glib/src/enums.rs
@@ -602,7 +602,7 @@ impl FlagsClass {
         let mut s = String::new();
         for val in self.values() {
             let v = val.value();
-            if (value & v) == v {
+            if v != 0 && (value & v) == v {
                 value &= !v;
                 if !s.is_empty() {
                     s.push('|');


### PR DESCRIPTION
Also to skip things like `G_APPLICATION_FLAGS_NONE`, etc