### PR TITLE
glib: Deprecate `ObjectSubclass::instance()` / `from_instance()` in f…

### DIFF
--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -121,7 +121,7 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
             type FromObjectType = <Self as #crate_ident::subclass::types::ObjectSubclass>::Type;
             #[inline]
             fn from_object(obj: &Self::FromObjectType) -> &Self {
-                <Self as #crate_ident::subclass::types::ObjectSubclassExt>::from_instance(obj)
+                <Self as #crate_ident::subclass::types::ObjectSubclassExt>::from_obj(obj)
             }
         }
 

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -127,7 +127,16 @@ pub trait ObjectInterfaceExt: ObjectInterface {
     ///
     /// This will panic if `obj` does not implement the interface.
     #[inline]
+    #[deprecated = "Use from_obj() instead"]
     fn from_instance<T: IsA<Object>>(obj: &T) -> &Self {
+        Self::from_obj(obj)
+    }
+
+    /// Get interface from an instance.
+    ///
+    /// This will panic if `obj` does not implement the interface.
+    #[inline]
+    fn from_obj<T: IsA<Object>>(obj: &T) -> &Self {
         assert!(obj.as_ref().type_().is_a(Self::type_()));
 
         unsafe {

--- a/glib/src/subclass/object_impl_ref.rs
+++ b/glib/src/subclass/object_impl_ref.rs
@@ -55,7 +55,7 @@ impl<T: ObjectSubclass> std::ops::Deref for ObjectImplRef<T> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        T::from_instance(&self.0)
+        T::from_obj(&self.0)
     }
 }
 

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -119,7 +119,7 @@ pub trait ObjectSubclassIsExt: ObjectSubclassIs {
 impl<T: ObjectSubclassIs<Subclass = S>, S: ObjectSubclass<Type = Self>> ObjectSubclassIsExt for T {
     #[inline]
     fn imp(&self) -> &T::Subclass {
-        T::Subclass::from_instance(self)
+        T::Subclass::from_obj(self)
     }
 }
 
@@ -665,10 +665,12 @@ pub trait ObjectSubclassExt: ObjectSubclass {
     // rustdoc-stripper-ignore-next
     /// Returns the corresponding object instance.
     #[doc(alias = "get_instance")]
+    #[deprecated = "Use obj() instead"]
     fn instance(&self) -> crate::BorrowedObject<Self::Type>;
 
     // rustdoc-stripper-ignore-next
     /// Returns the implementation from an instance.
+    #[deprecated = "Use from_obj() instead"]
     fn from_instance(obj: &Self::Type) -> &Self;
 
     // rustdoc-stripper-ignore-next


### PR DESCRIPTION
…avour of the shorter versions

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/807