### PR TITLE
image: Rebuild once every week

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,6 +1,9 @@
 name: github packages
 
 on:
+  # Rebuild the container once every week
+  schedule:
+  - cron: '0 0 * * 1'
   push:
     branches:
       - "master"


### PR DESCRIPTION
Rebuild the gtk-rs-core image once every week. The current image is already 5 months old and I suspect this to be the reason why the relm4 docs pipeline [fails](https://github.com/Relm4/docs/actions/runs/3322872513/jobs/5492499363#step:3:331) with some weird permission errors while building libpanel (but I might be wrong). 

Anyway, there's no good reason to pull the image from Fedora rawhide and then let it age for several weeks, right?
I think weekly builds are reasonable and if desired, I will send a PR for the gtk-rs image as well.

Btw. is there any reason why all the shell commands are connected with `&& \` in one single docker instruction?