### PR TITLE
Correct outdated references to `subclass::simple`

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -593,8 +593,8 @@ pub fn shared_boxed_derive(input: TokenStream) -> TokenStream {
 /// necessary for types that implement interfaces.
 ///
 /// ```ignore
-/// type Instance = glib::subclass::simple::InstanceStruct<Self>;
-/// type Class = glib::subclass::simple::ClassStruct<Self>;
+/// type Instance = glib::subclass::basic::InstanceStruct<Self>;
+/// type Class = glib::subclass::basic::ClassStruct<Self>;
 /// type Interfaces = ();
 /// ```
 ///


### PR DESCRIPTION
These were moved to `subclass::basic` in 6a19f8de4332df36893c7c901a6dd26064c08881.