### PR TITLE
glib/types: use rustc-hash for HashMap

### DIFF
--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -31,6 +31,7 @@ ffi = { package = "glib-sys", path = "sys" }
 gobject_ffi = { package = "gobject-sys", path = "gobject-sys" }
 glib-macros = { path = "../glib-macros" }
 rs-log = { package = "log", version = "0.4", optional = true }
+rustc-hash = "1.1.0"
 smallvec = "1.0"
 thiserror = "1"
 

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -6,10 +6,11 @@
 use crate::object::{Cast, IsClass, IsInterface, ObjectSubclassIs, ObjectType, ParentClassIs};
 use crate::translate::*;
 use crate::{Closure, Object, StaticType, Type, Value};
+use rustc_hash::FxHashMap as HashMap;
+use std::any::Any;
 use std::marker;
 use std::mem;
 use std::ptr;
-use std::{any::Any, collections::HashMap};
 
 use super::SignalId;
 
@@ -244,7 +245,7 @@ unsafe extern "C" fn interface_init<T: ObjectSubclass, A: IsImplementable<T>>(
 
     let mut data = T::type_data();
     if data.as_ref().parent_ifaces.is_none() {
-        data.as_mut().parent_ifaces = Some(HashMap::new());
+        data.as_mut().parent_ifaces = Some(HashMap::default());
     }
     {
         let copy = Box::new(*iface.as_ref());
@@ -451,7 +452,7 @@ impl TypeData {
     /// If the class_data already contains a data for the specified `type_`.
     pub unsafe fn set_class_data<T: Any + Send + Sync + 'static>(&mut self, type_: Type, data: T) {
         if self.class_data.is_none() {
-            self.class_data = Some(HashMap::new());
+            self.class_data = Some(HashMap::default());
         }
 
         if let Some(ref mut class_data) = self.class_data {
@@ -762,7 +763,7 @@ impl<T: ObjectSubclass> InitializingObject<T> {
             let priv_ = &mut *ptr;
 
             if priv_.instance_data.is_none() {
-                priv_.instance_data = Some(HashMap::new());
+                priv_.instance_data = Some(HashMap::default());
             }
 
             if let Some(ref mut instance_data) = priv_.instance_data {


### PR DESCRIPTION
While profiling the standalone threadshare benchmark in
gst-plugins-rs, callgrind showed 2% cycles spent in
`ElementImplExt::panicked`. This function retrieves the
panicking status in trampolines and makes use of
`instance_data` from `ObjectSubclass`, which is stored in
a `HashMap`.

Rust's `std::collections::HashMap` is known to make use of
a ["hashing algorithm selected to provide resistance against
HashDoS attacks"](https://doc.rust-lang.org/std/collections/struct.HashMap.html). Since the `intance_data` is indexed
by a `glib::Type`, I thought it would make sense to test a
less strict but quicker hasher.

I first tested [`fnv`](https://crates.io/crates/fnv) which is an implementation of the
Fowler-Noll-Vo hash function which is used in major crates
such as `hashbrown`. The crate [`twox-hash`](https://crates.io/crates/twox-hash) features a
benchmark showing larger throughputs for `fnv` with small
data. Callgrind reports a 50% reduction in cycle estimation
for `ElementImplExt::panicked`. I also observe a slight
reduction in CPU usage with `ts-standalone`.

[`rustc-hash`](https://crates.io/crates/rustc-hash) is used by `rustc` where it "consistently
out-performs adn FNV-based hash 5 [...] -- the collision
rate is similar or slightly worse then FNV, but the speed
of the has function itself is much higher". Callgrind
reports 70% reduction in cycle estimation for `panicked`
compared to the default hasher. CPU usage and stats seem
similar to those obtained with `fnv` for `ts-standalone`.

`rustc-hash` was adopted.