### PR TITLE
build-tools: Fix reporting of errors

### DIFF
--- a/glib-build-tools/src/lib.rs
+++ b/glib-build-tools/src/lib.rs
@@ -18,18 +18,20 @@ use std::{env, path::Path, process::Command};
 pub fn compile_resources<P: AsRef<Path>>(source_dir: P, gresource: &str, target: &str) {
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    let status = Command::new("glib-compile-resources")
+    let output = Command::new("glib-compile-resources")
         .arg("--sourcedir")
         .arg(source_dir.as_ref())
         .arg("--target")
         .arg(&format!("{out_dir}/{target}"))
         .arg(gresource)
-        .status()
+        .output()
         .unwrap();
 
     assert!(
-        status.success(),
-        "glib-compile-resources failed with exit status {status}",
+        output.status.success(),
+        "glib-compile-resources failed with exit status {} and stderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
     );
 
     println!("cargo:rerun-if-changed={gresource}");


### PR DESCRIPTION
I have to admit that I don't fully understand why this is happening, but if glib-compile-resources fails due to a bad file for example, the current code ends up printing no error message at all.
It seems that the stderr from the failing command and the stderr of the assert somehow cancel each other out.

With this patch, the stderr of the command is properly recorded and explicitly written to the stderr of the build script through the assert. This fixed the error reporting in my case and should be a much more robust solution in general.