### PR TITLE
Set properties improvements

### DIFF
--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -2736,10 +2736,6 @@ impl<T: ObjectType> ObjectExt for T {
                     return Some(ret);
                 }
 
-                // If it's not directly a valid type but an object type, we check if the
-                // actual typed of the contained object is compatible and if so create
-                // a properly typed Value. This can happen if the type field in the
-                // Value is set to a more generic type than the contained value
                 if let Err(got) = coerce_object_type(&mut ret, return_type) {
                     panic!(
                         "Signal '{}' of type '{}' required return value of type '{}' but got '{}'",
@@ -3330,10 +3326,6 @@ fn validate_property_type(
             pspec.value_type().into_glib(),
         ));
 
-        // If it's not directly a valid type but an object type, we check if the
-        // actual type of the contained object is compatible and if so create
-        // a properly typed Value. This can happen if the type field in the
-        // Value is set to a more generic type than the contained value
         if !valid_type {
             coerce_object_type(property_value, pspec.value_type())
                 .map_err(|got| {
@@ -3363,6 +3355,11 @@ fn validate_property_type(
     Ok(())
 }
 
+// If it's not directly a valid type but an object type, we check if the
+// actual type of the contained object is compatible and if so create
+// a properly typed Value (by mutating the existing Value).
+// This can happen if the type field in the Value is set to a more
+// generic type than the contained value.
 fn coerce_object_type(
     property_value: &mut Value,
     type_: Type,

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -2739,10 +2739,7 @@ impl<T: ObjectType> ObjectExt for T {
                 if let Err(got) = coerce_object_type(&mut ret, return_type) {
                     panic!(
                         "Signal '{}' of type '{}' required return value of type '{}' but got '{}'",
-                        signal_name,
-                        type_,
-                        return_type,
-                        got
+                        signal_name, type_, return_type, got
                     );
                 };
                 Some(ret)
@@ -3360,10 +3357,7 @@ fn validate_property_type(
 // a properly typed Value (by mutating the existing Value).
 // This can happen if the type field in the Value is set to a more
 // generic type than the contained value.
-fn coerce_object_type(
-    property_value: &mut Value,
-    type_: Type,
-) -> Result<(), Type> {
+fn coerce_object_type(property_value: &mut Value, type_: Type) -> Result<(), Type> {
     // return early if type coercion is not possible
     match property_value.get::<Option<Object>>() {
         Ok(Some(obj)) if !(obj.type_().is_a(type_)) => Err(obj.type_()),
@@ -3397,7 +3391,7 @@ fn validate_signal_arguments(
     for (i, (arg, param_type)) in param_types.enumerate() {
         let param_type: Type = (*param_type).into();
         if param_type != arg.type_() {
-            coerce_object_type(arg, param_type).map_err(|got| 
+            coerce_object_type(arg, param_type).map_err(|got|
                 bool_error!(
                     "Incompatible argument type in argument {} for signal '{}' of type '{}' (expected {}, got {})",
                     i,

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -2263,16 +2263,13 @@ impl<T: ObjectType> ObjectExt for T {
     }
 
     fn try_set_property<V: ToValue>(&self, property_name: &str, value: V) -> Result<(), BoolError> {
-        let pspec = match self.find_property(property_name) {
-            Some(pspec) => pspec,
-            None => {
-                return Err(bool_error!(
-                    "property '{}' of type '{}' not found",
-                    property_name,
-                    self.type_()
-                ));
-            }
-        };
+        let pspec = self.find_property(property_name).ok_or_else(|| {
+            bool_error!(
+                "property '{}' of type '{}' not found",
+                property_name,
+                self.type_()
+            )
+        })?;
 
         let mut property_value = value.to_value();
         validate_property_type(self.type_(), false, &pspec, &mut property_value)?;
@@ -2413,16 +2410,13 @@ impl<T: ObjectType> ObjectExt for T {
     }
 
     fn try_property_value(&self, property_name: &str) -> Result<Value, BoolError> {
-        let pspec = match self.find_property(property_name) {
-            Some(pspec) => pspec,
-            None => {
-                return Err(bool_error!(
-                    "property '{}' of type '{}' not found",
-                    property_name,
-                    self.type_()
-                ));
-            }
-        };
+        let pspec = self.find_property(property_name).ok_or_else(|| {
+            bool_error!(
+                "property '{}' of type '{}' not found",
+                property_name,
+                self.type_()
+            )
+        })?;
 
         if !pspec.flags().contains(crate::ParamFlags::READABLE) {
             return Err(bool_error!(

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -552,7 +552,7 @@ mod test {
                 .err()
                 .expect("Failed to set 'child' property")
                 .to_string(),
-            "property 'child' of type 'SimpleObject' can't be set from the given object type (expected: 'ChildObject', got: 'SimpleObject')",
+            "property 'child' of type 'SimpleObject' can't be set from the given type (expected: 'ChildObject', got: 'SimpleObject')",
         );
 
         let child = Object::with_type(ChildObject::static_type(), &[]).expect("Object::new failed");


### PR DESCRIPTION
Some refactoring to improve code consistency and readability. Had to change an error message slightly (removed one word, "object"), but I don't think that's a problem because in other places that word wasn't used anyway. It's just more consistent now.