### PR TITLE
Bump dockerfile to ubuntu 22.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.10
+FROM ubuntu:22.04
 
 RUN apt update -y
 RUN apt install -y \


### PR DESCRIPTION
Ubuntu 20.10 is EOL: https://lists.ubuntu.com/archives/ubuntu-announce/2021-July/000270.html