### PR TITLE
gio: Use guard objects for `Application::hold()` and `mark_busy()`

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -284,6 +284,26 @@ generate_builder = true
     name = "run"
     manual = true
     doc_trait_name = "ApplicationExtManual"
+    [[object.function]]
+    name = "hold"
+    # Returns a value that releases on Drop.
+    manual = true
+    doc_trait_name = "ApplicationExtManual"
+    [[object.function]]
+    name = "release"
+    # Implemented via Drop on ApplicationHoldGuard.
+    manual = true
+    doc_trait_name = "ApplicationExtManual"
+    [[object.function]]
+    name = "mark_busy"
+    manual = true
+    # Returns a value that unmarks-busy on Drop.
+    doc_trait_name = "ApplicationExtManual"
+    [[object.function]]
+    name = "unmark_busy"
+    # Implemented via Drop on ApplicationBusyGuard.
+    manual = true
+    doc_trait_name = "ApplicationExtManual"
 
 [[object]]
 name = "Gio.ApplicationCommandLine"

--- a/gio/src/auto/application.rs
+++ b/gio/src/auto/application.rs
@@ -206,12 +206,6 @@ pub trait ApplicationExt: 'static {
     #[doc(alias = "get_resource_base_path")]
     fn resource_base_path(&self) -> Option<glib::GString>;
 
-    #[doc(alias = "g_application_hold")]
-    fn hold(&self);
-
-    #[doc(alias = "g_application_mark_busy")]
-    fn mark_busy(&self);
-
     #[doc(alias = "g_application_open")]
     fn open(&self, files: &[File], hint: &str);
 
@@ -220,9 +214,6 @@ pub trait ApplicationExt: 'static {
 
     #[doc(alias = "g_application_register")]
     fn register(&self, cancellable: Option<&impl IsA<Cancellable>>) -> Result<(), glib::Error>;
-
-    #[doc(alias = "g_application_release")]
-    fn release(&self);
 
     #[doc(alias = "g_application_send_notification")]
     fn send_notification(&self, id: Option<&str>, notification: &Notification);
@@ -253,9 +244,6 @@ pub trait ApplicationExt: 'static {
 
     #[doc(alias = "g_application_unbind_busy_property")]
     fn unbind_busy_property(&self, object: &impl IsA<glib::Object>, property: &str);
-
-    #[doc(alias = "g_application_unmark_busy")]
-    fn unmark_busy(&self);
 
     #[doc(alias = "g_application_withdraw_notification")]
     fn withdraw_notification(&self, id: &str);
@@ -425,18 +413,6 @@ impl<O: IsA<Application>> ApplicationExt for O {
         }
     }
 
-    fn hold(&self) {
-        unsafe {
-            ffi::g_application_hold(self.as_ref().to_glib_none().0);
-        }
-    }
-
-    fn mark_busy(&self) {
-        unsafe {
-            ffi::g_application_mark_busy(self.as_ref().to_glib_none().0);
-        }
-    }
-
     fn open(&self, files: &[File], hint: &str) {
         let n_files = files.len() as i32;
         unsafe {
@@ -469,12 +445,6 @@ impl<O: IsA<Application>> ApplicationExt for O {
             } else {
                 Err(from_glib_full(error))
             }
-        }
-    }
-
-    fn release(&self) {
-        unsafe {
-            ffi::g_application_release(self.as_ref().to_glib_none().0);
         }
     }
 
@@ -561,12 +531,6 @@ impl<O: IsA<Application>> ApplicationExt for O {
                 object.as_ref().to_glib_none().0,
                 property.to_glib_none().0,
             );
-        }
-    }
-
-    fn unmark_busy(&self) {
-        unsafe {
-            ffi::g_application_unmark_busy(self.as_ref().to_glib_none().0);
         }
     }
 

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -14,6 +14,7 @@ pub use glib;
 
 mod app_info;
 mod application;
+pub use application::{ApplicationBusyGuard, ApplicationHoldGuard};
 mod async_initable;
 mod cancellable;
 mod converter;


### PR DESCRIPTION
These would automatically release/unmark_busy the application once
they're dropped and ensure that the release/unmark_busy operation is
called exactly the number of times the hold/mark_busy operation was
called.