### PR TITLE
Don't build gdk-pixbuf tests in the docker image

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -15,13 +15,14 @@ jobs:
   docker:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Push to GitHub Packages
-        uses: docker/build-push-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          push: ${{ github.event_name != 'pull_request' }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
-          repository: ${{ github.repository }}/core
-          tags: latest
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v3
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ github.repository }}/core:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone https://gitlab.gnome.org/GNOME/glib.git --depth=1 && \
         meson install -C builddir) && \
     git clone https://gitlab.gnome.org/GNOME/gdk-pixbuf.git --depth=1 && \
     (cd /gdk-pixbuf && \
-        meson setup builddir --prefix=/usr --buildtype release -Dintrospection=disabled -Dinstalled_tests=false -Dgio_sniffing=false && \
+        meson setup builddir --prefix=/usr --buildtype release -Dintrospection=disabled -Dtests=false -Dinstalled_tests=false -Dgio_sniffing=false && \
         meson install -C builddir) && \
     git clone https://github.com/ebassi/graphene.git --depth=1 && \
     (cd /graphene && \


### PR DESCRIPTION
Now that gdk-pixbuf is [updated](https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/132), on my CI it successfully builds to completion and then fails when trying to upload the image, which is expected: https://github.com/jf2048/gtk-rs-core/runs/6414933753?check_suite_focus=true#step:3:12617

Also a few more fixes:

- don't use the checkout action, it's unnecessary because build-push-action also does a checkout
- fixes a [deprecation warning](https://github.com/jf2048/gtk-rs-core/runs/6341505238?check_suite_focus=true#step:4:10) about build-push-action@v1