### PR TITLE
glib: Optimize various from/to `Vec` FFI translation functions

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -231,10 +231,12 @@ macro_rules! glib_boxed_wrapper {
                     return Vec::new();
                 }
 
-                let mut res = Vec::with_capacity(num);
+                let mut res = Vec::<Self>::with_capacity(num);
+                let res_ptr = res.as_mut_ptr();
                 for i in 0..num {
-                    res.push($crate::translate::from_glib_none(std::ptr::read(ptr.add(i))));
+                    ::std::ptr::write(res_ptr.add(i), $crate::translate::from_glib_none(std::ptr::read(ptr.add(i))));
                 }
+                res.set_len(num);
                 res
             }
 
@@ -251,9 +253,9 @@ macro_rules! glib_boxed_wrapper {
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for i in 0..num {
-                    res.push($crate::translate::from_glib_full(std::ptr::read(ptr.add(i))));
-                }
+                let res_ptr = res.as_mut_ptr();
+                ::std::ptr::copy_nonoverlapping(ptr as *mut Self, res_ptr, num);
+                res.set_len(num);
                 $crate::ffi::g_free(ptr as *mut _);
                 res
             }

--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -439,10 +439,12 @@ macro_rules! glib_boxed_inline_wrapper {
                     return Vec::new();
                 }
 
-                let mut res = Vec::with_capacity(num);
+                let mut res = Vec::<Self>::with_capacity(num);
+                let res_ptr = res.as_mut_ptr();
                 for i in 0..num {
-                    res.push($crate::translate::from_glib_none(ptr.add(i)));
+                    ::std::ptr::write(res_ptr.add(i), $crate::translate::from_glib_none(ptr.add(i)));
                 }
+                res.set_len(num);
                 res
             }
 
@@ -459,9 +461,9 @@ macro_rules! glib_boxed_inline_wrapper {
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for i in 0..num {
-                    res.push(std::ptr::read(ptr.add(i) as *const $name $(<$($generic),+>)?));
-                }
+                let res_ptr = res.as_mut_ptr();
+                ::std::ptr::copy_nonoverlapping(ptr as *mut Self, res_ptr, num);
+                res.set_len(num);
                 $crate::ffi::g_free(ptr as *mut _);
                 res
             }
@@ -474,10 +476,12 @@ macro_rules! glib_boxed_inline_wrapper {
                     return Vec::new();
                 }
 
-                let mut res = Vec::with_capacity(num);
+                let mut res = Vec::<Self>::with_capacity(num);
+                let res_ptr = res.as_mut_ptr();
                 for i in 0..num {
-                    res.push($crate::translate::from_glib_none(std::ptr::read(ptr.add(i))));
+                    ::std::ptr::write(res_ptr.add(i), $crate::translate::from_glib_none(::std::ptr::read(ptr.add(i))));
                 }
+                res.set_len(num);
                 res
             }
 
@@ -493,10 +497,12 @@ macro_rules! glib_boxed_inline_wrapper {
                     return Vec::new();
                 }
 
-                let mut res = Vec::with_capacity(num);
+                let mut res = Vec::<Self>::with_capacity(num);
+                let res_ptr = res.as_mut_ptr();
                 for i in 0..num {
-                    res.push($crate::translate::from_glib_full(std::ptr::read(ptr.add(i))));
+                    ::std::ptr::write(res_ptr.add(i), $crate::translate::from_glib_full(::std::ptr::read(ptr.add(i))));
                 }
+                res.set_len(num);
                 $crate::ffi::g_free(ptr as *mut _);
                 res
             }

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -943,10 +943,12 @@ macro_rules! glib_object_wrapper {
                     return Vec::new();
                 }
 
-                let mut res = Vec::with_capacity(num);
+                let mut res = Vec::<Self>::with_capacity(num);
+                let res_ptr = res.as_mut_ptr();
                 for i in 0..num {
-                    res.push($crate::translate::from_glib_none(std::ptr::read(ptr.add(i))));
+                    ::std::ptr::write(res_ptr.add(i), $crate::translate::from_glib_none(std::ptr::read(ptr.add(i))));
                 }
+                res.set_len(num);
                 res
             }
 
@@ -963,9 +965,9 @@ macro_rules! glib_object_wrapper {
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for i in 0..num {
-                    res.push($crate::translate::from_glib_full(std::ptr::read(ptr.add(i))));
-                }
+                let res_ptr = res.as_mut_ptr();
+                ::std::ptr::copy_nonoverlapping(ptr as *mut Self, res_ptr, num);
+                res.set_len(num);
                 $crate::ffi::g_free(ptr as *mut _);
                 res
             }

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -232,10 +232,12 @@ macro_rules! glib_shared_wrapper {
                     return Vec::new();
                 }
 
-                let mut res = Vec::with_capacity(num);
+                let mut res = Vec::<Self>::with_capacity(num);
+                let res_ptr = res.as_mut_ptr();
                 for i in 0..num {
-                    res.push($crate::translate::from_glib_none(std::ptr::read(ptr.add(i))));
+                    ::std::ptr::write(res_ptr.add(i), $crate::translate::from_glib_none(std::ptr::read(ptr.add(i))));
                 }
+                res.set_len(num);
                 res
             }
 
@@ -252,9 +254,9 @@ macro_rules! glib_shared_wrapper {
                 }
 
                 let mut res = Vec::with_capacity(num);
-                for i in 0..num {
-                    res.push($crate::translate::from_glib_full(std::ptr::read(ptr.add(i))));
-                }
+                let res_ptr = res.as_mut_ptr();
+                ::std::ptr::copy_nonoverlapping(ptr as *mut Self, res_ptr, num);
+                res.set_len(num);
                 $crate::ffi::g_free(ptr as *mut _);
                 res
             }

--- a/glib/src/subclass/signal.rs
+++ b/glib/src/subclass/signal.rs
@@ -354,30 +354,6 @@ impl IntoGlib for SignalType {
     }
 }
 
-impl FromGlibContainerAsVec<Type, *const ffi::GType> for SignalType {
-    unsafe fn from_glib_none_num_as_vec(ptr: *const ffi::GType, num: usize) -> Vec<Self> {
-        if num == 0 || ptr.is_null() {
-            return Vec::new();
-        }
-
-        let mut res = Vec::with_capacity(num);
-        for i in 0..num {
-            res.push(from_glib(*ptr.add(i)));
-        }
-        res
-    }
-
-    unsafe fn from_glib_container_num_as_vec(_: *const ffi::GType, _: usize) -> Vec<Self> {
-        // Can't really free a *const
-        unimplemented!();
-    }
-
-    unsafe fn from_glib_full_num_as_vec(_: *const ffi::GType, _: usize) -> Vec<Self> {
-        // Can't really free a *const
-        unimplemented!();
-    }
-}
-
 #[allow(clippy::type_complexity)]
 enum SignalRegistration {
     Unregistered {

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -560,10 +560,9 @@ impl<'a> ToGlibContainerFromSlice<'a, *mut ffi::GType> for Type {
 
         unsafe {
             let res =
-                ffi::g_malloc0(mem::size_of::<ffi::GType>() * (t.len() + 1)) as *mut ffi::GType;
-            for (i, v) in t.iter().enumerate() {
-                *res.add(i) = v.into_glib();
-            }
+                ffi::g_malloc(mem::size_of::<ffi::GType>() * (t.len() + 1)) as *mut ffi::GType;
+            std::ptr::copy_nonoverlapping(t.as_ptr() as *const ffi::GType, res, t.len());
+            *res.add(t.len()) = 0;
             res
         }
     }
@@ -575,10 +574,10 @@ impl FromGlibContainerAsVec<Type, *const ffi::GType> for Type {
             return Vec::new();
         }
 
-        let mut res = Vec::with_capacity(num);
-        for i in 0..num {
-            res.push(from_glib(*ptr.add(i)));
-        }
+        let mut res = Vec::<Self>::with_capacity(num);
+        let res_ptr = res.as_mut_ptr() as *mut ffi::GType;
+        std::ptr::copy_nonoverlapping(ptr, res_ptr, num);
+        res.set_len(num);
         res
     }
 


### PR DESCRIPTION
Use memcpys if possible instead of manual loops, and directly write into
the `Vec` memory and set the length afterwards to avoid having the
reallocate logic at every step.