### PR TITLE
Backport param spec builders

### DIFF
--- a/glib/src/gobject/flags.rs
+++ b/glib/src/gobject/flags.rs
@@ -32,6 +32,12 @@ bitflags::bitflags! {
     }
 }
 
+impl Default for ParamFlags {
+    fn default() -> Self {
+        ParamFlags::READWRITE
+    }
+}
+
 #[doc(hidden)]
 impl IntoGlib for ParamFlags {
     type GlibType = gobject_ffi::GParamFlags;

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -407,96 +407,66 @@ macro_rules! define_param_spec_min_max {
 }
 
 macro_rules! define_param_spec_numeric {
-    ($rust_type:ident, $ffi_type:path, $value_type:ty, $rust_type_offset:expr, $from_glib:expr) => {
+    ($rust_type:ident, $ffi_type:path, $value_type:ty, $rust_type_offset:expr, $ffi_fun:ident, $alias:literal) => {
         define_param_spec!($rust_type, $ffi_type, $rust_type_offset);
-        define_param_spec_default!($rust_type, $value_type, $from_glib);
-        define_param_spec_min_max!($rust_type, $value_type, $from_glib);
+        define_param_spec_default!($rust_type, $value_type, |x| x);
+        define_param_spec_min_max!($rust_type, $value_type, |x| x);
+
+        impl $rust_type {
+            #[allow(clippy::new_ret_no_self)]
+            #[doc(alias = $alias)]
+            pub fn new(
+                name: &str,
+                nick: &str,
+                blurb: &str,
+                minimum: $value_type,
+                maximum: $value_type,
+                default_value: $value_type,
+                flags: ParamFlags,
+            ) -> ParamSpec {
+                assert_param_name(name);
+                unsafe {
+                    from_glib_none(gobject_ffi::$ffi_fun(
+                        name.to_glib_none().0,
+                        nick.to_glib_none().0,
+                        blurb.to_glib_none().0,
+                        minimum,
+                        maximum,
+                        default_value,
+                        flags.into_glib(),
+                    ))
+                }
+            }
+        }
     };
 }
 
+fn assert_param_name(name: &str) {
+    assert!(
+        is_canonical_pspec_name(name),
+        "{} is not a valid canonical parameter name",
+        name
+    );
+}
 define_param_spec_numeric!(
     ParamSpecChar,
     gobject_ffi::GParamSpecChar,
     i8,
     0,
-    |x| x
+    g_param_spec_char,
+    "g_param_spec_char"
 );
-
-impl ParamSpecChar {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_char")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: i8,
-        maximum: i8,
-        default_value: i8,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_char(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
 
 define_param_spec_numeric!(
     ParamSpecUChar,
     gobject_ffi::GParamSpecUChar,
     u8,
     1,
-    |x| x
+    g_param_spec_uchar,
+    "g_param_spec_uchar"
 );
 
-impl ParamSpecUChar {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_uchar")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: u8,
-        maximum: u8,
-        default_value: u8,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_uchar(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
-
-define_param_spec!(
-    ParamSpecBoolean,
-    gobject_ffi::GParamSpecBoolean,
-    2
-);
+define_param_spec!(ParamSpecBoolean, gobject_ffi::GParamSpecBoolean, 2);
 
 define_param_spec_default!(ParamSpecBoolean, bool, |x| from_glib(x));
 
@@ -510,11 +480,7 @@ impl ParamSpecBoolean {
         default_value: bool,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_boolean(
                 name.to_glib_none().0,
@@ -532,240 +498,56 @@ define_param_spec_numeric!(
     gobject_ffi::GParamSpecInt,
     i32,
     3,
-    |x| x
+    g_param_spec_int,
+    "g_param_spec_int"
 );
-
-impl ParamSpecInt {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_int")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: i32,
-        maximum: i32,
-        default_value: i32,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_int(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
 
 define_param_spec_numeric!(
     ParamSpecUInt,
     gobject_ffi::GParamSpecUInt,
     u32,
     4,
-    |x| x
+    g_param_spec_uint,
+    "g_param_spec_uint"
 );
-
-impl ParamSpecUInt {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_uint")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: u32,
-        maximum: u32,
-        default_value: u32,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_uint(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
 
 define_param_spec_numeric!(
     ParamSpecLong,
     gobject_ffi::GParamSpecLong,
     libc::c_long,
     5,
-    |x| x
+    g_param_spec_long,
+    "g_param_spec_long"
 );
-
-impl ParamSpecLong {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_long")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: libc::c_long,
-        maximum: libc::c_long,
-        default_value: libc::c_long,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_long(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
 
 define_param_spec_numeric!(
     ParamSpecULong,
     gobject_ffi::GParamSpecULong,
     libc::c_ulong,
     6,
-    |x| x
+    g_param_spec_ulong,
+    "g_param_spec_ulong"
 );
-
-impl ParamSpecULong {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_ulong")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: libc::c_ulong,
-        maximum: libc::c_ulong,
-        default_value: libc::c_ulong,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_ulong(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
 
 define_param_spec_numeric!(
     ParamSpecInt64,
     gobject_ffi::GParamSpecInt64,
     i64,
     7,
-    |x| x
+    g_param_spec_int64,
+    "g_param_spec_int64"
 );
-
-impl ParamSpecInt64 {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_int64")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: i64,
-        maximum: i64,
-        default_value: i64,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_int64(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
 
 define_param_spec_numeric!(
     ParamSpecUInt64,
     gobject_ffi::GParamSpecUInt64,
     u64,
     8,
-    |x| x
+    g_param_spec_uint64,
+    "g_param_spec_uint64"
 );
 
-impl ParamSpecUInt64 {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_uint64")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: u64,
-        maximum: u64,
-        default_value: u64,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_uint64(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
-
-define_param_spec!(
-    ParamSpecUnichar,
-    gobject_ffi::GParamSpecUnichar,
-    9
-);
+define_param_spec!(ParamSpecUnichar, gobject_ffi::GParamSpecUnichar, 9);
 
 define_param_spec_default!(ParamSpecUnichar, Result<char, CharTryFromError>, TryFrom::try_from);
 
@@ -779,11 +561,7 @@ impl ParamSpecUnichar {
         default_value: char,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_unichar(
                 name.to_glib_none().0,
@@ -796,11 +574,7 @@ impl ParamSpecUnichar {
     }
 }
 
-define_param_spec!(
-    ParamSpecEnum,
-    gobject_ffi::GParamSpecEnum,
-    10
-);
+define_param_spec!(ParamSpecEnum, gobject_ffi::GParamSpecEnum, 10);
 
 define_param_spec_default!(ParamSpecEnum, i32, |x| x);
 
@@ -815,11 +589,7 @@ impl ParamSpecEnum {
         default_value: i32,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_enum(
                 name.to_glib_none().0,
@@ -845,11 +615,7 @@ impl ParamSpecEnum {
     }
 }
 
-define_param_spec!(
-    ParamSpecFlags,
-    gobject_ffi::GParamSpecFlags,
-    11
-);
+define_param_spec!(ParamSpecFlags, gobject_ffi::GParamSpecFlags, 11);
 
 define_param_spec_default!(ParamSpecFlags, u32, |x| x);
 
@@ -864,11 +630,7 @@ impl ParamSpecFlags {
         default_value: u32,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_flags(
                 name.to_glib_none().0,
@@ -899,84 +661,20 @@ define_param_spec_numeric!(
     gobject_ffi::GParamSpecFloat,
     f32,
     12,
-    |x| x
+    g_param_spec_float,
+    "g_param_spec_float"
 );
-
-impl ParamSpecFloat {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_float")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: f32,
-        maximum: f32,
-        default_value: f32,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_float(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
 
 define_param_spec_numeric!(
     ParamSpecDouble,
     gobject_ffi::GParamSpecDouble,
     f64,
     13,
-    |x| x
+    g_param_spec_double,
+    "g_param_spec_double"
 );
 
-impl ParamSpecDouble {
-    #[allow(clippy::new_ret_no_self)]
-    #[doc(alias = "g_param_spec_double")]
-    pub fn new(
-        name: &str,
-        nick: &str,
-        blurb: &str,
-        minimum: f64,
-        maximum: f64,
-        default_value: f64,
-        flags: ParamFlags,
-    ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_double(
-                name.to_glib_none().0,
-                nick.to_glib_none().0,
-                blurb.to_glib_none().0,
-                minimum,
-                maximum,
-                default_value,
-                flags.into_glib(),
-            ))
-        }
-    }
-}
-
-define_param_spec!(
-    ParamSpecString,
-    gobject_ffi::GParamSpecString,
-    14
-);
+define_param_spec!(ParamSpecString, gobject_ffi::GParamSpecString, 14);
 
 define_param_spec_default!(ParamSpecString, Option<&str>, |x: *mut libc::c_char| {
     use std::ffi::CStr;
@@ -998,11 +696,7 @@ impl ParamSpecString {
         default_value: Option<&str>,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         let default_value = default_value.to_glib_none();
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_string(
@@ -1016,11 +710,7 @@ impl ParamSpecString {
     }
 }
 
-define_param_spec!(
-    ParamSpecParam,
-    gobject_ffi::GParamSpecParam,
-    15
-);
+define_param_spec!(ParamSpecParam, gobject_ffi::GParamSpecParam, 15);
 
 impl ParamSpecParam {
     #[allow(clippy::new_ret_no_self)]
@@ -1032,11 +722,7 @@ impl ParamSpecParam {
         param_type: crate::Type,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_param(
                 name.to_glib_none().0,
@@ -1049,11 +735,7 @@ impl ParamSpecParam {
     }
 }
 
-define_param_spec!(
-    ParamSpecBoxed,
-    gobject_ffi::GParamSpecBoxed,
-    16
-);
+define_param_spec!(ParamSpecBoxed, gobject_ffi::GParamSpecBoxed, 16);
 
 impl ParamSpecBoxed {
     #[allow(clippy::new_ret_no_self)]
@@ -1065,11 +747,7 @@ impl ParamSpecBoxed {
         boxed_type: crate::Type,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_boxed(
                 name.to_glib_none().0,
@@ -1082,21 +760,13 @@ impl ParamSpecBoxed {
     }
 }
 
-define_param_spec!(
-    ParamSpecPointer,
-    gobject_ffi::GParamSpecPointer,
-    17
-);
+define_param_spec!(ParamSpecPointer, gobject_ffi::GParamSpecPointer, 17);
 
 impl ParamSpecPointer {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_pointer")]
     pub fn new(name: &str, nick: &str, blurb: &str, flags: ParamFlags) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_pointer(
                 name.to_glib_none().0,
@@ -1108,11 +778,7 @@ impl ParamSpecPointer {
     }
 }
 
-define_param_spec!(
-    ParamSpecValueArray,
-    gobject_ffi::GParamSpecValueArray,
-    18
-);
+define_param_spec!(ParamSpecValueArray, gobject_ffi::GParamSpecValueArray, 18);
 
 impl ParamSpecValueArray {
     #[allow(clippy::new_ret_no_self)]
@@ -1124,11 +790,7 @@ impl ParamSpecValueArray {
         element_spec: &ParamSpec,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_value_array(
                 name.to_glib_none().0,
@@ -1159,11 +821,7 @@ impl ParamSpecValueArray {
     }
 }
 
-define_param_spec!(
-    ParamSpecObject,
-    gobject_ffi::GParamSpecObject,
-    19
-);
+define_param_spec!(ParamSpecObject, gobject_ffi::GParamSpecObject, 19);
 
 impl ParamSpecObject {
     #[allow(clippy::new_ret_no_self)]
@@ -1175,11 +833,7 @@ impl ParamSpecObject {
         object_type: crate::Type,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_object(
                 name.to_glib_none().0,
@@ -1192,21 +846,13 @@ impl ParamSpecObject {
     }
 }
 
-define_param_spec!(
-    ParamSpecOverride,
-    gobject_ffi::GParamSpecOverride,
-    20
-);
+define_param_spec!(ParamSpecOverride, gobject_ffi::GParamSpecOverride, 20);
 
 impl ParamSpecOverride {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_override")]
     pub fn new(name: &str, overridden: &ParamSpec) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_override(
                 name.to_glib_none().0,
@@ -1230,11 +876,7 @@ impl ParamSpecOverride {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_override")]
     pub fn for_interface<T: IsA<Object> + IsInterface>(name: &str) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         // in case it's an interface
         let interface_ref: InterfaceRef<T> = Interface::from_type(T::static_type()).unwrap();
         let pspec = interface_ref
@@ -1263,11 +905,7 @@ impl ParamSpecOverride {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_override")]
     pub fn for_class<T: IsA<Object> + IsClass>(name: &str) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         let pspec = ObjectClass::from_type(T::static_type())
             .unwrap()
             .find_property(name)
@@ -1290,11 +928,7 @@ impl ParamSpecOverride {
     }
 }
 
-define_param_spec!(
-    ParamSpecGType,
-    gobject_ffi::GParamSpecGType,
-    21
-);
+define_param_spec!(ParamSpecGType, gobject_ffi::GParamSpecGType, 21);
 
 impl ParamSpecGType {
     #[allow(clippy::new_ret_no_self)]
@@ -1306,11 +940,7 @@ impl ParamSpecGType {
         is_a_type: crate::Type,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_gtype(
                 name.to_glib_none().0,
@@ -1323,11 +953,7 @@ impl ParamSpecGType {
     }
 }
 
-define_param_spec!(
-    ParamSpecVariant,
-    gobject_ffi::GParamSpecVariant,
-    22
-);
+define_param_spec!(ParamSpecVariant, gobject_ffi::GParamSpecVariant, 22);
 
 define_param_spec_default!(
     ParamSpecVariant,
@@ -1346,11 +972,7 @@ impl ParamSpecVariant {
         default_value: Option<&crate::Variant>,
         flags: ParamFlags,
     ) -> ParamSpec {
-        assert!(
-            is_canonical_pspec_name(name),
-            "{} is not a valid canonical parameter name",
-            name
-        );
+        assert_param_name(name);
         unsafe {
             from_glib_none(gobject_ffi::g_param_spec_variant(
                 name.to_glib_none().0,

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -441,6 +441,8 @@ macro_rules! define_param_spec_numeric {
     };
 }
 
+#[track_caller]
+// the default panic formatter will use its caller as the location in its error message
 fn assert_param_name(name: &str) {
     assert!(
         is_canonical_pspec_name(name),

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -471,7 +471,7 @@ macro_rules! define_builder {
             name: &'a str,
             nick: Option<&'a str>,
             blurb: Option<&'a str>,
-            flags: Option<crate::ParamFlags>, // `ParamFlags` doesn't implement `Default` so I wrap it in `Option`
+            flags: crate::ParamFlags,
             $($field_id: Option<$field_ty>),*
         }
         impl<'a> $builder_type<'a> {
@@ -488,7 +488,7 @@ macro_rules! define_builder {
 
             /// Default: `glib::ParamFlags::READWRITE`
             pub fn flags(mut self, flags: crate::ParamFlags) -> Self {
-                self.flags = Some(flags);
+                self.flags = flags;
                 self
             }
 
@@ -511,7 +511,7 @@ macro_rules! define_builder {
                         $(.or(Some($field_expr)))?
                         .expect("impossible: missing parameter in ParamSpec*Builder")
                     ,)*
-                    self.flags.unwrap_or(crate::ParamFlags::READWRITE),
+                    self.flags
                 )
             }
         }

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -387,19 +387,19 @@ macro_rules! define_param_spec_default {
 }
 
 macro_rules! define_param_spec_min_max {
-    ($rust_type:ident, $value_type:ty, $from_glib:expr) => {
+    ($rust_type:ident, $value_type:ty) => {
         impl $rust_type {
             pub fn minimum(&self) -> $value_type {
                 unsafe {
                     let ptr = self.to_glib_none().0;
-                    $from_glib((*ptr).minimum)
+                    (*ptr).minimum
                 }
             }
 
             pub fn maximum(&self) -> $value_type {
                 unsafe {
                     let ptr = self.to_glib_none().0;
-                    $from_glib((*ptr).maximum)
+                    (*ptr).maximum
                 }
             }
         }
@@ -410,7 +410,7 @@ macro_rules! define_param_spec_numeric {
     ($rust_type:ident, $ffi_type:path, $value_type:ty, $rust_type_offset:expr, $ffi_fun:ident, $alias:literal) => {
         define_param_spec!($rust_type, $ffi_type, $rust_type_offset);
         define_param_spec_default!($rust_type, $value_type, |x| x);
-        define_param_spec_min_max!($rust_type, $value_type, |x| x);
+        define_param_spec_min_max!($rust_type, $value_type);
 
         impl $rust_type {
             #[allow(clippy::new_ret_no_self)]

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -252,7 +252,7 @@ extern "C" {
 }
 
 macro_rules! define_param_spec {
-    ($rust_type:ident, $ffi_type:path, $mod_name:ident, $rust_type_offset:expr) => {
+    ($rust_type:ident, $ffi_type:path, $rust_type_offset:expr) => {
         // Can't use get_type here as this is not a boxed type but another fundamental type
         wrapper! {
             #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -407,8 +407,8 @@ macro_rules! define_param_spec_min_max {
 }
 
 macro_rules! define_param_spec_numeric {
-    ($rust_type:ident, $ffi_type:path, $value_type:ty, $mod_name:ident, $rust_type_offset:expr, $from_glib:expr) => {
-        define_param_spec!($rust_type, $ffi_type, $mod_name, $rust_type_offset);
+    ($rust_type:ident, $ffi_type:path, $value_type:ty, $rust_type_offset:expr, $from_glib:expr) => {
+        define_param_spec!($rust_type, $ffi_type, $rust_type_offset);
         define_param_spec_default!($rust_type, $value_type, $from_glib);
         define_param_spec_min_max!($rust_type, $value_type, $from_glib);
     };
@@ -418,7 +418,6 @@ define_param_spec_numeric!(
     ParamSpecChar,
     gobject_ffi::GParamSpecChar,
     i8,
-    param_spec_char,
     0,
     |x| x
 );
@@ -458,7 +457,6 @@ define_param_spec_numeric!(
     ParamSpecUChar,
     gobject_ffi::GParamSpecUChar,
     u8,
-    param_spec_uchar,
     1,
     |x| x
 );
@@ -497,7 +495,6 @@ impl ParamSpecUChar {
 define_param_spec!(
     ParamSpecBoolean,
     gobject_ffi::GParamSpecBoolean,
-    param_spec_bool,
     2
 );
 
@@ -534,7 +531,6 @@ define_param_spec_numeric!(
     ParamSpecInt,
     gobject_ffi::GParamSpecInt,
     i32,
-    param_spec_int,
     3,
     |x| x
 );
@@ -574,7 +570,6 @@ define_param_spec_numeric!(
     ParamSpecUInt,
     gobject_ffi::GParamSpecUInt,
     u32,
-    param_spec_uint,
     4,
     |x| x
 );
@@ -614,7 +609,6 @@ define_param_spec_numeric!(
     ParamSpecLong,
     gobject_ffi::GParamSpecLong,
     libc::c_long,
-    param_spec_long,
     5,
     |x| x
 );
@@ -654,7 +648,6 @@ define_param_spec_numeric!(
     ParamSpecULong,
     gobject_ffi::GParamSpecULong,
     libc::c_ulong,
-    param_spec_ulong,
     6,
     |x| x
 );
@@ -694,7 +687,6 @@ define_param_spec_numeric!(
     ParamSpecInt64,
     gobject_ffi::GParamSpecInt64,
     i64,
-    param_spec_int64,
     7,
     |x| x
 );
@@ -734,7 +726,6 @@ define_param_spec_numeric!(
     ParamSpecUInt64,
     gobject_ffi::GParamSpecUInt64,
     u64,
-    param_spec_uint64,
     8,
     |x| x
 );
@@ -773,7 +764,6 @@ impl ParamSpecUInt64 {
 define_param_spec!(
     ParamSpecUnichar,
     gobject_ffi::GParamSpecUnichar,
-    param_spec_unichar,
     9
 );
 
@@ -809,7 +799,6 @@ impl ParamSpecUnichar {
 define_param_spec!(
     ParamSpecEnum,
     gobject_ffi::GParamSpecEnum,
-    param_spec_enum,
     10
 );
 
@@ -859,7 +848,6 @@ impl ParamSpecEnum {
 define_param_spec!(
     ParamSpecFlags,
     gobject_ffi::GParamSpecFlags,
-    param_spec_flags,
     11
 );
 
@@ -910,7 +898,6 @@ define_param_spec_numeric!(
     ParamSpecFloat,
     gobject_ffi::GParamSpecFloat,
     f32,
-    param_spec_float,
     12,
     |x| x
 );
@@ -950,7 +937,6 @@ define_param_spec_numeric!(
     ParamSpecDouble,
     gobject_ffi::GParamSpecDouble,
     f64,
-    param_spec_double,
     13,
     |x| x
 );
@@ -989,7 +975,6 @@ impl ParamSpecDouble {
 define_param_spec!(
     ParamSpecString,
     gobject_ffi::GParamSpecString,
-    param_spec_string,
     14
 );
 
@@ -1034,7 +1019,6 @@ impl ParamSpecString {
 define_param_spec!(
     ParamSpecParam,
     gobject_ffi::GParamSpecParam,
-    param_spec_param,
     15
 );
 
@@ -1068,7 +1052,6 @@ impl ParamSpecParam {
 define_param_spec!(
     ParamSpecBoxed,
     gobject_ffi::GParamSpecBoxed,
-    param_spec_boxed,
     16
 );
 
@@ -1102,7 +1085,6 @@ impl ParamSpecBoxed {
 define_param_spec!(
     ParamSpecPointer,
     gobject_ffi::GParamSpecPointer,
-    param_spec_pointer,
     17
 );
 
@@ -1129,7 +1111,6 @@ impl ParamSpecPointer {
 define_param_spec!(
     ParamSpecValueArray,
     gobject_ffi::GParamSpecValueArray,
-    param_spec_value_array,
     18
 );
 
@@ -1181,7 +1162,6 @@ impl ParamSpecValueArray {
 define_param_spec!(
     ParamSpecObject,
     gobject_ffi::GParamSpecObject,
-    param_spec_object,
     19
 );
 
@@ -1215,7 +1195,6 @@ impl ParamSpecObject {
 define_param_spec!(
     ParamSpecOverride,
     gobject_ffi::GParamSpecOverride,
-    param_spec_override,
     20
 );
 
@@ -1314,7 +1293,6 @@ impl ParamSpecOverride {
 define_param_spec!(
     ParamSpecGType,
     gobject_ffi::GParamSpecGType,
-    param_spec_gtype,
     21
 );
 
@@ -1348,7 +1326,6 @@ impl ParamSpecGType {
 define_param_spec!(
     ParamSpecVariant,
     gobject_ffi::GParamSpecVariant,
-    param_spec_variant,
     22
 );
 

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -1036,12 +1036,13 @@ impl ParamSpecOverride {
     #[doc(alias = "g_param_spec_override")]
     pub fn new(name: &str, overridden: &ParamSpec) -> ParamSpec {
         assert_param_name(name);
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_override(
-                name.to_glib_none().0,
-                overridden.to_glib_none().0,
-            ))
-        }
+        unsafe { Self::new_unchecked(name, overridden) }
+    }
+    unsafe fn new_unchecked(name: &str, overridden: &ParamSpec) -> ParamSpec {
+        from_glib_none(gobject_ffi::g_param_spec_override(
+            name.to_glib_none().0,
+            overridden.to_glib_none().0,
+        ))
     }
 
     // rustdoc-stripper-ignore-next
@@ -1065,12 +1066,8 @@ impl ParamSpecOverride {
         let pspec = interface_ref
             .find_property(name)
             .unwrap_or_else(|| panic!("Couldn't find a property named `{}` to override", name));
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_override(
-                name.to_glib_none().0,
-                pspec.to_glib_none().0,
-            ) as *const _)
-        }
+
+        unsafe { Self::new_unchecked(name, &pspec) }
     }
 
     // rustdoc-stripper-ignore-next
@@ -1093,12 +1090,8 @@ impl ParamSpecOverride {
             .unwrap()
             .find_property(name)
             .unwrap_or_else(|| panic!("Couldn't find a property named `{}` to override", name));
-        unsafe {
-            from_glib_none(gobject_ffi::g_param_spec_override(
-                name.to_glib_none().0,
-                pspec.to_glib_none().0,
-            ) as *const _)
-        }
+
+        unsafe { Self::new_unchecked(name, &pspec) }
     }
 
     #[doc(alias = "get_overridden")]


### PR DESCRIPTION
Putting it here for reference as per discussion on the chat. Feel free to close it. Apart from this I did not find any other patch on mainline that applies cleanly to 0.15 and that does not break API.

This patchset applies cleanly to the stable branch and it is not an API break, only addition... on the other hand we do not have any evidence that the proposed API saw much testing.


