### PR TITLE
gio: add AsyncInitable subclassing support

### DIFF
--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -41,6 +41,7 @@ once_cell = "1.0"
 futures-core = { version = "0.3", default-features = false }
 futures-channel = "0.3"
 futures-io = "0.3"
+futures-util = { version = "0.3", default-features = false }
 ffi = { package = "gio-sys", path = "sys" }
 glib = { path = "../glib" }
 thiserror = "1"

--- a/gio/src/async_initable.rs
+++ b/gio/src/async_initable.rs
@@ -119,4 +119,62 @@ impl AsyncInitable {
             },
         ))
     }
+
+    #[doc(alias = "g_async_initable_new_async")]
+    pub fn with_values<P: IsA<Cancellable>, Q: FnOnce(Result<Object, InitableError>) + 'static>(
+        type_: Type,
+        properties: &[(&str, glib::Value)],
+        io_priority: glib::Priority,
+        cancellable: Option<&P>,
+        callback: Q,
+    ) {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            return callback(Err(InitableError::NewObjectFailed(glib::bool_error!(
+                "Type '{}' is not async initable",
+                type_
+            ))));
+        }
+        let obj = match Object::with_values(type_, properties) {
+            Ok(obj) => obj,
+            Err(e) => return callback(Err(e.into())),
+        };
+        unsafe {
+            obj.unsafe_cast_ref::<Self>().init_async(
+                io_priority,
+                cancellable,
+                glib::clone!(@strong obj => move |res| {
+                    callback(res.map(|_| obj).map_err(|e| e.into()));
+                }),
+            )
+        };
+    }
+
+    #[doc(alias = "g_async_initable_new_async")]
+    pub fn with_values_future(
+        type_: Type,
+        properties: &[(&str, glib::Value)],
+        io_priority: glib::Priority,
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<Object, InitableError>> + 'static>> {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            return Box::pin(future::ready(Err(InitableError::NewObjectFailed(
+                glib::bool_error!("Type '{}' is not async initable", type_),
+            ))));
+        }
+        let obj = match Object::with_values(type_, properties) {
+            Ok(obj) => obj,
+            Err(e) => return Box::pin(future::ready(Err(e.into()))),
+        };
+        Box_::pin(crate::GioFuture::new(
+            &obj,
+            move |obj, cancellable, send| unsafe {
+                obj.unsafe_cast_ref::<Self>().init_async(
+                    io_priority,
+                    Some(cancellable),
+                    glib::clone!(@strong obj => move |res| {
+                        send.resolve(res.map(|_| obj).map_err(|e| e.into()));
+                    }),
+                );
+            },
+        ))
+    }
 }

--- a/gio/src/async_initable.rs
+++ b/gio/src/async_initable.rs
@@ -1,8 +1,10 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::initable::InitableError;
 use crate::traits::AsyncInitableExt;
 use crate::AsyncInitable;
 use crate::Cancellable;
+use futures_util::future;
 use glib::object::IsA;
 use glib::object::IsClass;
 use glib::value::ToValue;
@@ -15,19 +17,24 @@ impl AsyncInitable {
     pub fn new_async<
         O: Sized + IsClass + IsA<Object> + IsA<AsyncInitable>,
         P: IsA<Cancellable>,
-        Q: FnOnce(Result<O, glib::Error>) + 'static,
+        Q: FnOnce(Result<O, InitableError>) + 'static,
     >(
         properties: &[(&str, &dyn ToValue)],
         io_priority: glib::Priority,
         cancellable: Option<&P>,
         callback: Q,
     ) {
-        let obj = Object::new::<O>(properties).unwrap();
+        let obj = match Object::new::<O>(properties) {
+            Ok(obj) => obj,
+            Err(e) => return callback(Err(e.into())),
+        };
         unsafe {
             obj.init_async(
                 io_priority,
                 cancellable,
-                glib::clone!(@strong obj => move |res| callback(res.map(|_| obj))),
+                glib::clone!(@strong obj => move |res| {
+                    callback(res.map(|_| obj).map_err(|e| e.into()));
+                }),
             );
         }
     }
@@ -36,15 +43,19 @@ impl AsyncInitable {
     pub fn new_future<O: Sized + IsClass + IsA<Object> + IsA<AsyncInitable>>(
         properties: &[(&str, &dyn ToValue)],
         io_priority: glib::Priority,
-    ) -> Pin<Box_<dyn std::future::Future<Output = Result<O, glib::Error>> + 'static>> {
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<O, InitableError>> + 'static>> {
+        let obj = match Object::new::<O>(properties) {
+            Ok(obj) => obj,
+            Err(e) => return Box::pin(future::ready(Err(e.into()))),
+        };
         Box_::pin(crate::GioFuture::new(
-            &Object::new::<O>(properties).unwrap(),
+            &obj,
             move |obj, cancellable, send| unsafe {
                 obj.init_async(
                     io_priority,
                     Some(cancellable),
                     glib::clone!(@strong obj => move |res| {
-                        send.resolve(res.map(|_| obj));
+                        send.resolve(res.map(|_| obj).map_err(|e| e.into()));
                     }),
                 );
             },
@@ -52,20 +63,30 @@ impl AsyncInitable {
     }
 
     #[doc(alias = "g_async_initable_new_async")]
-    pub fn with_type<P: IsA<Cancellable>, Q: FnOnce(Result<Object, glib::Error>) + 'static>(
+    pub fn with_type<P: IsA<Cancellable>, Q: FnOnce(Result<Object, InitableError>) + 'static>(
         type_: Type,
         properties: &[(&str, &dyn ToValue)],
         io_priority: glib::Priority,
         cancellable: Option<&P>,
         callback: Q,
     ) {
-        assert!(type_.is_a(AsyncInitable::static_type()));
-        let obj = Object::with_type(type_, properties).unwrap();
+        if !type_.is_a(AsyncInitable::static_type()) {
+            return callback(Err(InitableError::NewObjectFailed(glib::bool_error!(
+                "Type '{}' is not async initable",
+                type_
+            ))));
+        }
+        let obj = match Object::with_type(type_, properties) {
+            Ok(obj) => obj,
+            Err(e) => return callback(Err(e.into())),
+        };
         unsafe {
             obj.unsafe_cast_ref::<Self>().init_async(
                 io_priority,
                 cancellable,
-                glib::clone!(@strong obj => move |res| callback(res.map(|_| obj))),
+                glib::clone!(@strong obj => move |res| {
+                    callback(res.map(|_| obj).map_err(|e| e.into()));
+                }),
             )
         };
     }
@@ -75,16 +96,24 @@ impl AsyncInitable {
         type_: Type,
         properties: &[(&str, &dyn ToValue)],
         io_priority: glib::Priority,
-    ) -> Pin<Box_<dyn std::future::Future<Output = Result<Object, glib::Error>> + 'static>> {
-        assert!(type_.is_a(AsyncInitable::static_type()));
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<Object, InitableError>> + 'static>> {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            return Box::pin(future::ready(Err(InitableError::NewObjectFailed(
+                glib::bool_error!("Type '{}' is not async initable", type_),
+            ))));
+        }
+        let obj = match Object::with_type(type_, properties) {
+            Ok(obj) => obj,
+            Err(e) => return Box::pin(future::ready(Err(e.into()))),
+        };
         Box_::pin(crate::GioFuture::new(
-            &Object::with_type(type_, properties).unwrap(),
+            &obj,
             move |obj, cancellable, send| unsafe {
                 obj.unsafe_cast_ref::<Self>().init_async(
                     io_priority,
                     Some(cancellable),
                     glib::clone!(@strong obj => move |res| {
-                        send.resolve(res.map(|_| obj));
+                        send.resolve(res.map(|_| obj).map_err(|e| e.into()));
                     }),
                 );
             },

--- a/gio/src/initable.rs
+++ b/gio/src/initable.rs
@@ -44,6 +44,27 @@ impl Initable {
         unsafe { object.unsafe_cast_ref::<Self>().init(cancellable)? };
         Ok(object)
     }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an initable object of the given type with the given properties.
+    ///
+    /// Similar to [`Object::with_values`] but can fail either because the object
+    /// creation failed or because `Initable::init` failed.
+    pub fn with_values(
+        type_: Type,
+        properties: &[(&str, glib::Value)],
+        cancellable: Option<&impl IsA<Cancellable>>,
+    ) -> Result<Object, InitableError> {
+        if !type_.is_a(Initable::static_type()) {
+            return Err(InitableError::NewObjectFailed(glib::bool_error!(
+                "Type '{}' is not initable",
+                type_
+            )));
+        }
+        let object = Object::with_values(type_, properties)?;
+        unsafe { object.unsafe_cast_ref::<Self>().init(cancellable)? };
+        Ok(object)
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/gio/src/subclass/async_initable.rs
+++ b/gio/src/subclass/async_initable.rs
@@ -321,6 +321,22 @@ mod tests {
     }
 
     #[test]
+    fn test_async_initable_with_async_initable_with_values() {
+        glib::MainContext::new().block_on(async {
+            let test = AsyncInitable::with_values_future(
+                AsyncInitableTestType::static_type(),
+                &[],
+                glib::PRIORITY_DEFAULT,
+            )
+            .await
+            .expect("Failed creation/initialization of AsyncInitableTestType object from values")
+            .downcast::<AsyncInitableTestType>()
+            .expect("Failed downcast of AsyncInitableTestType object");
+            assert_eq!(0x123456789abcdef, test.value());
+        });
+    }
+
+    #[test]
     fn test_async_initable_through_ffi() {
         use futures_channel::oneshot;
 

--- a/gio/src/subclass/async_initable.rs
+++ b/gio/src/subclass/async_initable.rs
@@ -1,0 +1,379 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::object::Cast;
+use glib::thread_guard::ThreadGuard;
+use glib::translate::*;
+use glib::Error;
+
+use glib::subclass::prelude::*;
+
+use std::ptr;
+
+use crate::prelude::CancellableExt;
+use crate::prelude::CancellableExtManual;
+use crate::AsyncInitable;
+use crate::AsyncResult;
+use crate::Cancellable;
+use crate::GioFutureResult;
+use crate::LocalTask;
+
+use std::{future::Future, pin::Pin};
+
+pub trait AsyncInitableImpl: ObjectImpl {
+    fn init_future(
+        &self,
+        initable: &Self::Type,
+        io_priority: glib::Priority,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>> {
+        self.parent_init_future(initable, io_priority)
+    }
+}
+
+pub trait AsyncInitableImplExt: ObjectSubclass {
+    fn parent_init_future(
+        &self,
+        initable: &Self::Type,
+        io_priority: glib::Priority,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>>;
+}
+
+impl<T: AsyncInitableImpl> AsyncInitableImplExt for T {
+    fn parent_init_future(
+        &self,
+        initable: &Self::Type,
+        io_priority: glib::Priority,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>> {
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface = type_data.as_ref().parent_interface::<AsyncInitable>()
+                as *const ffi::GAsyncInitableIface;
+
+            let init_async = (*parent_iface)
+                .init_async
+                .expect("no parent \"init_async\" implementation");
+
+            unsafe extern "C" fn parent_init_future_callback<T>(
+                source_object: *mut glib::gobject_ffi::GObject,
+                res: *mut crate::ffi::GAsyncResult,
+                user_data: glib::ffi::gpointer,
+            ) where
+                T: AsyncInitableImpl,
+            {
+                let type_data = T::type_data();
+                let parent_iface = type_data.as_ref().parent_interface::<AsyncInitable>()
+                    as *const ffi::GAsyncInitableIface;
+                let init_finish = (*parent_iface)
+                    .init_finish
+                    .expect("no parent \"init_finish\" implementation");
+
+                let r: Box<ThreadGuard<GioFutureResult<(), Error>>> =
+                    Box::from_raw(user_data as *mut _);
+                let r = r.into_inner();
+
+                let mut error = ptr::null_mut();
+                init_finish(source_object as *mut _, res, &mut error);
+                let result = if error.is_null() {
+                    Ok(())
+                } else {
+                    Err(from_glib_full(error))
+                };
+                r.resolve(result);
+            }
+
+            Box::pin(crate::GioFuture::new(
+                initable,
+                move |obj, cancellable, res| {
+                    let user_data: Box<ThreadGuard<GioFutureResult<(), Error>>> =
+                        Box::new(ThreadGuard::new(res));
+                    let user_data = Box::into_raw(user_data);
+                    init_async(
+                        obj.unsafe_cast_ref::<AsyncInitable>().to_glib_none().0,
+                        io_priority.into_glib(),
+                        cancellable.to_glib_none().0,
+                        Some(parent_init_future_callback::<T>),
+                        user_data as *mut _,
+                    );
+                },
+            ))
+        }
+    }
+}
+
+unsafe impl<T: AsyncInitableImpl> IsImplementable<T> for AsyncInitable {
+    fn interface_init(iface: &mut glib::Interface<Self>) {
+        let iface = iface.as_mut();
+        iface.init_async = Some(async_initable_init_async::<T>);
+        iface.init_finish = Some(async_initable_init_finish::<T>);
+    }
+}
+
+unsafe extern "C" fn async_initable_init_async<T: AsyncInitableImpl>(
+    initable: *mut ffi::GAsyncInitable,
+    io_priority: std::os::raw::c_int,
+    cancellable: *mut ffi::GCancellable,
+    callback: ffi::GAsyncReadyCallback,
+    user_data: glib::ffi::gpointer,
+) {
+    let instance = &*(initable as *mut T::Instance);
+    let imp = instance.imp();
+    let initable = from_glib_borrow::<_, AsyncInitable>(initable);
+    let cancellable = from_glib_borrow::<_, Option<Cancellable>>(cancellable);
+
+    let task = callback.map(|callback| {
+        let task = LocalTask::new(
+            Some(initable.upcast_ref::<glib::Object>()),
+            cancellable.as_ref().as_ref(),
+            move |task, obj| {
+                let result: *mut crate::ffi::GAsyncResult =
+                    task.upcast_ref::<AsyncResult>().to_glib_none().0;
+                let obj: *mut glib::object::GObject = obj.to_glib_none().0;
+                callback(obj, result, user_data);
+            },
+        );
+        task.set_check_cancellable(true);
+        task.set_return_on_cancel(true);
+        task
+    });
+
+    glib::MainContext::ref_thread_default().spawn_local(async move {
+        let initable = initable.unsafe_cast_ref();
+        let io_priority = from_glib(io_priority);
+        let res = if let Some(cancellable) = cancellable.as_ref() {
+            futures_util::future::select(
+                imp.init_future(initable, io_priority),
+                Box::pin(async {
+                    cancellable.future().await;
+                    cancellable.set_error_if_cancelled()
+                }),
+            )
+            .await
+            .factor_first()
+            .0
+        } else {
+            imp.init_future(initable, io_priority).await
+        };
+        if let Some(task) = task {
+            task.return_result(res.map(|_t| true));
+        }
+    });
+}
+
+unsafe extern "C" fn async_initable_init_finish<T: AsyncInitableImpl>(
+    initable: *mut ffi::GAsyncInitable,
+    res: *mut ffi::GAsyncResult,
+    error: *mut *mut glib::ffi::GError,
+) -> glib::ffi::gboolean {
+    let initable = from_glib_borrow::<_, AsyncInitable>(initable);
+    let res = from_glib_none::<_, AsyncResult>(res);
+
+    let task = res
+        .downcast::<LocalTask<bool>>()
+        .expect("GAsyncResult is not a GTask");
+    if !LocalTask::<bool>::is_valid(&task, Some(initable.as_ref())) {
+        panic!("Task is not valid for source object");
+    }
+
+    match task.propagate() {
+        Ok(v) => {
+            assert!(v);
+            true.into_glib()
+        }
+        Err(e) => {
+            if !error.is_null() {
+                *error = e.into_glib_ptr();
+            }
+            false.into_glib()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+    use crate::traits::AsyncInitableExt;
+
+    pub mod imp {
+        use super::*;
+        use crate::AsyncInitable;
+        use std::cell::Cell;
+
+        pub struct AsyncInitableTestType(pub Cell<u64>);
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for AsyncInitableTestType {
+            const NAME: &'static str = "AsyncInitableTestType";
+            type Type = super::AsyncInitableTestType;
+            type Interfaces = (AsyncInitable,);
+
+            fn new() -> Self {
+                Self(Cell::new(0))
+            }
+        }
+
+        impl AsyncInitableImpl for AsyncInitableTestType {
+            fn init_future(
+                &self,
+                initable: &Self::Type,
+                _io_priority: glib::Priority,
+            ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + 'static>> {
+                let initable = initable.clone();
+                Box::pin(async move {
+                    glib::timeout_future_seconds(0).await;
+                    initable.imp().0.set(0x123456789abcdef);
+                    Ok(())
+                })
+            }
+        }
+
+        impl ObjectImpl for AsyncInitableTestType {}
+    }
+
+    pub mod ffi {
+        use super::*;
+        pub type AsyncInitableTestType = <imp::AsyncInitableTestType as ObjectSubclass>::Instance;
+
+        pub unsafe extern "C" fn async_initable_test_type_get_value(
+            this: *mut AsyncInitableTestType,
+        ) -> u64 {
+            let this = super::AsyncInitableTestType::from_glib_borrow(this);
+            this.imp().0.get()
+        }
+    }
+
+    glib::wrapper! {
+        pub struct AsyncInitableTestType(ObjectSubclass<imp::AsyncInitableTestType>)
+            @implements AsyncInitable;
+    }
+
+    #[allow(clippy::new_without_default)]
+    impl AsyncInitableTestType {
+        pub async fn new() -> Self {
+            AsyncInitable::new_future(&[], glib::PRIORITY_DEFAULT)
+                .await
+                .expect("Failed creation/initialization of AsyncInitableTestType object")
+        }
+
+        pub fn new_uninit() -> Self {
+            // This creates an uninitialized AsyncInitableTestType object, for testing
+            // purposes. In real code, using AsyncInitable::new_future (like the new() method
+            // does) is recommended.
+            glib::Object::new(&[]).expect("Failed creation of AsyncInitableTestType object")
+        }
+
+        pub fn value(&self) -> u64 {
+            self.imp().0.get()
+        }
+    }
+
+    #[test]
+    fn test_async_initable_with_init() {
+        glib::MainContext::new().block_on(async {
+            let test = AsyncInitableTestType::new_uninit();
+
+            assert_ne!(0x123456789abcdef, test.value());
+
+            let result = unsafe { test.init_future(glib::PRIORITY_DEFAULT) }.await;
+            assert!(result.is_ok());
+
+            assert_eq!(0x123456789abcdef, test.value());
+        });
+    }
+
+    #[test]
+    fn test_async_initable_with_initable_new() {
+        glib::MainContext::new().block_on(async {
+            let test = AsyncInitableTestType::new().await;
+            assert_eq!(0x123456789abcdef, test.value());
+        });
+    }
+
+    #[test]
+    fn test_async_initable_new_failure() {
+        glib::MainContext::new().block_on(async {
+            let value: u32 = 2;
+            match AsyncInitable::new_future::<AsyncInitableTestType>(
+                &[("invalid-property", &value)],
+                glib::PRIORITY_DEFAULT,
+            )
+            .await
+            {
+                Err(InitableError::NewObjectFailed(_)) => (),
+                v => panic!("expected InitableError::NewObjectFailed, got {:?}", v),
+            }
+        });
+    }
+
+    #[test]
+    fn test_async_initable_with_initable_with_type() {
+        glib::MainContext::new().block_on(async {
+            let test = AsyncInitable::with_type_future(
+                AsyncInitableTestType::static_type(),
+                &[],
+                glib::PRIORITY_DEFAULT,
+            )
+            .await
+            .expect("Failed creation/initialization of AsyncInitableTestType object from type")
+            .downcast::<AsyncInitableTestType>()
+            .expect("Failed downcast of AsyncInitableTestType object");
+            assert_eq!(0x123456789abcdef, test.value());
+        });
+    }
+
+    #[test]
+    fn test_async_initable_through_ffi() {
+        use futures_channel::oneshot;
+
+        glib::MainContext::new().block_on(async {
+            unsafe {
+                let test = AsyncInitableTestType::new_uninit();
+                let test: *mut ffi::AsyncInitableTestType = test.as_ptr();
+
+                assert_ne!(
+                    0x123456789abcdef,
+                    ffi::async_initable_test_type_get_value(test)
+                );
+
+                let (tx, rx) = oneshot::channel::<Result<(), glib::Error>>();
+                let user_data = Box::new(ThreadGuard::new(tx));
+                unsafe extern "C" fn init_async_callback(
+                    source_object: *mut glib::gobject_ffi::GObject,
+                    res: *mut crate::ffi::GAsyncResult,
+                    user_data: glib::ffi::gpointer,
+                ) {
+                    let tx: Box<ThreadGuard<oneshot::Sender<Result<(), glib::Error>>>> =
+                        Box::from_raw(user_data as *mut _);
+                    let tx = tx.into_inner();
+                    let mut error = ptr::null_mut();
+                    let ret = crate::ffi::g_async_initable_init_finish(
+                        source_object as *mut _,
+                        res,
+                        &mut error,
+                    );
+                    assert_eq!(ret, glib::ffi::GTRUE);
+                    let result = if error.is_null() {
+                        Ok(())
+                    } else {
+                        Err(from_glib_full(error))
+                    };
+                    tx.send(result).unwrap();
+                }
+
+                crate::ffi::g_async_initable_init_async(
+                    test as *mut crate::ffi::GAsyncInitable,
+                    glib::ffi::G_PRIORITY_DEFAULT,
+                    std::ptr::null_mut(),
+                    Some(init_async_callback),
+                    Box::into_raw(user_data) as *mut _,
+                );
+
+                let result = rx.await.unwrap();
+                assert!(result.is_ok());
+                assert_eq!(
+                    0x123456789abcdef,
+                    ffi::async_initable_test_type_get_value(test)
+                );
+            }
+        });
+    }
+}

--- a/gio/src/subclass/initable.rs
+++ b/gio/src/subclass/initable.rs
@@ -209,6 +209,19 @@ mod tests {
     }
 
     #[test]
+    fn test_initable_with_initable_with_values() {
+        let test = Initable::with_values(
+            InitableTestType::static_type(),
+            &[],
+            Option::<&Cancellable>::None,
+        )
+        .expect("Failed creation/initialization of InitableTestType object from values")
+        .downcast::<InitableTestType>()
+        .expect("Failed downcast of InitableTestType object");
+        assert_eq!(0x123456789abcdef, test.value());
+    }
+
+    #[test]
     fn test_initable_through_ffi() {
         unsafe {
             let test = InitableTestType::new_uninit();

--- a/gio/src/subclass/initable.rs
+++ b/gio/src/subclass/initable.rs
@@ -131,12 +131,6 @@ mod tests {
         use super::*;
         pub type InitableTestType = <imp::InitableTestType as ObjectSubclass>::Instance;
 
-        #[no_mangle]
-        pub unsafe extern "C" fn initable_test_type_get_type() -> glib::ffi::GType {
-            imp::InitableTestType::type_().into_glib()
-        }
-
-        #[no_mangle]
         pub unsafe extern "C" fn initable_test_type_get_value(this: *mut InitableTestType) -> u64 {
             let this = super::InitableTestType::from_glib_borrow(this);
             this.imp().0.get()

--- a/gio/src/subclass/initable.rs
+++ b/gio/src/subclass/initable.rs
@@ -12,7 +12,9 @@ use crate::Cancellable;
 use crate::Initable;
 
 pub trait InitableImpl: ObjectImpl {
-    fn init(&self, initable: &Self::Type, cancellable: Option<&Cancellable>) -> Result<(), Error>;
+    fn init(&self, initable: &Self::Type, cancellable: Option<&Cancellable>) -> Result<(), Error> {
+        self.parent_init(initable, cancellable)
+    }
 }
 
 pub trait InitableImplExt: ObjectSubclass {

--- a/gio/src/subclass/mod.rs
+++ b/gio/src/subclass/mod.rs
@@ -3,6 +3,7 @@
 mod action_group;
 mod action_map;
 mod application;
+mod async_initable;
 mod initable;
 mod input_stream;
 mod io_stream;
@@ -19,6 +20,7 @@ pub mod prelude {
     pub use super::action_group::{ActionGroupImpl, ActionGroupImplExt};
     pub use super::action_map::{ActionMapImpl, ActionMapImplExt};
     pub use super::application::{ApplicationImpl, ApplicationImplExt};
+    pub use super::async_initable::{AsyncInitableImpl, AsyncInitableImplExt};
     pub use super::initable::{InitableImpl, InitableImplExt};
     pub use super::input_stream::{InputStreamImpl, InputStreamImplExt};
     pub use super::io_stream::{IOStreamImpl, IOStreamImplExt};


### PR DESCRIPTION
Fixes #22

Questions:

- Is it worth having both `init_async` and `init_future`? I think it would be fine with just `init_future`
- I made a lightweight alternative to `LocalTask` that only stores the object and the return value, not sure if it makes sense? If it does, should we try to make it public and use it in other places like here? [content_provider.rs#L391-L395](https://github.com/gtk-rs/gtk4-rs/blob/master/gdk4/src/subclass/content_provider.rs#L391-L395)