### PR TITLE
glib: Use actual function name in `glib::BoolError` and include function name/source file/line number in structured logs

### DIFF
--- a/glib/src/error.rs
+++ b/glib/src/error.rs
@@ -158,30 +158,46 @@ pub trait ErrorDomain: Copy {
 #[macro_export]
 macro_rules! bool_error(
 // Plain strings
-    ($msg:expr) =>  {
-        $crate::BoolError::new($msg, file!(), module_path!(), line!())
-    };
+    ($msg:expr) => {{
+        $crate::BoolError::new(
+            $msg,
+            file!(),
+            $crate::function_name!(),
+            line!(),
+        )
+    }};
 
 // Format strings
-    ($($msg:tt)*) =>  { {
-        $crate::BoolError::new(format!($($msg)*), file!(), module_path!(), line!())
+    ($($msg:tt)*) =>  {{
+        $crate::BoolError::new(
+            format!($($msg)*),
+            file!(),
+            $crate::function_name!(),
+            line!(),
+        )
     }};
 );
 
 #[macro_export]
 macro_rules! result_from_gboolean(
 // Plain strings
-    ($ffi_bool:expr, $msg:expr) =>  {
-        $crate::BoolError::from_glib($ffi_bool, $msg, file!(), module_path!(), line!())
-    };
+    ($ffi_bool:expr, $msg:expr) => {{
+        $crate::BoolError::from_glib(
+            $ffi_bool,
+            $msg,
+            file!(),
+            $crate::function_name!(),
+            line!(),
+        )
+    }};
 
 // Format strings
-    ($ffi_bool:expr, $($msg:tt)*) =>  { {
+    ($ffi_bool:expr, $($msg:tt)*) =>  {{
         $crate::BoolError::from_glib(
             $ffi_bool,
             format!($($msg)*),
             file!(),
-            module_path!(),
+            $crate::function_name!(),
             line!(),
         )
     }};

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -48,6 +48,49 @@ pub use self::variant_dict::VariantDict;
 pub use self::variant_iter::{VariantIter, VariantStrIter};
 pub use self::variant_type::{VariantTy, VariantTyIterator, VariantType};
 
+// Hack for the time being to retrieve the current function's name as a string.
+// Based on the stdext cratelicensed under the MIT license.
+//
+// Copyright (c) 2020 Igor Aleksanov
+//
+// Previous attempts to get such a macro into std:
+// * https://github.com/rust-lang/rfcs/pull/466
+// * https://github.com/rust-lang/rfcs/pull/1719
+// * https://github.com/rust-lang/rfcs/issues/1743
+// * https://github.com/rust-lang/rfcs/pull/2818
+// * ...
+// rustdoc-stripper-ignore-next
+/// This macro returns the name of the enclosing function.
+/// As the internal implementation is based on the [`std::any::type_name`], this macro derives
+/// all the limitations of this function.
+///
+/// ## Examples
+///
+/// ```rust
+/// mod bar {
+///     pub fn sample_function() {
+///         assert!(glib::function_name!().ends_with("bar::sample_function"));
+///     }
+/// }
+///
+/// bar::sample_function();
+/// ```
+///
+/// [`std::any::type_name`]: https://doc.rust-lang.org/std/any/fn.type_name.html
+#[macro_export]
+macro_rules! function_name {
+    () => {{
+        // Okay, this is ugly, I get it. However, this is the best we can get on a stable rust.
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        // `3` is the length of the `::f`.
+        &name[..name.len() - 3]
+    }};
+}
+
 pub mod clone;
 #[macro_use]
 pub mod wrapper;

--- a/glib/tests/structured_log.rs
+++ b/glib/tests/structured_log.rs
@@ -82,12 +82,22 @@ fn structured_log() {
             )
         })
         .collect::<Vec<_>>();
+
+    let path = if cfg!(windows) {
+        "glib\\tests\\structured_log.rs"
+    } else {
+        "glib/tests/structured_log.rs"
+    };
+
     assert_eq!(
         log[0],
         (
             LogLevel::Message,
             vec![
                 ("PRIORITY", "5" as &str),
+                ("CODE_FILE", path as &str),
+                ("CODE_LINE", "30" as &str),
+                ("CODE_FUNC", "structured_log::structured_log" as &str),
                 ("MY_META", "abc"),
                 ("MESSAGE", "normal with meta"),
                 ("MY_META2", "def"),
@@ -101,6 +111,9 @@ fn structured_log() {
             LogLevel::Message,
             vec![
                 ("PRIORITY", "5" as &str),
+                ("CODE_FILE", path as &str),
+                ("CODE_LINE", "40" as &str),
+                ("CODE_FUNC", "structured_log::structured_log" as &str),
                 ("MY_META", "abc"),
                 ("MESSAGE", "formatted with meta: 123 456"),
                 ("MY_META2", "defghi"),


### PR DESCRIPTION
See individual commits