### PR TITLE
ProcessLauncher: `close` method should be available on unix only

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -1206,6 +1206,9 @@ status = "generate"
     [[object.function]]
     name = "set_child_setup"
     cfg_condition = "unix"
+    [[object.function]]
+    name = "close"
+    cfg_condition = "unix"
 
 [[object]]
 name = "Gio.ThemedIcon"

--- a/gio/src/auto/subprocess_launcher.rs
+++ b/gio/src/auto/subprocess_launcher.rs
@@ -26,6 +26,8 @@ impl SubprocessLauncher {
         unsafe { from_glib_full(ffi::g_subprocess_launcher_new(flags.into_glib())) }
     }
 
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     #[cfg(any(feature = "v2_68", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2_68")))]
     #[doc(alias = "g_subprocess_launcher_close")]

--- a/gio/sys/Gir.toml
+++ b/gio/sys/Gir.toml
@@ -42,3 +42,19 @@ cfg_condition = "windows"
 name = "Gio.Win32OutputStream"
 status = "manual"
 cfg_condition = "windows"
+
+[[object]]
+name = "Gio.SubprocessLauncher"
+status = "generate"
+    [[object.function]]
+    pattern = "take_.*"
+    cfg_condition = "unix"
+    [[object.function]]
+    pattern = "set_std.*file_path"
+    cfg_condition = "unix"
+    [[object.function]]
+    name = "set_child_setup"
+    cfg_condition = "unix"
+    [[object.function]]
+    name = "close"
+    cfg_condition = "unix"

--- a/gio/sys/src/lib.rs
+++ b/gio/sys/src/lib.rs
@@ -13978,11 +13978,15 @@ extern "C" {
     pub fn g_subprocess_launcher_new(flags: GSubprocessFlags) -> *mut GSubprocessLauncher;
     #[cfg(any(feature = "v2_68", feature = "dox"))]
     #[cfg_attr(feature = "dox", doc(cfg(feature = "v2_68")))]
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_close(self_: *mut GSubprocessLauncher);
     pub fn g_subprocess_launcher_getenv(
         self_: *mut GSubprocessLauncher,
         variable: *const c_char,
     ) -> *const c_char;
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_set_child_setup(
         self_: *mut GSubprocessLauncher,
         child_setup: glib::GSpawnChildSetupFunc,
@@ -13998,14 +14002,20 @@ extern "C" {
         self_: *mut GSubprocessLauncher,
         flags: GSubprocessFlags,
     );
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_set_stderr_file_path(
         self_: *mut GSubprocessLauncher,
         path: *const c_char,
     );
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_set_stdin_file_path(
         self_: *mut GSubprocessLauncher,
         path: *const c_char,
     );
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_set_stdout_file_path(
         self_: *mut GSubprocessLauncher,
         path: *const c_char,
@@ -14027,13 +14037,21 @@ extern "C" {
         argv: *const *const c_char,
         error: *mut *mut glib::GError,
     ) -> *mut GSubprocess;
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_take_fd(
         self_: *mut GSubprocessLauncher,
         source_fd: c_int,
         target_fd: c_int,
     );
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_take_stderr_fd(self_: *mut GSubprocessLauncher, fd: c_int);
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_take_stdin_fd(self_: *mut GSubprocessLauncher, fd: c_int);
+    #[cfg(any(unix, feature = "dox"))]
+    #[cfg_attr(feature = "dox", doc(cfg(unix)))]
     pub fn g_subprocess_launcher_take_stdout_fd(self_: *mut GSubprocessLauncher, fd: c_int);
     pub fn g_subprocess_launcher_unsetenv(self_: *mut GSubprocessLauncher, variable: *const c_char);
 


### PR DESCRIPTION
According to the gio public header, `g_subprocess_launcher_close` should
be available on unix platforms only:
https://gitlab.gnome.org/GNOME/glib/-/blob/glib-2-72/gio/gsubprocesslauncher.h#L81-115