### PR TITLE
glib: Fix `mkdtemp()` and `mkdtemp_full()`

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -232,7 +232,16 @@ status = "generate"
     manual = true
     [[object.function]]
     name = "mkstemp"
-    #manual is_windows_utf8
+    #manual is_windows_utf8 and also modifies the string passed in
+    manual = true
+    [[object.function]]
+    name = "mkstemp_full"
+    # modifies the string passed in
+    manual = true
+    [[object.function]]
+    pattern = "mkdtemp(_full)?"
+    # needs to be transfer full, see
+    # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2596
     manual = true
     [[object.function]]
     name = "strdup"

--- a/glib/src/auto/functions.rs
+++ b/glib/src/auto/functions.rs
@@ -482,21 +482,6 @@ pub fn mkdir_with_parents(pathname: impl AsRef<std::path::Path>, mode: i32) -> i
     unsafe { ffi::g_mkdir_with_parents(pathname.as_ref().to_glib_none().0, mode) }
 }
 
-#[doc(alias = "g_mkdtemp")]
-pub fn mkdtemp(tmpl: impl AsRef<std::path::Path>) -> Option<std::path::PathBuf> {
-    unsafe { from_glib_full(ffi::g_mkdtemp(tmpl.as_ref().to_glib_none().0)) }
-}
-
-#[doc(alias = "g_mkdtemp_full")]
-pub fn mkdtemp_full(tmpl: impl AsRef<std::path::Path>, mode: i32) -> Option<std::path::PathBuf> {
-    unsafe { from_glib_full(ffi::g_mkdtemp_full(tmpl.as_ref().to_glib_none().0, mode)) }
-}
-
-#[doc(alias = "g_mkstemp_full")]
-pub fn mkstemp_full(tmpl: impl AsRef<std::path::Path>, flags: i32, mode: i32) -> i32 {
-    unsafe { ffi::g_mkstemp_full(tmpl.as_ref().to_glib_none().0, flags, mode) }
-}
-
 #[doc(alias = "g_on_error_query")]
 pub fn on_error_query(prg_name: &str) {
     unsafe {

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -663,6 +663,12 @@ impl<'a> ToGlibPtr<'a, *mut c_char> for Path {
         let tmp = path_to_c(self);
         Stash(tmp.as_ptr() as *mut c_char, tmp)
     }
+
+    #[inline]
+    fn to_glib_full(&self) -> *mut c_char {
+        let tmp = path_to_c(self);
+        unsafe { ffi::g_strdup(tmp.as_ptr()) }
+    }
 }
 
 impl<'a> ToGlibPtr<'a, *const c_char> for PathBuf {
@@ -682,6 +688,12 @@ impl<'a> ToGlibPtr<'a, *mut c_char> for PathBuf {
     fn to_glib_none(&'a self) -> Stash<'a, *mut c_char, Self> {
         let tmp = path_to_c(self);
         Stash(tmp.as_ptr() as *mut c_char, tmp)
+    }
+
+    #[inline]
+    fn to_glib_full(&self) -> *mut c_char {
+        let tmp = path_to_c(self);
+        unsafe { ffi::g_strdup(tmp.as_ptr()) }
     }
 }
 
@@ -711,6 +723,12 @@ impl<'a> ToGlibPtr<'a, *mut c_char> for OsStr {
         let tmp = os_str_to_c(self);
         Stash(tmp.as_ptr() as *mut c_char, tmp)
     }
+
+    #[inline]
+    fn to_glib_full(&self) -> *mut c_char {
+        let tmp = os_str_to_c(self);
+        unsafe { ffi::g_strdup(tmp.as_ptr()) }
+    }
 }
 
 impl<'a> ToGlibPtr<'a, *const c_char> for OsString {
@@ -730,6 +748,12 @@ impl<'a> ToGlibPtr<'a, *mut c_char> for OsString {
     fn to_glib_none(&'a self) -> Stash<'a, *mut c_char, Self> {
         let tmp = os_str_to_c(self);
         Stash(tmp.as_ptr() as *mut c_char, tmp)
+    }
+
+    #[inline]
+    fn to_glib_full(&self) -> *mut c_char {
+        let tmp = os_str_to_c(self);
+        unsafe { ffi::g_strdup(tmp.as_ptr()) }
     }
 }
 


### PR DESCRIPTION
These functions modify the passed in string in-place and either return it directly or return `NULL`. This kind of behaviour can only be handled manually.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/628
