### PR TITLE
glib: Bind more `g_utf8` APIs

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -24,6 +24,7 @@ generate = [
     "GLib.LogWriterOutput",
     "GLib.MainContextFlags",
     "GLib.MarkupError",
+    "GLib.NormalizeMode",
     "GLib.OptionArg",
     "GLib.OptionFlags",
     "GLib.SeekType",

--- a/glib/src/auto/enums.rs
+++ b/glib/src/auto/enums.rs
@@ -807,6 +807,66 @@ impl ErrorDomain for MarkupError {
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
 #[non_exhaustive]
+#[doc(alias = "GNormalizeMode")]
+pub enum NormalizeMode {
+    #[doc(alias = "G_NORMALIZE_DEFAULT")]
+    Default,
+    #[doc(alias = "G_NORMALIZE_DEFAULT_COMPOSE")]
+    DefaultCompose,
+    #[doc(alias = "G_NORMALIZE_ALL")]
+    All,
+    #[doc(alias = "G_NORMALIZE_ALL_COMPOSE")]
+    AllCompose,
+    #[doc(hidden)]
+    __Unknown(i32),
+}
+
+impl fmt::Display for NormalizeMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "NormalizeMode::{}",
+            match *self {
+                Self::Default => "Default",
+                Self::DefaultCompose => "DefaultCompose",
+                Self::All => "All",
+                Self::AllCompose => "AllCompose",
+                _ => "Unknown",
+            }
+        )
+    }
+}
+
+#[doc(hidden)]
+impl IntoGlib for NormalizeMode {
+    type GlibType = ffi::GNormalizeMode;
+
+    fn into_glib(self) -> ffi::GNormalizeMode {
+        match self {
+            Self::Default => ffi::G_NORMALIZE_DEFAULT,
+            Self::DefaultCompose => ffi::G_NORMALIZE_DEFAULT_COMPOSE,
+            Self::All => ffi::G_NORMALIZE_ALL,
+            Self::AllCompose => ffi::G_NORMALIZE_ALL_COMPOSE,
+            Self::__Unknown(value) => value,
+        }
+    }
+}
+
+#[doc(hidden)]
+impl FromGlib<ffi::GNormalizeMode> for NormalizeMode {
+    unsafe fn from_glib(value: ffi::GNormalizeMode) -> Self {
+        match value {
+            ffi::G_NORMALIZE_DEFAULT => Self::Default,
+            ffi::G_NORMALIZE_DEFAULT_COMPOSE => Self::DefaultCompose,
+            ffi::G_NORMALIZE_ALL => Self::All,
+            ffi::G_NORMALIZE_ALL_COMPOSE => Self::AllCompose,
+            value => Self::__Unknown(value),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+#[non_exhaustive]
 #[doc(alias = "GOptionArg")]
 pub enum OptionArg {
     #[doc(alias = "G_OPTION_ARG_NONE")]

--- a/glib/src/auto/mod.rs
+++ b/glib/src/auto/mod.rs
@@ -42,6 +42,7 @@ pub use self::enums::FileError;
 pub use self::enums::KeyFileError;
 pub use self::enums::LogWriterOutput;
 pub use self::enums::MarkupError;
+pub use self::enums::NormalizeMode;
 pub use self::enums::OptionArg;
 pub use self::enums::SeekType;
 pub use self::enums::TimeType;

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -121,6 +121,12 @@ impl GStr {
     pub fn as_c_str(&self) -> &CStr {
         unsafe { CStr::from_bytes_with_nul_unchecked(self.to_bytes_with_nul()) }
     }
+
+    #[doc(alias = "g_utf8_collate")]
+    #[doc(alias = "utf8_collate")]
+    pub fn collate(&self, other: impl AsRef<GStr>) -> Ordering {
+        unsafe { ffi::g_utf8_collate(self.as_ptr(), other.as_ref().as_ptr()) }.cmp(&0)
+    }
 }
 
 // rustdoc-stripper-ignore-next


### PR DESCRIPTION
I decided to make most of these associated functions on `GStr`, except for the utf8<->utf32 conversions.

Ref #763