### PR TITLE
Suggest kebab-case for the error domain

### DIFF
--- a/glib-macros/src/error_domain_derive.rs
+++ b/glib-macros/src/error_domain_derive.rs
@@ -18,7 +18,7 @@ pub fn impl_error_domain(input: &syn::DeriveInput) -> TokenStream {
     let domain_name = match parse_name(input, "error_domain") {
         Ok(name) => name,
         Err(e) => abort_call_site!(
-            "{}: #[derive(glib::ErrorDomain)] requires #[error_domain(name = \"DomainName\")]",
+            "{}: #[derive(glib::ErrorDomain)] requires #[error_domain(name = \"domain-name\")]",
             e
         ),
     };

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -512,7 +512,7 @@ pub fn flags(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// use glib::subclass::prelude::*;
 ///
 /// #[derive(Debug, Copy, Clone, glib::ErrorDomain)]
-/// #[error_domain(name = "ExFoo")]
+/// #[error_domain(name = "ex-foo")]
 /// enum Foo {
 ///     Blah,
 ///     Baaz,


### PR DESCRIPTION
Since the quark string is part of the public API (it ends up in the gir file), follow the same convention used by glib.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/873
