### PR TITLE
application: Return ExitCode

### DIFF
--- a/glib/src/exit_code.rs
+++ b/glib/src/exit_code.rs
@@ -1,0 +1,33 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use std::process::Termination;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord)]
+pub struct ExitCode(i32);
+
+impl ExitCode {
+    pub const SUCCESS: Self = Self(0);
+    pub const FAILURE: Self = Self(1);
+
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+}
+
+impl From<i32> for ExitCode {
+    fn from(value: i32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ExitCode> for i32 {
+    fn from(value: ExitCode) -> Self {
+        value.0
+    }
+}
+
+impl Termination for ExitCode {
+    fn report(self) -> std::process::ExitCode {
+        std::process::ExitCode::from(self.0 as u8)
+    }
+}

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -105,6 +105,8 @@ pub mod object;
 
 mod boxed_any_object;
 pub use boxed_any_object::BoxedAnyObject;
+mod exit_code;
+pub use exit_code::ExitCode;
 
 pub mod collections;
 pub use collections::{


### PR DESCRIPTION
Allows writing

```rust
    fn main() -> ExitCode {
        let app = gio::Application::new(None, Default::default());
        // ...
        app.run()
    }
```

in Rust 1.61 or newer. 

Note that the [termination](https://doc.rust-lang.org/std/process/trait.Termination.html) trait is supported for any Result<T: Termination, E: Debug>, we might want to return that instead, but it is kinda redundant at gtk already returns errors as a number.
