### PR TITLE
glib: Reduce number of allocations when writing non-structured logs v…

### DIFF
--- a/cairo/src/surface.rs
+++ b/cairo/src/surface.rs
@@ -421,7 +421,7 @@ mod tests {
         /* Initially the data for any mime type has to be none */
         assert!(data.is_none());
 
-        assert!(surface.set_mime_data(MIME_TYPE_PNG, &[1u8, 10u8]).is_ok());
+        assert!(surface.set_mime_data(MIME_TYPE_PNG, [1u8, 10u8]).is_ok());
         let data = surface.mime_data(MIME_TYPE_PNG).unwrap();
         assert_eq!(data, &[1u8, 10u8]);
     }

--- a/cairo/sys/src/lib.rs
+++ b/cairo/sys/src/lib.rs
@@ -240,7 +240,7 @@ impl cairo_bool_t {
 
 impl From<bool> for cairo_bool_t {
     fn from(b: bool) -> cairo_bool_t {
-        let value = if b { 1 } else { 0 };
+        let value = c_int::from(b);
         cairo_bool_t { value }
     }
 }

--- a/gio/src/list_store.rs
+++ b/gio/src/list_store.rs
@@ -161,10 +161,10 @@ mod tests {
         let item0 = ListStore::new(ListStore::static_type());
         let item1 = ListStore::new(ListStore::static_type());
         let mut list = ListStore::new(ListStore::static_type());
-        list.extend(&[&item0, &item1]);
+        list.extend([&item0, &item1]);
         assert_eq!(list.item(0).as_ref(), Some(item0.upcast_ref()));
         assert_eq!(list.item(1).as_ref(), Some(item1.upcast_ref()));
-        list.extend(&[item0.clone(), item1.clone()]);
+        list.extend([item0.clone(), item1.clone()]);
         assert_eq!(list.item(2).as_ref(), Some(item0.upcast_ref()));
         assert_eq!(list.item(3).as_ref(), Some(item1.upcast_ref()));
 

--- a/gio/src/settings.rs
+++ b/gio/src/settings.rs
@@ -180,7 +180,7 @@ mod test {
     fn set_env() {
         INIT.call_once(|| {
             let output = Command::new("glib-compile-schemas")
-                .args(&[
+                .args([
                     &format!("{}/tests", env!("CARGO_MANIFEST_DIR")),
                     "--targetdir",
                     env!("OUT_DIR"),

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -1080,7 +1080,7 @@ impl_from_glib_container_as_vec_string!(GString, *const c_char);
 impl_from_glib_container_as_vec_string!(GString, *mut c_char);
 
 #[cfg(test)]
-#[allow(clippy::blacklisted_name)]
+#[allow(clippy::disallowed_names)]
 mod tests {
     use super::*;
     use std::ffi::CString;

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -135,6 +135,8 @@ impl Clone for VariantType {
 
 impl Deref for VariantType {
     type Target = VariantTy;
+
+    #[allow(clippy::cast_slice_from_raw_parts)]
     fn deref(&self) -> &VariantTy {
         unsafe {
             &*(slice::from_raw_parts(self.ptr.as_ptr() as *const u8, self.len) as *const [u8]
@@ -449,6 +451,7 @@ impl VariantTy {
     /// Creates `&VariantTy` with a wildcard lifetime from a `GVariantType`
     /// pointer.
     #[doc(hidden)]
+    #[allow(clippy::cast_slice_from_raw_parts)]
     pub unsafe fn from_ptr<'a>(ptr: *const ffi::GVariantType) -> &'a VariantTy {
         assert!(!ptr.is_null());
         let len = ffi::g_variant_type_get_string_length(ptr) as usize;

--- a/glib/tests/log.rs
+++ b/glib/tests/log.rs
@@ -38,11 +38,11 @@ fn check_log_handlers() {
     let count = Arc::new(Mutex::new(Counters::default()));
     log_set_default_handler(clone!(@weak count => move |_, level, _| {
         match level {
-            LogLevel::Critical => { (*count.lock().expect("failed to lock 3")).criticals += 1; }
-            LogLevel::Warning => { (*count.lock().expect("failed to lock 4")).warnings += 1; }
-            LogLevel::Message => { (*count.lock().expect("failed to lock 5")).messages += 1; }
-            LogLevel::Info => { (*count.lock().expect("failed to lock 6")).infos += 1; }
-            LogLevel::Debug => { (*count.lock().expect("failed to lock 7")).debugs += 1; }
+            LogLevel::Critical => { count.lock().expect("failed to lock 3").criticals += 1; }
+            LogLevel::Warning => { count.lock().expect("failed to lock 4").warnings += 1; }
+            LogLevel::Message => { count.lock().expect("failed to lock 5").messages += 1; }
+            LogLevel::Info => { count.lock().expect("failed to lock 6").infos += 1; }
+            LogLevel::Debug => { count.lock().expect("failed to lock 7").debugs += 1; }
             _ => unreachable!(),
         }
     }));
@@ -76,8 +76,8 @@ fn check_log_handlers() {
         false,
         clone!(@weak count => move |_, level, _| {
             match level {
-                LogLevel::Warning => { (*count.lock().expect("failed to lock 4")).warnings += 1; }
-                LogLevel::Debug => { (*count.lock().expect("failed to lock 7")).debugs += 1; }
+                LogLevel::Warning => { count.lock().expect("failed to lock 4").warnings += 1; }
+                LogLevel::Debug => { count.lock().expect("failed to lock 7").debugs += 1; }
                 _ => unreachable!(),
             }
         }),


### PR DESCRIPTION
…ia the `GlibLogger`

Directly construct a `NUL`-terminated string instead of going via temporary Rust `String`s.