### PR TITLE
gdk_pixbuf: Improve `Pixbuf::pixels` documentation

### DIFF
--- a/gdk-pixbuf/Gir.toml
+++ b/gdk-pixbuf/Gir.toml
@@ -39,6 +39,8 @@ status = "generate"
     name = "get_pixels"
     #manual array without length
     manual = true
+    # docs were manually written to include a section on safety
+    generate_doc = false
     [[object.function]]
     name = "get_pixels_with_length"
     #manual as get_pixels

--- a/gdk-pixbuf/src/pixbuf.rs
+++ b/gdk-pixbuf/src/pixbuf.rs
@@ -306,6 +306,19 @@ impl Pixbuf {
         }))
     }
 
+    // rustdoc-stripper-ignore-next
+    /// Returns a mutable slice to the pixbuf's pixel data.
+    ///
+    /// This function will cause an implicit copy if the pixbuf was created from read-only data.
+    ///
+    /// Please see the section on [image data](#image-data) for information about how the pixel
+    /// data is stored in memory.
+    ///
+    /// # Safety
+    /// No other reference to this pixbuf's data must exist when this method is called.
+    ///
+    /// Until you drop the returned reference, you must not call any methods on the pixbuf which may read
+    /// or write to the data.
     #[allow(clippy::mut_from_ref)]
     #[allow(clippy::missing_safety_doc)]
     #[doc(alias = "gdk_pixbuf_get_pixels_with_length")]


### PR DESCRIPTION
This patch adds a section detailing the safety invariant one must hold
while using `Pixbuf::pixels` and also fixes a broken link.

---

Marking as draft as it depends on gtk-rs/gir#1341