### PR TITLE
glib: Add a doc string for `as_ptr` generated impls

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -36,6 +36,7 @@ macro_rules! glib_boxed_wrapper {
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $name $(<$($generic),+>)? {
+            #[doc = "Return the inner pointer to the underlying C value."]
             pub fn as_ptr(&self) -> *mut $ffi_name {
                 $crate::translate::ToGlibPtr::to_glib_none(&self.inner).0 as *mut _
             }

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -34,6 +34,7 @@ macro_rules! glib_shared_wrapper {
         }
 
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $name $(<$($generic),+>)? {
+            #[doc = "Return the inner pointer to the underlying C value."]
             pub fn as_ptr(&self) -> *mut $ffi_name {
                 $crate::translate::ToGlibPtr::to_glib_none(&self.inner).0 as *mut _
             }


### PR DESCRIPTION
In some of my projects we use `#![deny(missing_docs)]`, and this trips up on these new generated `as_ptr` functions.

Document them on general principle.