### PR TITLE
glib: Don't allow passing a construct(-only) property twice during ob…

### DIFF
--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -528,6 +528,19 @@ mod test {
     }
 
     #[test]
+    fn test_construct_property_set_twice() {
+        assert_eq!(
+            Object::with_type(
+                SimpleObject::static_type(),
+                &[("construct-name", &"meh"), ("construct-name", &"meh2")],
+            )
+            .expect_err("Can't set construct property twice")
+            .to_string(),
+            "Can't set construct property 'construct-name' for type 'SimpleObject' twice",
+        );
+    }
+
+    #[test]
     fn test_signals() {
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::Arc;


### PR DESCRIPTION
…ject construction

GLib also does not allow this and would give a critical warning.