### PR TITLE
Port Dockerfile to fedora rawhide and use system deps from git

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -8,15 +8,18 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          push: true
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
-          repository: ${{ github.repository }}/core
-          tags: latest
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          allow: security.insecure
+          tags: ${{ github.repository }}/core:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,33 @@
-FROM ubuntu:20.10
+FROM fedora:rawhide
 
-RUN apt update -y
-RUN apt install -y \
-    libgtk-3-dev \
-    libglib2.0-dev \
-    libgraphene-1.0-dev \
-    git \
-    xvfb \
-    curl \
-    libcairo-gobject2 \
-    libcairo2-dev \
-    wget
+RUN dnf update -y && \
+    dnf install wget git meson cmake gcc gcc-c++ \
+    libpng-devel turbojpeg-devel libXext-devel libXrender-devel -y && \
+    dnf clean all -y
+
+RUN git clone https://gitlab.gnome.org/GNOME/glib.git --depth=1 && \
+    (cd /glib && \
+        meson setup builddir --prefix=/usr --buildtype release -Dtests=false && \
+        meson install -C builddir) && \
+    git clone https://gitlab.freedesktop.org/cairo/cairo.git --depth=1 && \
+    (cd /cairo && \
+        meson setup builddir --prefix=/usr --buildtype release -Dglib=enabled -Dtests=disabled && \
+        meson install -C builddir) && \
+    git clone https://github.com/harfbuzz/harfbuzz.git --depth=1 && \
+    (cd /harfbuzz && \
+        meson setup builddir --prefix=/usr --buildtype release -Dintrospection=disabled -Dtests=disabled -Ddocs=disabled && \
+        meson install -C builddir) && \
+    git clone https://gitlab.gnome.org/GNOME/pango.git --depth=1 && \
+    (cd /pango && \
+        meson setup builddir --prefix=/usr --buildtype release -Dfreetype=enabled -Dintrospection=disabled -Dxft=disabled && \
+        meson install -C builddir) && \
+    git clone https://gitlab.gnome.org/GNOME/gdk-pixbuf.git --depth=1 && \
+    (cd /gdk-pixbuf && \
+        meson setup builddir --prefix=/usr --buildtype release -Dintrospection=disabled -Dinstalled_tests=false -Dgio_sniffing=false && \
+        meson install -C builddir) && \
+    git clone https://github.com/ebassi/graphene.git --depth=1 && \
+    (cd /graphene && \
+        meson setup builddir --prefix=/usr --buildtype release -Dintrospection=disabled -Dtests=false -Dinstalled_tests=false && \
+        meson install -C builddir) && \
+    rm -rf /glib /cairo /harfbuzz /pango /gdk-pixbuf /graphene
+


### PR DESCRIPTION
Fixes part of #484

This is not using xlib/xft/rsvg, but we probably need those to build the gtk-rs images later? Or we can leave the gtk-rs images and not base them on this image? The image is already pretty large as-is, around 1.6GB on my system because of all the debug symbols. Another option is to maybe use `--buildtype release`