### PR TITLE
gio: Manually implement ActionEntry

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -11,7 +11,6 @@ trust_return_value_nullability = true
 
 generate = [
     "Gio.Action",
-    "Gio.ActionMap",
     "Gio.AppInfoCreateFlags",
     "Gio.AppInfoMonitor",
     "Gio.ApplicationFlags",
@@ -153,6 +152,7 @@ ignore = [
 ]
 
 manual = [
+    "Gio.ActionEntry",
     "Gio.FileAttributeInfo",
     "Gio.IOExtension",
     "Gio.IOExtensionPoint",
@@ -240,6 +240,14 @@ status = "generate"
     [[object.function]]
     name = "query_action"
     ignore = true
+
+[[object]]
+name = "Gio.ActionMap"
+status = "generate"
+manual_traits = ["ActionMapExtManual"]
+    [[object.function]]
+    name = "add_action_entries"
+    manual = true # GActionEntry is manually implemented
 
 [[object]]
 name = "Gio.AppInfo"

--- a/gio/src/action_entry.rs
+++ b/gio/src/action_entry.rs
@@ -1,0 +1,120 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{ActionMap, SimpleAction};
+use glib::{IsA, Variant};
+
+#[doc(alias = "GActionEntry")]
+pub struct ActionEntry<O>
+where
+    O: IsA<ActionMap>,
+{
+    name: String,
+    parameter_type: Option<String>,
+    state: Option<String>,
+    pub(crate) activate: Option<Box<dyn Fn(&O, &SimpleAction, Option<&Variant>) + 'static>>,
+    pub(crate) change_state: Option<Box<dyn Fn(&O, &SimpleAction, Option<&Variant>) + 'static>>,
+}
+
+impl<O> ActionEntry<O>
+where
+    O: IsA<ActionMap>,
+{
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn parameter_type(&self) -> Option<&str> {
+        self.parameter_type.as_deref()
+    }
+
+    pub fn state(&self) -> Option<&str> {
+        self.state.as_deref()
+    }
+
+    pub fn builder(name: &str) -> ActionEntryBuilder<O> {
+        ActionEntryBuilder::new(name)
+    }
+}
+
+impl<O> std::fmt::Debug for ActionEntry<O>
+where
+    O: IsA<ActionMap>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ActionEntry")
+            .field("name", &self.name())
+            .field("parameter_type", &self.parameter_type())
+            .field("state", &self.state())
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct ActionEntryBuilder<O>(ActionEntry<O>)
+where
+    O: IsA<ActionMap>;
+
+impl<O> ActionEntryBuilder<O>
+where
+    O: IsA<ActionMap>,
+{
+    pub fn new(name: &str) -> Self {
+        Self(ActionEntry {
+            name: name.to_owned(),
+            parameter_type: Default::default(),
+            state: Default::default(),
+            activate: Default::default(),
+            change_state: Default::default(),
+        })
+    }
+
+    pub fn parameter_type(mut self, parameter_type: &str) -> Self {
+        self.0.parameter_type = Some(parameter_type.to_owned());
+        self
+    }
+
+    pub fn state(mut self, state: &str) -> Self {
+        self.0.state = Some(state.to_owned());
+        self
+    }
+
+    pub fn activate<F: Fn(&O, &SimpleAction, Option<&Variant>) + 'static>(
+        mut self,
+        callback: F,
+    ) -> Self {
+        self.0.activate = Some(Box::new(callback));
+        self
+    }
+
+    pub fn change_state<F: Fn(&O, &SimpleAction, Option<&Variant>) + 'static>(
+        mut self,
+        callback: F,
+    ) -> Self {
+        self.0.change_state = Some(Box::new(callback));
+        self
+    }
+
+    pub fn build(self) -> ActionEntry<O> {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn action_entry() {
+        let app = crate::Application::new(None, Default::default());
+
+        let close = ActionEntry::builder("close")
+            .activate(move |_app, _, _| {
+                //Do something
+            })
+            .build();
+        app.add_action_entries(vec![close]).unwrap();
+        assert!(app.lookup_action("close").is_some());
+    }
+}

--- a/gio/src/action_map.rs
+++ b/gio/src/action_map.rs
@@ -1,0 +1,56 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{prelude::*, ActionEntry, ActionMap, SimpleAction};
+use glib::{clone, Cast, IsA};
+
+pub trait ActionMapExtManual {
+    #[doc(alias = "g_action_map_add_action_entries")]
+    fn add_action_entries(
+        &self,
+        entries: impl IntoIterator<Item = ActionEntry<Self>>,
+    ) -> Result<(), glib::BoolError>
+    where
+        Self: IsA<ActionMap>;
+}
+
+impl<O: IsA<ActionMap>> ActionMapExtManual for O {
+    fn add_action_entries(
+        &self,
+        entries: impl IntoIterator<Item = ActionEntry<Self>>,
+    ) -> Result<(), glib::BoolError> {
+        for entry in entries.into_iter() {
+            let parameter_type = if let Some(param_type) = entry.parameter_type() {
+                Some(glib::VariantType::new(param_type)?)
+            } else {
+                None
+            };
+            let action = if let Some(state) = entry.state() {
+                let state = glib::Variant::parse(None, state).map_err(|e| {
+                    glib::bool_error!(
+                        "Invalid state passed to gio::ActionEntry {} {}",
+                        entry.name(),
+                        e
+                    )
+                })?;
+                SimpleAction::new_stateful(entry.name(), parameter_type.as_deref(), &state)
+            } else {
+                SimpleAction::new(entry.name(), parameter_type.as_deref())
+            };
+            let action_map = self.as_ref();
+            if let Some(callback) = entry.activate {
+                action.connect_activate(clone!(@strong action_map =>  move |action, state| {
+                    // safe to unwrap as O: IsA<ActionMap>
+                    callback(action_map.downcast_ref::<O>().unwrap(), action, state);
+                }));
+            }
+            if let Some(callback) = entry.change_state {
+                action.connect_change_state(clone!(@strong action_map => move |action, state| {
+                    // safe to unwrap as O: IsA<ActionMap>
+                    callback(action_map.downcast_ref::<O>().unwrap(), action, state);
+                }));
+            }
+            self.as_ref().add_action(&action);
+        }
+        Ok(())
+    }
+}

--- a/gio/src/auto/action_map.rs
+++ b/gio/src/auto/action_map.rs
@@ -24,9 +24,6 @@ pub trait ActionMapExt: 'static {
     #[doc(alias = "g_action_map_add_action")]
     fn add_action(&self, action: &impl IsA<Action>);
 
-    //#[doc(alias = "g_action_map_add_action_entries")]
-    //fn add_action_entries(&self, entries: /*Ignored*/&[ActionEntry], user_data: /*Unimplemented*/Option<Basic: Pointer>);
-
     #[doc(alias = "g_action_map_lookup_action")]
     fn lookup_action(&self, action_name: &str) -> Option<Action>;
 
@@ -43,10 +40,6 @@ impl<O: IsA<ActionMap>> ActionMapExt for O {
             );
         }
     }
-
-    //fn add_action_entries(&self, entries: /*Ignored*/&[ActionEntry], user_data: /*Unimplemented*/Option<Basic: Pointer>) {
-    //    unsafe { TODO: call ffi:g_action_map_add_action_entries() }
-    //}
 
     fn lookup_action(&self, action_name: &str) -> Option<Action> {
         unsafe {

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -12,8 +12,11 @@
 pub use ffi;
 pub use glib;
 
+mod action_entry;
+mod action_map;
 mod app_info;
 mod application;
+pub use action_entry::{ActionEntry, ActionEntryBuilder};
 pub use application::{ApplicationBusyGuard, ApplicationHoldGuard};
 mod async_initable;
 mod cancellable;

--- a/gio/src/prelude.rs
+++ b/gio/src/prelude.rs
@@ -8,6 +8,7 @@ pub use glib::prelude::*;
 
 pub use crate::auto::traits::*;
 
+pub use crate::action_map::ActionMapExtManual;
 #[cfg(any(feature = "v2_60", feature = "dox"))]
 pub use crate::app_info::AppInfoExtManual;
 pub use crate::application::*;


### PR DESCRIPTION
It is pretty useful for ActionMap implementors like GtkApplication
and GtkWindow. It avoids usually the usage of the clone! macro
as we pass the ActionMap to the activate/change_state callbacks.

Especially that Gtk doesn't provide a
gtk_application_class_install_action
alternative to the gtk_widget_class_install_action.