### PR TITLE
Move `g_cancellable_set_error_if_cancelled()` to manual

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -398,6 +398,9 @@ manual_traits = ["CancellableExtManual"]
     name = "cancelled"
     # Racy, use 'connect' and 'disconnect' instead
     ignore = true
+    [[object.function]]
+    name = "set_error_if_cancelled"
+    manual = true
 
 [[object]]
 name = "Gio.CharsetConverter"

--- a/gio/src/auto/cancellable.rs
+++ b/gio/src/auto/cancellable.rs
@@ -5,7 +5,6 @@
 use glib::object::IsA;
 use glib::translate::*;
 use std::fmt;
-use std::ptr;
 
 glib::wrapper! {
     #[doc(alias = "GCancellable")]
@@ -62,9 +61,6 @@ pub trait CancellableExt: 'static {
 
     #[doc(alias = "g_cancellable_release_fd")]
     fn release_fd(&self);
-
-    #[doc(alias = "g_cancellable_set_error_if_cancelled")]
-    fn set_error_if_cancelled(&self) -> Result<(), glib::Error>;
 }
 
 impl<O: IsA<Cancellable>> CancellableExt for O {
@@ -105,22 +101,6 @@ impl<O: IsA<Cancellable>> CancellableExt for O {
     fn release_fd(&self) {
         unsafe {
             ffi::g_cancellable_release_fd(self.as_ref().to_glib_none().0);
-        }
-    }
-
-    fn set_error_if_cancelled(&self) -> Result<(), glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let is_ok = ffi::g_cancellable_set_error_if_cancelled(
-                self.as_ref().to_glib_none().0,
-                &mut error,
-            );
-            assert_eq!(is_ok == glib::ffi::GFALSE, !error.is_null());
-            if error.is_null() {
-                Ok(())
-            } else {
-                Err(from_glib_full(error))
-            }
         }
     }
 }

--- a/gio/src/subclass/async_initable.rs
+++ b/gio/src/subclass/async_initable.rs
@@ -9,7 +9,6 @@ use glib::subclass::prelude::*;
 
 use std::ptr;
 
-use crate::prelude::CancellableExt;
 use crate::prelude::CancellableExtManual;
 use crate::AsyncInitable;
 use crate::AsyncResult;


### PR DESCRIPTION
Regression from this change:
https://github.com/gtk-rs/gtk-rs-core/commit/7c9b36c270a945012a2f5d07c8d0f11912d66d34#diff-8439ea6875c9b60b7d07a7b39f6dde1d31d38459f7c27173e56b4cecb0eadefaR142

Basically `g_cancellable_set_error_if_cancelled()` doesn't follow the GError conventions - it's the inverse, it returns `TRUE` if an error was set, and `FALSE` otherwise.

We need to move this to manual implementation.

I caught this while updating ostree-rs-ext to use gio 0.15, and our https://github.com/ostreedev/ostree-rs-ext/blob/main/lib/src/tokio_util.rs unit test started to panic.