### PR TITLE
glib: Fix `ParamSpec::name()` return value lifetime

### DIFF
--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -178,7 +178,7 @@ impl ParamSpec {
 
     #[doc(alias = "g_param_spec_get_name")]
     #[doc(alias = "get_name")]
-    pub fn name(&self) -> &str {
+    pub fn name<'a>(&self) -> &'a str {
         unsafe {
             CStr::from_ptr(gobject_ffi::g_param_spec_get_name(self.to_glib_none().0))
                 .to_str()


### PR DESCRIPTION
The string is an interned string that is valid for the remaining runtime
of the process and is not bound by the `&self` reference.

----

See https://github.com/gtk-rs/gtk-rs-core/pull/726/files#r917705349