### PR TITLE
cairo: Use AsRef<T> for custom subclassing types

### DIFF
--- a/cairo/src/context.rs
+++ b/cairo/src/context.rs
@@ -161,8 +161,8 @@ impl Context {
         status_to_result(status)
     }
 
-    pub fn new(target: &Surface) -> Result<Context, Error> {
-        let ctx = unsafe { Self::from_raw_full(ffi::cairo_create(target.to_raw_none())) };
+    pub fn new(target: impl AsRef<Surface>) -> Result<Context, Error> {
+        let ctx = unsafe { Self::from_raw_full(ffi::cairo_create(target.as_ref().to_raw_none())) };
         ctx.status().map(|_| ctx)
     }
 
@@ -223,7 +223,8 @@ impl Context {
     }
 
     #[doc(alias = "cairo_set_source")]
-    pub fn set_source(&self, source: &Pattern) -> Result<(), Error> {
+    pub fn set_source(&self, source: impl AsRef<Pattern>) -> Result<(), Error> {
+        let source = source.as_ref();
         source.status()?;
         unsafe {
             ffi::cairo_set_source(self.0.as_ptr(), source.to_raw_none());
@@ -238,7 +239,13 @@ impl Context {
     }
 
     #[doc(alias = "cairo_set_source_surface")]
-    pub fn set_source_surface(&self, surface: &Surface, x: f64, y: f64) -> Result<(), Error> {
+    pub fn set_source_surface(
+        &self,
+        surface: impl AsRef<Surface>,
+        x: f64,
+        y: f64,
+    ) -> Result<(), Error> {
+        let surface = surface.as_ref();
         surface.status()?;
         unsafe {
             ffi::cairo_set_source_surface(self.0.as_ptr(), surface.to_raw_none(), x, y);
@@ -474,14 +481,16 @@ impl Context {
     }
 
     #[doc(alias = "cairo_mask")]
-    pub fn mask(&self, pattern: &Pattern) -> Result<(), Error> {
+    pub fn mask(&self, pattern: impl AsRef<Pattern>) -> Result<(), Error> {
+        let pattern = pattern.as_ref();
         pattern.status()?;
         unsafe { ffi::cairo_mask(self.0.as_ptr(), pattern.to_raw_none()) };
         self.status()
     }
 
     #[doc(alias = "cairo_mask_surface")]
-    pub fn mask_surface(&self, surface: &Surface, x: f64, y: f64) -> Result<(), Error> {
+    pub fn mask_surface(&self, surface: impl AsRef<Surface>, x: f64, y: f64) -> Result<(), Error> {
+        let surface = surface.as_ref();
         surface.status()?;
         unsafe {
             ffi::cairo_mask_surface(self.0.as_ptr(), surface.to_raw_none(), x, y);

--- a/cairo/src/device.rs
+++ b/cairo/src/device.rs
@@ -117,7 +117,8 @@ impl Device {
 
     #[cfg(any(feature = "script", feature = "dox"))]
     #[doc(alias = "cairo_script_surface_create_for_target")]
-    pub fn surface_create_for_target(&self, target: &Surface) -> Result<Surface, Error> {
+    pub fn surface_create_for_target(&self, target: impl AsRef<Surface>) -> Result<Surface, Error> {
+        let target = target.as_ref();
         target.status()?;
         unsafe {
             Surface::from_raw_full(ffi::cairo_script_surface_create_for_target(

--- a/cairo/src/patterns.rs
+++ b/cairo/src/patterns.rs
@@ -113,6 +113,12 @@ impl Drop for Pattern {
     }
 }
 
+impl AsRef<Pattern> for Pattern {
+    fn as_ref(&self) -> &Pattern {
+        self
+    }
+}
+
 macro_rules! convert {
     ($source: ident => $dest: ident = $( $variant: ident )|+ $( ($intermediate: ident) )*) => {
         impl TryFrom<$source> for $dest {
@@ -144,6 +150,12 @@ macro_rules! pattern_type(
             type Target = Pattern;
 
             fn deref(&self) -> &Pattern {
+                &self.0
+            }
+        }
+
+        impl AsRef<Pattern> for $pattern_type {
+            fn as_ref(&self) -> &Pattern {
                 &self.0
             }
         }
@@ -270,6 +282,18 @@ macro_rules! gradient_type {
             }
         }
 
+        impl AsRef<Gradient> for $gradient_type {
+            fn as_ref(&self) -> &Gradient {
+                &self.0
+            }
+        }
+
+        impl AsRef<Pattern> for $gradient_type {
+            fn as_ref(&self) -> &Pattern {
+                &self.0
+            }
+        }
+
         impl fmt::Display for $gradient_type {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(f, stringify!($gradient_type))
@@ -357,10 +381,10 @@ pattern_type!(SurfacePattern = Surface);
 
 impl SurfacePattern {
     #[doc(alias = "cairo_pattern_create_for_surface")]
-    pub fn create(surface: &Surface) -> Self {
+    pub fn create(surface: impl AsRef<Surface>) -> Self {
         unsafe {
             Self(Pattern::from_raw_full(
-                ffi::cairo_pattern_create_for_surface(surface.to_raw_none()),
+                ffi::cairo_pattern_create_for_surface(surface.as_ref().to_raw_none()),
             ))
         }
     }

--- a/cairo/src/pdf.rs
+++ b/cairo/src/pdf.rs
@@ -180,7 +180,7 @@ mod test {
         let buffer: Vec<u8> = vec![];
 
         let surface = PdfSurface::for_stream(100., 100., buffer).unwrap();
-        surface.restrict(PdfVersion::_1_5);
+        surface.restrict(PdfVersion::_1_5).unwrap();
         draw(&surface);
         *surface.finish_output_stream().unwrap().downcast().unwrap()
     }

--- a/cairo/src/surface.rs
+++ b/cairo/src/surface.rs
@@ -349,6 +349,12 @@ impl Drop for Surface {
     }
 }
 
+impl AsRef<Surface> for Surface {
+    fn as_ref(&self) -> &Surface {
+        self
+    }
+}
+
 impl fmt::Display for Surface {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Surface")
@@ -387,6 +393,12 @@ impl Deref for MappedImageSurface {
     type Target = ImageSurface;
 
     fn deref(&self) -> &ImageSurface {
+        &self.image_surface
+    }
+}
+
+impl AsRef<ImageSurface> for MappedImageSurface {
+    fn as_ref(&self) -> &ImageSurface {
         &self.image_surface
     }
 }

--- a/cairo/src/surface_macros.rs
+++ b/cairo/src/surface_macros.rs
@@ -96,6 +96,12 @@ macro_rules! declare_surface {
             }
         }
 
+        impl AsRef<Surface> for $surf_name {
+            fn as_ref(&self) -> &Surface {
+                &self.0
+            }
+        }
+
         impl Clone for $surf_name {
             fn clone(&self) -> $surf_name {
                 $surf_name(self.0.clone())

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -1392,7 +1392,7 @@ impl ParamSpecValueArray {
         name: &str,
         nick: impl Into<Option<&'a str>>,
         blurb: impl Into<Option<&'a str>>,
-        element_spec: Option<&ParamSpec>,
+        element_spec: Option<impl AsRef<ParamSpec>>,
         flags: ParamFlags,
     ) -> ParamSpec {
         assert_param_name(name);
@@ -1401,7 +1401,7 @@ impl ParamSpecValueArray {
                 name.to_glib_none().0,
                 nick.into().to_glib_none().0,
                 blurb.into().to_glib_none().0,
-                element_spec.to_glib_none().0,
+                element_spec.as_ref().map(|p| p.as_ref()).to_glib_none().0,
                 flags.into_glib(),
             ))
         }
@@ -1565,14 +1565,15 @@ define_param_spec!(ParamSpecOverride, gobject_ffi::GParamSpecOverride, 20);
 impl ParamSpecOverride {
     #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_param_spec_override")]
-    pub fn new(name: &str, overridden: &ParamSpec) -> ParamSpec {
+    pub fn new(name: &str, overridden: impl AsRef<ParamSpec>) -> ParamSpec {
         assert_param_name(name);
         unsafe { Self::new_unchecked(name, overridden) }
     }
-    unsafe fn new_unchecked(name: &str, overridden: &ParamSpec) -> ParamSpec {
+
+    unsafe fn new_unchecked(name: &str, overridden: impl AsRef<ParamSpec>) -> ParamSpec {
         from_glib_none(gobject_ffi::g_param_spec_override(
             name.to_glib_none().0,
-            overridden.to_glib_none().0,
+            overridden.as_ref().to_glib_none().0,
         ))
     }
 


### PR DESCRIPTION
Instead of requiring the user to go through the Deref implementation
Fixes #189