### PR TITLE
SocketAddressEnumerator: `next` return value should be nullable

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -116,7 +116,6 @@ generate = [
     "Gio.SettingsSchemaSource",
     "Gio.SimpleActionGroup",
     "Gio.SimplePermission",
-    "Gio.SocketAddressEnumerator",
     "Gio.SocketClient",
     "Gio.SocketClientEvent",
     "Gio.SocketConnectable",
@@ -1121,6 +1120,24 @@ manual_traits = ["SocketExtManual"]
 name = "Gio.SocketAddress"
 status = "generate"
 concurrency = "send+sync"
+
+[[object]]
+name = "Gio.SocketAddressEnumerator"
+status = "generate"
+    [[object.function]]
+    name = "next"
+        # enforce nullable return value, since a NULL
+        # return value is used to indicate the end of stream.
+        # Glib MR: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2701
+        [object.function.return]
+        nullable = true
+    [[object.function]]
+    name = "next_async"
+        # enforce nullable return value, since a NULL
+        # return value is used to indicate the end of stream.
+        # Glib MR: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2701
+        [object.function.return]
+        nullable = true
 
 [[object]]
 name = "Gio.Subprocess"

--- a/gio/src/auto/socket_address_enumerator.rs
+++ b/gio/src/auto/socket_address_enumerator.rs
@@ -30,10 +30,10 @@ pub trait SocketAddressEnumeratorExt: 'static {
     fn next(
         &self,
         cancellable: Option<&impl IsA<Cancellable>>,
-    ) -> Result<SocketAddress, glib::Error>;
+    ) -> Result<Option<SocketAddress>, glib::Error>;
 
     #[doc(alias = "g_socket_address_enumerator_next_async")]
-    fn next_async<P: FnOnce(Result<SocketAddress, glib::Error>) + 'static>(
+    fn next_async<P: FnOnce(Result<Option<SocketAddress>, glib::Error>) + 'static>(
         &self,
         cancellable: Option<&impl IsA<Cancellable>>,
         callback: P,
@@ -41,14 +41,18 @@ pub trait SocketAddressEnumeratorExt: 'static {
 
     fn next_future(
         &self,
-    ) -> Pin<Box_<dyn std::future::Future<Output = Result<SocketAddress, glib::Error>> + 'static>>;
+    ) -> Pin<
+        Box_<
+            dyn std::future::Future<Output = Result<Option<SocketAddress>, glib::Error>> + 'static,
+        >,
+    >;
 }
 
 impl<O: IsA<SocketAddressEnumerator>> SocketAddressEnumeratorExt for O {
     fn next(
         &self,
         cancellable: Option<&impl IsA<Cancellable>>,
-    ) -> Result<SocketAddress, glib::Error> {
+    ) -> Result<Option<SocketAddress>, glib::Error> {
         unsafe {
             let mut error = ptr::null_mut();
             let ret = ffi::g_socket_address_enumerator_next(
@@ -64,7 +68,7 @@ impl<O: IsA<SocketAddressEnumerator>> SocketAddressEnumeratorExt for O {
         }
     }
 
-    fn next_async<P: FnOnce(Result<SocketAddress, glib::Error>) + 'static>(
+    fn next_async<P: FnOnce(Result<Option<SocketAddress>, glib::Error>) + 'static>(
         &self,
         cancellable: Option<&impl IsA<Cancellable>>,
         callback: P,
@@ -82,7 +86,7 @@ impl<O: IsA<SocketAddressEnumerator>> SocketAddressEnumeratorExt for O {
         let user_data: Box_<glib::thread_guard::ThreadGuard<P>> =
             Box_::new(glib::thread_guard::ThreadGuard::new(callback));
         unsafe extern "C" fn next_async_trampoline<
-            P: FnOnce(Result<SocketAddress, glib::Error>) + 'static,
+            P: FnOnce(Result<Option<SocketAddress>, glib::Error>) + 'static,
         >(
             _source_object: *mut glib::gobject_ffi::GObject,
             res: *mut crate::ffi::GAsyncResult,
@@ -117,8 +121,11 @@ impl<O: IsA<SocketAddressEnumerator>> SocketAddressEnumeratorExt for O {
 
     fn next_future(
         &self,
-    ) -> Pin<Box_<dyn std::future::Future<Output = Result<SocketAddress, glib::Error>> + 'static>>
-    {
+    ) -> Pin<
+        Box_<
+            dyn std::future::Future<Output = Result<Option<SocketAddress>, glib::Error>> + 'static,
+        >,
+    > {
         Box_::pin(crate::GioFuture::new(
             self,
             move |obj, cancellable, send| {


### PR DESCRIPTION
The `next` method (both the sync and async variants) relies on the
pointer being NULL to indicate the end of the address stream.
See also the corresponding MR to add the annotation in the glib source
code:

https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2701