### PR TITLE
Don't checkout submodules by default

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,11 +145,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          set-safe-directory: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - run: git submodule update --checkout
       - run: python3 generator.py
       - run: git diff --exit-code
 
@@ -160,11 +162,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          set-safe-directory: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - run: git submodule update --checkout
       - run: cargo install rustdoc-stripper
       - run: python3 generator.py --embed-docs
       - run: python3 generator.py --strip-docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,6 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     name: build
-    container:
-      image: ghcr.io/gtk-rs/gtk-rs-core/core:latest
     env:
       RELEASES: |
         0.15=0.15
@@ -23,14 +21,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          set-safe-directory: true
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: nightly
           override: true
           components: rustfmt
-      - working-directory: gir
-        run: cargo build --release
+      - run: git submodule update --checkout
       - run: cargo install rustdoc-stripper
       - run: python3 ./generator.py --embed-docs --yes ./
       - run: git clone https://gitlab.gnome.org/World/Rust/gir-rustdoc/ # checkout action doesn't support random urls

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "gir"]
 	path = gir
 	url = https://github.com/gtk-rs/gir
+	update = none
 [submodule "gir-files"]
 	path = gir-files
 	url = https://github.com/gtk-rs/gir-files
+	update = none

--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ crates like `glib-rs`.
 
 ## Regenerating
 
-To regenerate crates using [gir], please use the `generator.py`
-file as follows:
+To regenerate crates using [gir], please use the `generator.py` file as follows:
 
 ```bash
 $ python3 generator.py
+```
+
+If you didn't do so yet, please check out all the submodules before via
+
+```bash
+$ git submodule update --checkout
 ```
 
 ## Development


### PR DESCRIPTION
This makes sure that cargo does not clone and checkout all the
submodules if pointing to this repository as a git dependency.

To checkout the submodules `git submodule update --checkout` can be
used.