### PR TITLE
as_ptr() and as_mut_ptr() accessors are safe

### DIFF
--- a/glib/src/subclass/shared.rs
+++ b/glib/src/subclass/shared.rs
@@ -17,7 +17,7 @@ pub unsafe trait RefCounted: Clone + Sized + 'static {
 
     // rustdoc-stripper-ignore-next
     /// Provides access to a raw pointer to InnerType
-    unsafe fn as_ptr(&self) -> *const Self::InnerType;
+    fn as_ptr(&self) -> *const Self::InnerType;
 
     // rustdoc-stripper-ignore-next
     /// Converts the RefCounted object to a raw pointer to InnerType
@@ -39,7 +39,7 @@ where
         this
     }
 
-    unsafe fn as_ptr(&self) -> *const Self::InnerType {
+    fn as_ptr(&self) -> *const Self::InnerType {
         std::sync::Arc::as_ptr(self)
     }
 
@@ -64,7 +64,7 @@ where
         std::rc::Rc::into_raw(ManuallyDrop::take(&mut this_rc.clone()))
     }
 
-    unsafe fn as_ptr(&self) -> *const Self::InnerType {
+    fn as_ptr(&self) -> *const Self::InnerType {
         std::rc::Rc::as_ptr(self)
     }
 

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -738,7 +738,7 @@ impl<T: ObjectSubclass> InitializingObject<T> {
     /// The returned object has not been completely initialized at this point. Use of the object
     /// should be restricted to methods that are explicitly documented to be safe to call during
     /// `instance_init()`.
-    pub unsafe fn as_ptr(&self) -> *mut T::Type {
+    pub fn as_ptr(&self) -> *mut T::Type {
         self.0.as_ptr() as *const T::Type as *mut T::Type
     }
 


### PR DESCRIPTION
Nothing unsafe about getting a pointer, deferencing it is unsafe.