### PR TITLE
pango: use the new List api to simplify reorder_items

### DIFF
--- a/pango/src/functions.rs
+++ b/pango/src/functions.rs
@@ -1,7 +1,5 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::ptr;
-
 use glib::translate::*;
 
 #[cfg(any(feature = "v1_44", feature = "dox"))]
@@ -9,19 +7,11 @@ use crate::ShapeFlags;
 use crate::{Analysis, GlyphString, Item};
 
 #[doc(alias = "pango_reorder_items")]
-pub fn reorder_items(logical_items: &[&Item]) -> Vec<Item> {
+pub fn reorder_items(logical_items: &glib::List<Item>) -> glib::List<Item> {
     unsafe {
-        let stash_vec: Vec<_> = logical_items
-            .iter()
-            .rev()
-            .map(|v| v.to_glib_none())
-            .collect();
-        let mut list: *mut glib::ffi::GList = ptr::null_mut();
-        for stash in &stash_vec {
-            list = glib::ffi::g_list_prepend(list, Ptr::to(stash.0));
-        }
-
-        FromGlibPtrContainer::from_glib_full(ffi::pango_reorder_items(list))
+        FromGlibPtrContainer::from_glib_full(ffi::pango_reorder_items(
+            logical_items.as_ptr() as *mut _
+        ))
     }
 }
 


### PR DESCRIPTION
As discussed in chat, we could also change the signature to take `&[Item]` and avoid the cloning, but I am not familiar enough with the use of this API to understand if that would be problematic for the caller