### PR TITLE
pango: Make `pango::Language::from_string()` infallible

### DIFF
--- a/pango/Gir.toml
+++ b/pango/Gir.toml
@@ -344,8 +344,12 @@ status = "generate"
         const = true
     [[object.function]]
     name = "from_string"
+    # This only returns NULL when passing NULL
+        [[object.function.parameter]]
+        name = "language"
+        nullable = false
         [object.function.return]
-        nullable_return_is_error = "Can't parse Language"
+        nullable = false
 
 [[object]]
 name = "Pango.Layout"

--- a/pango/src/auto/language.rs
+++ b/pango/src/auto/language.rs
@@ -59,11 +59,8 @@ impl Language {
     }
 
     #[doc(alias = "pango_language_from_string")]
-    pub fn from_string(language: Option<&str>) -> Result<Language, glib::BoolError> {
-        unsafe {
-            Option::<_>::from_glib_none(ffi::pango_language_from_string(language.to_glib_none().0))
-                .ok_or_else(|| glib::bool_error!("Can't parse Language"))
-        }
+    pub fn from_string(language: &str) -> Language {
+        unsafe { from_glib_none(ffi::pango_language_from_string(language.to_glib_none().0)) }
     }
 
     #[doc(alias = "pango_language_get_default")]

--- a/pango/src/language.rs
+++ b/pango/src/language.rs
@@ -44,8 +44,9 @@ impl Language {
 }
 
 impl FromStr for Language {
-    type Err = glib::BoolError;
+    type Err = std::convert::Infallible;
+
     fn from_str(language: &str) -> Result<Self, Self::Err> {
-        Self::from_string(Some(language))
+        Ok(Self::from_string(language))
     }
 }


### PR DESCRIPTION
It only ever returns `NULL` if passing `NULL`, which makes not much sense.