### PR TITLE
glib: Remove unneeded and wrong `upcast()` from `BoxedAnyObject` docs…

### DIFF
--- a/glib/src/boxed_any_object.rs
+++ b/glib/src/boxed_any_object.rs
@@ -75,7 +75,7 @@ wrapper! {
     ///
     /// // The boxed data can be stored as a `glib::object::Object`
     /// let list = ListStore::new(BoxedAnyObject::static_type());
-    /// list.append(boxed.upcast());
+    /// list.append(&boxed);
     /// ```
     pub struct BoxedAnyObject(ObjectSubclass<imp::BoxedAnyObject>);
 }


### PR DESCRIPTION
… example

`ListStore::append()` takes a reference of any kind of object, so
`upcast()` is wrong in two ways
  - it doesn't give a reference but a plain value
  - the compiler can't figure out to what object type to upcast because
    any possible one would be accepted here

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/757