### PR TITLE
glib: WatchedObject improvements

### DIFF
--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -652,4 +652,48 @@ fn closure() {
         };
         cast_test.invoke::<()>(&[]);
     }
+
+    {
+        use glib::subclass::prelude::*;
+
+        #[derive(Default)]
+        pub struct SendObjectPrivate {
+            value: std::sync::Mutex<i32>,
+        }
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for SendObjectPrivate {
+            const NAME: &'static str = "SendObject";
+            type Type = SendObject;
+        }
+
+        impl ObjectImpl for SendObjectPrivate {}
+
+        glib::wrapper! {
+            pub struct SendObject(ObjectSubclass<SendObjectPrivate>);
+        }
+        impl SendObject {
+            fn value(&self) -> i32 {
+                *self.imp().value.lock().unwrap()
+            }
+            fn set_value(&self, v: i32) {
+                *self.imp().value.lock().unwrap() = v;
+            }
+        }
+
+        let inc_by = {
+            let obj = glib::Object::new::<SendObject>(&[]).unwrap();
+            let inc_by = glib::closure!(@watch obj => move |x: i32| {
+                let old = obj.value();
+                obj.set_value(x + old);
+                old
+            });
+            obj.set_value(42);
+            assert_eq!(obj.value(), 42);
+            assert_eq!(inc_by.invoke::<i32>(&[&24i32]), 42);
+            assert_eq!(obj.value(), 66);
+            inc_by
+        };
+        inc_by.invoke::<()>(&[]);
+    }
 }

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -3286,6 +3286,11 @@ impl<T: ObjectType> WatchedObject<T> {
     pub fn new(obj: &T) -> Self {
         Self(unsafe { ptr::NonNull::new_unchecked(obj.as_ptr()) })
     }
+    // rustdoc-stripper-ignore-next
+    /// # Safety
+    ///
+    /// This should only be called from within a closure that was previously attached to `T` using
+    /// `Watchable::watch_closure`.
     pub unsafe fn borrow(&self) -> Borrowed<T>
     where
         T: FromGlibPtrBorrow<*mut <T as ObjectType>::GlibType>,

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -3282,6 +3282,9 @@ pub struct WatchedObject<T: ObjectType>(ptr::NonNull<T::GlibType>);
 unsafe impl<T: ObjectType + Send + Sync> Send for WatchedObject<T> {}
 
 #[doc(hidden)]
+unsafe impl<T: ObjectType + Send + Sync> Sync for WatchedObject<T> {}
+
+#[doc(hidden)]
 impl<T: ObjectType> WatchedObject<T> {
     pub fn new(obj: &T) -> Self {
         Self(unsafe { ptr::NonNull::new_unchecked(obj.as_ptr()) })


### PR DESCRIPTION
Adds support for watching a `Sync` object, adds a test for that, and adds safety docs as per #646