### PR TITLE
Fix off-by-one in GString::from (and missing null terminator in a test)

### DIFF
--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -700,7 +700,7 @@ impl From<&str> for GString {
         unsafe {
             // No check for valid UTF-8 here
             let copy = ffi::g_malloc(s.len() + 1) as *mut c_char;
-            ptr::copy_nonoverlapping(s.as_ptr() as *const c_char, copy, s.len() + 1);
+            ptr::copy_nonoverlapping(s.as_ptr() as *const c_char, copy, s.len());
             ptr::write(copy.add(s.len()), 0);
 
             GString(Inner::Foreign {
@@ -1164,7 +1164,7 @@ mod tests {
     fn test_from_glib_container() {
         unsafe {
             let test_a: GString = FromGlibContainer::from_glib_container_num(
-                ffi::g_strdup("hello_world".as_ptr() as *const _),
+                ffi::g_strdup("hello_world\0".as_ptr() as *const _),
                 5,
             );
             assert_eq!("hello", test_a.as_str());


### PR DESCRIPTION
I'm running a lot of crates under AddressSanitizer. You can find these bugs in the `glib` crate by running this in it:
```
RUSTDOCFLAGS=-Zsanitizer=address RUSTFLAGS=-Zsanitizer=address cargo +nightly test -Zbuild-std --target=x86_64-unknown-linux-gnu
```
You should see an error that looks something like this
```
==324602==ERROR: AddressSanitizer: global-buffer-overflow on address 0x557a09bb8769 at pc 0x557a08a066b7 bp 0x7f845cfd7cf0 sp 0x7f845cfd74c0
READ of size 10 at 0x557a09bb8769 thread T37 (gstring::tests:)
    #0 0x557a08a066b6 in __asan_memcpy /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3
    #1 0x557a08d66236 in core::intrinsics::copy_nonoverlapping::hca817e807f3b91c2 /home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/intrinsics.rs:2137:9
    #2 0x557a08b13a2f in _$LT$glib..gstring..GString$u20$as$u20$core..convert..From$LT$$RF$str$GT$$GT$::from::h95d440218de09a16 /home/ben/gtk-rs-core/glib/src/gstring.rs:703:13
    #3 0x557a08ce5ff8 in _$LT$T$u20$as$u20$core..convert..Into$LT$U$GT$$GT$::into::h3390d22d7d9b7ac5 /home/ben/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:550:9
    #4 0x557a08a8f98d in glib::gstring::tests::test_as_ref_path::h51110ffcb393aae3 /home/ben/gtk-rs-core/glib/src/gstring.rs:1157:32
```

This finds a buffer overflow when creating a `GString` (the destination is `s.len() + 1` long, but the source isn't), and a missing null terminator in a test.