### PR TITLE
gio: Add a GioInfaliableFuture

### DIFF
--- a/gio/src/gio_future.rs
+++ b/gio/src/gio_future.rs
@@ -11,6 +11,123 @@ use std::pin::{self, Pin};
 use crate::prelude::*;
 use crate::Cancellable;
 
+pub struct GioInfaliableFuture<F, O, T> {
+    obj: O,
+    schedule_operation: Option<F>,
+    cancellable: Option<Cancellable>,
+    receiver: Option<oneshot::Receiver<T>>,
+}
+
+pub struct GioInfaliableResult<T> {
+    sender: oneshot::Sender<T>,
+}
+
+impl<T> GioInfaliableResult<T> {
+    pub fn resolve(self, res: T) {
+        let _ = self.sender.send(res);
+    }
+}
+
+impl<F, O, T: 'static> GioInfaliableFuture<F, O, T>
+where
+    O: Clone + 'static,
+    F: FnOnce(&O, &Cancellable, GioInfaliableResult<T>) + 'static,
+{
+    pub fn new(obj: &O, schedule_operation: F) -> GioInfaliableFuture<F, O, T> {
+        Self {
+            obj: obj.clone(),
+            schedule_operation: Some(schedule_operation),
+            cancellable: Some(Cancellable::new()),
+            receiver: None,
+        }
+    }
+}
+
+impl<F, O, T> Future for GioInfaliableFuture<F, O, T>
+where
+    O: Clone + 'static,
+    F: FnOnce(&O, &Cancellable, GioInfaliableResult<T>) + 'static,
+{
+    type Output = T;
+
+    fn poll(mut self: pin::Pin<&mut Self>, ctx: &mut Context) -> Poll<T> {
+        let GioInfaliableFuture {
+            ref obj,
+            ref mut schedule_operation,
+            ref mut cancellable,
+            ref mut receiver,
+            ..
+        } = *self;
+
+        if let Some(schedule_operation) = schedule_operation.take() {
+            let main_context = glib::MainContext::ref_thread_default();
+            assert!(
+                main_context.is_owner(),
+                "Spawning futures only allowed if the thread is owning the MainContext"
+            );
+
+            // Channel for sending back the GIO async operation
+            // result to our future here.
+            //
+            // In theory, we could directly continue polling the
+            // corresponding task from the GIO async operation
+            // callback, however this would break at the very
+            // least the g_main_current_source() API.
+            let (send, recv) = oneshot::channel();
+
+            schedule_operation(
+                obj,
+                cancellable.as_ref().unwrap(),
+                GioInfaliableResult { sender: send },
+            );
+
+            *receiver = Some(recv);
+        }
+
+        // At this point we must have a receiver
+        let res = {
+            let receiver = receiver.as_mut().unwrap();
+            Pin::new(receiver).poll(ctx)
+        };
+
+        match res {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(_)) => panic!("Async operation sender was unexpectedly closed"),
+            Poll::Ready(Ok(v)) => {
+                // Get rid of the reference to the cancellable and receiver
+                let _ = cancellable.take();
+                let _ = receiver.take();
+                Poll::Ready(v)
+            }
+        }
+    }
+}
+
+impl<F, O, T> FusedFuture for GioInfaliableFuture<F, O, T>
+where
+    O: Clone + 'static,
+    F: FnOnce(&O, &Cancellable, GioInfaliableResult<T>) + 'static,
+{
+    fn is_terminated(&self) -> bool {
+        self.schedule_operation.is_none()
+            && self
+                .receiver
+                .as_ref()
+                .map_or(true, |receiver| receiver.is_terminated())
+    }
+}
+
+impl<F, O, T> Drop for GioInfaliableFuture<F, O, T> {
+    fn drop(&mut self) {
+        if let Some(cancellable) = self.cancellable.take() {
+            cancellable.cancel();
+        }
+        let _ = self.receiver.take();
+    }
+}
+
+impl<F, O, T> Unpin for GioInfaliableFuture<F, O, T> {}
+
 pub struct GioFuture<F, O, T, E> {
     obj: O,
     schedule_operation: Option<F>,


### PR DESCRIPTION
Needed for https://github.com/gtk-rs/gir/pull/1397

Note this is only needed for 0.16, for 0.17 we should break the GioFuture API to make use of `T` directly instead of `Result<T, E>`