### PR TITLE
Fixed clippy lints and warnings

### DIFF
--- a/cairo/src/stream.rs
+++ b/cairo/src/stream.rs
@@ -101,7 +101,7 @@ impl Surface {
     ///
     /// This calls [`Surface::finish`], to make sure pending writes are done.
     ///
-    /// This is relevant for surfaces created for example with [`PdfSurface::for_stream`].
+    /// This is relevant for surfaces created for example with [`crate::PdfSurface::for_stream`].
     ///
     /// Use [`Box::downcast`] to recover the concrete stream type.
     ///

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -169,7 +169,7 @@ fn derive_boxed_nullable() {
     assert_eq!(b, v.get::<Option<MyNullableBoxed>>().unwrap().unwrap());
 
     let b = Some(MyNullableBoxed(String::from("def")));
-    let v = (&b).to_value();
+    let v = b.to_value();
     let b = b.unwrap();
     assert_eq!(&b, v.get::<Option<&MyNullableBoxed>>().unwrap().unwrap());
     assert_eq!(b, v.get::<Option<MyNullableBoxed>>().unwrap().unwrap());


### PR DESCRIPTION
When running `cargo doc --all-features`, I got two warnings (and a lot of deprecation warnings, which I ignored).

1. A doc link was broken (rustdoc::broken_intra_doc_links)
2. A needless borrow