### PR TITLE
translate.rs: free the container memory also when the container is empty

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -219,6 +219,7 @@ macro_rules! glib_boxed_wrapper {
 
             unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
+                    $crate::ffi::g_free(ptr as *mut _);
                     return Vec::new();
                 }
 

--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -422,6 +422,7 @@ macro_rules! glib_boxed_inline_wrapper {
 
             unsafe fn from_glib_full_num_as_vec(ptr: *const $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
+                    $crate::ffi::g_free(ptr as *mut _);
                     return Vec::new();
                 }
 
@@ -456,6 +457,7 @@ macro_rules! glib_boxed_inline_wrapper {
 
             unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
+                    $crate::ffi::g_free(ptr as *mut _);
                     return Vec::new();
                 }
 

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -533,6 +533,7 @@ impl FromGlibContainerAsVec<*mut GObject, *mut *mut GObject> for ObjectRef {
 
     unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut GObject, num: usize) -> Vec<Self> {
         if num == 0 || ptr.is_null() {
+            ffi::g_free(ptr as *mut _);
             return Vec::new();
         }
 
@@ -992,6 +993,7 @@ macro_rules! glib_object_wrapper {
 
             unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
+                    $crate::ffi::g_free(ptr as *mut _);
                     return Vec::new();
                 }
 

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -210,6 +210,7 @@ macro_rules! glib_shared_wrapper {
 
             unsafe fn from_glib_full_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
+                    $crate::ffi::g_free(ptr as *mut _);
                     return Vec::new();
                 }
 

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -1857,6 +1857,7 @@ macro_rules! impl_from_glib_container_as_vec_string {
 
             unsafe fn from_glib_full_num_as_vec(ptr: *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
+                    ffi::g_free(ptr as *mut _);
                     return Vec::new();
                 }
 
@@ -2286,7 +2287,11 @@ where
     }
 
     unsafe fn from_glib_full_num_as_vec(ptr: *mut ffi::GPtrArray, num: usize) -> Vec<T> {
-        if num == 0 || ptr.is_null() {
+        if ptr.is_null() {
+            return Vec::new();
+        }
+        if num == 0 {
+            ffi::g_ptr_array_unref(ptr);
             return Vec::new();
         }
         let pdata = (*ptr).pdata;


### PR DESCRIPTION
When transferring ownership of the container to the caller, the
container should be freed also when it is empty, since it might contain
a terminating NULL element. Calling g_free on a NULL container is
harmless, since in this case g_free is a no-op.