### PR TITLE
glib: Add `MainContext::spawn_from_within()` for spawning non-`Send` …

### DIFF
--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -199,7 +199,7 @@ pub use self::bridged_logging::{rust_log_handler, GlibLogger, GlibLoggerDomain, 
 pub mod subclass;
 
 mod main_context_futures;
-pub use main_context_futures::{JoinError, JoinHandle};
+pub use main_context_futures::{JoinError, JoinHandle, SpawnWithinJoinHandle};
 mod source_futures;
 pub use self::source_futures::*;
 


### PR DESCRIPTION
…futures from another thread

This requires a `Send` closure to construct the non-`Send` future and is for example useful if spawning a future that creates non-`Send` GObjects on the main context from another thread.

----

CC @elmarco @pbor 