### PR TITLE
add set_glyph to GlyphInfo

### DIFF
--- a/pango/src/glyph_info.rs
+++ b/pango/src/glyph_info.rs
@@ -13,6 +13,10 @@ impl GlyphInfo {
         self.inner.glyph
     }
 
+    pub fn set_glyph(&mut self, glyph: u32) {
+        self.inner.glyph = glyph
+    }
+
     pub fn geometry(&self) -> &GlyphGeometry {
         unsafe { &*(&self.inner.geometry as *const _ as *const GlyphGeometry) }
     }


### PR DESCRIPTION
I believe this method should exist, so that after shaping, you can change, not only the position of glyphs, but which glyphs get chosen from shaping.

For example, shaping decides that tabs characters are displayed as arrows, and I would like to modify the glyph afterwards to be a space.  Or, maybe I want to display whitespace as visible.  In C, you would just modify the glyph field after shaping.  You should be able to modify it in rust too.