### PR TITLE
glib: Add new object constructor for constructing an object with default property values

### DIFF
--- a/examples/gio_task/file_size/mod.rs
+++ b/examples/gio_task/file_size/mod.rs
@@ -13,7 +13,7 @@ unsafe impl Sync for FileSize {}
 
 impl FileSize {
     pub fn new() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 
     pub fn retrieved_size(&self) -> Option<i64> {

--- a/gio/src/async_initable.rs
+++ b/gio/src/async_initable.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::{boxed::Box as Box_, pin::Pin};
+use std::{boxed::Box as Box_, marker::PhantomData, pin::Pin};
 
 use futures_util::TryFutureExt;
 use glib::{object::IsClass, prelude::*, Object, Type};
@@ -8,16 +8,21 @@ use glib::{object::IsClass, prelude::*, Object, Type};
 use crate::{prelude::*, AsyncInitable, Cancellable};
 
 impl AsyncInitable {
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object with the given properties.
+    ///
+    /// Similar to [`Object::new`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
+    #[allow(clippy::new_ret_no_self)]
     #[doc(alias = "g_async_initable_new_async")]
     #[track_caller]
-    pub fn new_async<
-        O: Sized + IsClass + IsA<Object> + IsA<AsyncInitable>,
-        P: IsA<Cancellable>,
+    pub fn new<
+        O: IsClass + IsA<Object> + IsA<AsyncInitable>,
         Q: FnOnce(Result<O, glib::Error>) + 'static,
     >(
         properties: &[(&str, &dyn ToValue)],
         io_priority: glib::Priority,
-        cancellable: Option<&P>,
+        cancellable: Option<&impl IsA<Cancellable>>,
         callback: Q,
     ) {
         Self::with_type(
@@ -29,9 +34,14 @@ impl AsyncInitable {
         )
     }
 
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object with the given properties as future.
+    ///
+    /// Similar to [`Object::new`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
     #[doc(alias = "g_async_initable_new_async")]
     #[track_caller]
-    pub fn new_future<O: Sized + IsClass + IsA<Object> + IsA<AsyncInitable>>(
+    pub fn new_future<O: IsClass + IsA<Object> + IsA<AsyncInitable>>(
         properties: &[(&str, &dyn ToValue)],
         io_priority: glib::Priority,
     ) -> Pin<Box_<dyn std::future::Future<Output = Result<O, glib::Error>> + 'static>> {
@@ -41,13 +51,18 @@ impl AsyncInitable {
         )
     }
 
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the given properties.
+    ///
+    /// Similar to [`Object::with_type`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
     #[doc(alias = "g_async_initable_new_async")]
     #[track_caller]
-    pub fn with_type<P: IsA<Cancellable>, Q: FnOnce(Result<Object, glib::Error>) + 'static>(
+    pub fn with_type<Q: FnOnce(Result<Object, glib::Error>) + 'static>(
         type_: Type,
         properties: &[(&str, &dyn ToValue)],
         io_priority: glib::Priority,
-        cancellable: Option<&P>,
+        cancellable: Option<&impl IsA<Cancellable>>,
         callback: Q,
     ) {
         if !type_.is_a(AsyncInitable::static_type()) {
@@ -71,6 +86,11 @@ impl AsyncInitable {
         };
     }
 
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the given properties as future.
+    ///
+    /// Similar to [`Object::with_type`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
     #[doc(alias = "g_async_initable_new_async")]
     #[track_caller]
     pub fn with_type_future(
@@ -105,13 +125,116 @@ impl AsyncInitable {
         }
     }
 
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object with the default property values.
+    ///
+    /// Similar to [`Object::new_default`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
     #[doc(alias = "g_async_initable_new_async")]
     #[track_caller]
-    pub fn with_values<P: IsA<Cancellable>, Q: FnOnce(Result<Object, glib::Error>) + 'static>(
+    pub fn new_default<
+        O: IsClass + IsA<Object> + IsA<AsyncInitable>,
+        Q: FnOnce(Result<O, glib::Error>) + 'static,
+    >(
+        io_priority: glib::Priority,
+        cancellable: Option<&impl IsA<Cancellable>>,
+        callback: Q,
+    ) {
+        Self::new_default_with_type(O::static_type(), io_priority, cancellable, move |res| {
+            callback(res.map(|o| unsafe { o.unsafe_cast() }))
+        })
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object with the default property values as future.
+    ///
+    /// Similar to [`Object::new_default`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
+    #[doc(alias = "g_async_initable_new_async")]
+    #[track_caller]
+    pub fn new_default_future<O: IsClass + IsA<Object> + IsA<AsyncInitable>>(
+        io_priority: glib::Priority,
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<O, glib::Error>> + 'static>> {
+        Box::pin(
+            Self::new_default_with_type_future(O::static_type(), io_priority)
+                .map_ok(|o| unsafe { o.unsafe_cast() }),
+        )
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the default
+    /// property values.
+    ///
+    /// Similar to [`Object::new_default_with_type`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
+    #[doc(alias = "g_async_initable_new_async")]
+    #[track_caller]
+    pub fn new_default_with_type<Q: FnOnce(Result<Object, glib::Error>) + 'static>(
+        type_: Type,
+        io_priority: glib::Priority,
+        cancellable: Option<&impl IsA<Cancellable>>,
+        callback: Q,
+    ) {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            panic!("Type '{type_}' is not async initable");
+        }
+
+        unsafe {
+            let obj = Object::new_internal(type_, &mut []);
+            obj.unsafe_cast_ref::<Self>().init_async(
+                io_priority,
+                cancellable,
+                glib::clone!(@strong obj => move |res| {
+                    callback(res.map(|_| obj));
+                }),
+            )
+        };
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the default property values as future.
+    ///
+    /// Similar to [`Object::new_default_with_type`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
+    #[doc(alias = "g_async_initable_new_async")]
+    #[track_caller]
+    pub fn new_default_with_type_future(
+        type_: Type,
+        io_priority: glib::Priority,
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<Object, glib::Error>> + 'static>> {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            panic!("Type '{type_}' is not async initable");
+        }
+
+        unsafe {
+            Box_::pin(crate::GioFuture::new(
+                &(),
+                move |_obj, cancellable, send| {
+                    let obj = Object::new_internal(type_, &mut []);
+                    obj.unsafe_cast_ref::<Self>().init_async(
+                        io_priority,
+                        Some(cancellable),
+                        glib::clone!(@strong obj => move |res| {
+                            send.resolve(res.map(|_| obj));
+                        }),
+                    );
+                },
+            ))
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the given properties.
+    ///
+    /// Similar to [`Object::with_values`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
+    #[doc(alias = "g_async_initable_new_async")]
+    #[track_caller]
+    pub fn with_values<Q: FnOnce(Result<Object, glib::Error>) + 'static>(
         type_: Type,
         properties: &[(&str, glib::Value)],
         io_priority: glib::Priority,
-        cancellable: Option<&P>,
+        cancellable: Option<&impl IsA<Cancellable>>,
         callback: Q,
     ) {
         if !type_.is_a(AsyncInitable::static_type()) {
@@ -135,6 +258,11 @@ impl AsyncInitable {
         };
     }
 
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the given properties as a future.
+    ///
+    /// Similar to [`Object::with_values`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
     #[doc(alias = "g_async_initable_new_async")]
     #[track_caller]
     pub fn with_values_future(
@@ -167,5 +295,172 @@ impl AsyncInitable {
                 },
             ))
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the given properties as mutable values.
+    ///
+    /// Similar to [`Object::with_mut_values`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
+    #[doc(alias = "g_async_initable_new_async")]
+    #[track_caller]
+    pub fn with_mut_values<Q: FnOnce(Result<Object, glib::Error>) + 'static>(
+        type_: Type,
+        properties: &mut [(&str, glib::Value)],
+        io_priority: glib::Priority,
+        cancellable: Option<&impl IsA<Cancellable>>,
+        callback: Q,
+    ) {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            panic!("Type '{type_}' is not async initable");
+        }
+
+        unsafe {
+            let obj = Object::new_internal(type_, properties);
+            obj.unsafe_cast_ref::<Self>().init_async(
+                io_priority,
+                cancellable,
+                glib::clone!(@strong obj => move |res| {
+                    callback(res.map(|_| obj));
+                }),
+            )
+        };
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an async initable object of the given type with the given properties as mutable values as a future.
+    ///
+    /// Similar to [`Object::with_mut_values`] but can fail because the object initialization in
+    /// `AsyncInitable::init` failed.
+    #[doc(alias = "g_async_initable_new_async")]
+    #[track_caller]
+    pub fn with_mut_values_future(
+        type_: Type,
+        properties: &mut [(&str, glib::Value)],
+        io_priority: glib::Priority,
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<Object, glib::Error>> + 'static>> {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            panic!("Type '{type_}' is not async initable");
+        }
+
+        unsafe {
+            // FIXME: object construction should ideally happen as part of the future
+            let obj = Object::new_internal(type_, properties);
+            Box_::pin(crate::GioFuture::new(
+                &obj,
+                move |obj, cancellable, send| {
+                    obj.unsafe_cast_ref::<Self>().init_async(
+                        io_priority,
+                        Some(cancellable),
+                        glib::clone!(@strong obj => move |res| {
+                            send.resolve(res.map(|_| obj));
+                        }),
+                    );
+                },
+            ))
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new object builder for a specific type.
+    pub fn builder<'a, O: IsA<Object> + IsClass + IsA<AsyncInitable>>(
+    ) -> AsyncInitableBuilder<'a, O> {
+        AsyncInitableBuilder::new(O::static_type())
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new object builder for a specific type.
+    pub fn builder_with_type<'a>(type_: Type) -> AsyncInitableBuilder<'a, Object> {
+        if !type_.is_a(AsyncInitable::static_type()) {
+            panic!("Type '{type_}' is not async initable");
+        }
+
+        AsyncInitableBuilder::new(type_)
+    }
+}
+
+#[must_use = "builder doesn't do anything unless built"]
+pub struct AsyncInitableBuilder<'a, O> {
+    type_: Type,
+    properties: smallvec::SmallVec<[(&'a str, glib::Value); 16]>,
+    phantom: PhantomData<O>,
+}
+
+impl<'a, O: IsA<Object> + IsClass> AsyncInitableBuilder<'a, O> {
+    #[inline]
+    fn new(type_: Type) -> Self {
+        AsyncInitableBuilder {
+            type_,
+            properties: smallvec::SmallVec::new(),
+            phantom: PhantomData,
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Gets the type of this builder.
+    #[inline]
+    pub fn type_(&self) -> Type {
+        self.type_
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Set property `name` to the given value `value`.
+    #[inline]
+    pub fn property(self, name: &'a str, value: impl Into<glib::Value>) -> Self {
+        let AsyncInitableBuilder {
+            type_,
+            mut properties,
+            ..
+        } = self;
+        properties.push((name, value.into()));
+
+        AsyncInitableBuilder {
+            type_,
+            properties,
+            phantom: PhantomData,
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the object with the provided properties.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the object is not instantiable, doesn't have all the given properties or
+    /// property values of the wrong type are provided.
+    #[track_caller]
+    #[inline]
+    pub fn build<Q: FnOnce(Result<O, glib::Error>) + 'static>(
+        mut self,
+        io_priority: glib::Priority,
+        cancellable: Option<&impl IsA<Cancellable>>,
+        callback: Q,
+    ) {
+        AsyncInitable::with_mut_values(
+            self.type_,
+            &mut self.properties,
+            io_priority,
+            cancellable,
+            move |res| callback(res.map(|o| unsafe { o.unsafe_cast() })),
+        );
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the object with the provided properties.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the object is not instantiable, doesn't have all the given properties or
+    /// property values of the wrong type are provided.
+    #[track_caller]
+    #[inline]
+    pub fn build_future(
+        mut self,
+        io_priority: glib::Priority,
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<O, glib::Error>> + 'static>> {
+        Box::pin(
+            AsyncInitable::with_mut_values_future(self.type_, &mut self.properties, io_priority)
+                .map_ok(|o| unsafe { o.unsafe_cast() }),
+        )
     }
 }

--- a/gio/src/initable.rs
+++ b/gio/src/initable.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::marker::PhantomData;
+
 use glib::{object::IsClass, prelude::*, Object, Type};
 
 use crate::{prelude::*, Cancellable, Initable};
@@ -12,9 +14,9 @@ impl Initable {
     /// `Initable::init` failed.
     #[allow(clippy::new_ret_no_self)]
     #[track_caller]
-    pub fn new<O: Sized + IsClass + IsA<Object> + IsA<Initable>, P: IsA<Cancellable>>(
+    pub fn new<O: IsClass + IsA<Object> + IsA<Initable>>(
         properties: &[(&str, &dyn ToValue)],
-        cancellable: Option<&P>,
+        cancellable: Option<&impl IsA<Cancellable>>,
     ) -> Result<O, glib::Error> {
         Self::with_type(O::static_type(), properties, cancellable)
             .map(|o| unsafe { o.unsafe_cast() })
@@ -48,6 +50,40 @@ impl Initable {
     }
 
     // rustdoc-stripper-ignore-next
+    /// Create a new instance of an object with the default property values.
+    ///
+    /// Similar to [`Object::new_default`] but can fail because the object initialization in
+    /// `Initable::init` failed.
+    #[track_caller]
+    pub fn new_default<T: IsA<Object> + IsClass + IsA<Initable>>(
+        cancellable: Option<&impl IsA<Cancellable>>,
+    ) -> Result<T, glib::Error> {
+        let object = Self::new_default_with_type(T::static_type(), cancellable)?;
+        Ok(unsafe { object.unsafe_cast() })
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an object with the default property values.
+    ///
+    /// Similar to [`Object::new_default_with_type`] but can fail because the object initialization in
+    /// `Initable::init` failed.
+    #[track_caller]
+    pub fn new_default_with_type(
+        type_: Type,
+        cancellable: Option<&impl IsA<Cancellable>>,
+    ) -> Result<Object, glib::Error> {
+        if !type_.is_a(Initable::static_type()) {
+            panic!("Type '{type_}' is not initable");
+        }
+
+        unsafe {
+            let object = Object::new_internal(type_, &mut []);
+            object.unsafe_cast_ref::<Self>().init(cancellable)?;
+            Ok(object)
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
     /// Create a new instance of an initable object of the given type with the given properties.
     ///
     /// Similar to [`Object::with_values`] but can fail because the object initialization in
@@ -72,5 +108,103 @@ impl Initable {
             object.unsafe_cast_ref::<Self>().init(cancellable)?;
             Ok(object)
         }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new instance of an object of the given type with the given properties as mutable
+    /// values.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the object is not instantiable, doesn't have all the given properties or
+    /// property values of the wrong type are provided.
+    #[track_caller]
+    pub fn with_mut_values(
+        type_: Type,
+        properties: &mut [(&str, glib::Value)],
+        cancellable: Option<&impl IsA<Cancellable>>,
+    ) -> Result<Object, glib::Error> {
+        if !type_.is_a(Initable::static_type()) {
+            panic!("Type '{type_}' is not initable");
+        }
+
+        unsafe {
+            let object = Object::new_internal(type_, properties);
+            object.unsafe_cast_ref::<Self>().init(cancellable)?;
+            Ok(object)
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new object builder for a specific type.
+    pub fn builder<'a, O: IsA<Object> + IsClass + IsA<Initable>>() -> InitableBuilder<'a, O> {
+        InitableBuilder::new(O::static_type())
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Create a new object builder for a specific type.
+    pub fn builder_with_type<'a>(type_: Type) -> InitableBuilder<'a, Object> {
+        if !type_.is_a(Initable::static_type()) {
+            panic!("Type '{type_}' is not initable");
+        }
+
+        InitableBuilder::new(type_)
+    }
+}
+
+#[must_use = "builder doesn't do anything unless built"]
+pub struct InitableBuilder<'a, O> {
+    type_: Type,
+    properties: smallvec::SmallVec<[(&'a str, glib::Value); 16]>,
+    phantom: PhantomData<O>,
+}
+
+impl<'a, O: IsA<Object> + IsClass> InitableBuilder<'a, O> {
+    #[inline]
+    fn new(type_: Type) -> Self {
+        InitableBuilder {
+            type_,
+            properties: smallvec::SmallVec::new(),
+            phantom: PhantomData,
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Gets the type of this builder.
+    #[inline]
+    pub fn type_(&self) -> Type {
+        self.type_
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Set property `name` to the given value `value`.
+    #[inline]
+    pub fn property(self, name: &'a str, value: impl Into<glib::Value>) -> Self {
+        let InitableBuilder {
+            type_,
+            mut properties,
+            ..
+        } = self;
+        properties.push((name, value.into()));
+
+        InitableBuilder {
+            type_,
+            properties,
+            phantom: PhantomData,
+        }
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Build the object with the provided properties.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the object is not instantiable, doesn't have all the given properties or
+    /// property values of the wrong type are provided.
+    #[track_caller]
+    #[inline]
+    pub fn build(mut self, cancellable: Option<&impl IsA<Cancellable>>) -> Result<O, glib::Error> {
+        let object = Initable::with_mut_values(self.type_, &mut self.properties, cancellable)?;
+        Ok(unsafe { object.unsafe_cast::<O>() })
     }
 }

--- a/gio/src/read_input_stream.rs
+++ b/gio/src/read_input_stream.rs
@@ -146,7 +146,7 @@ glib::wrapper! {
 
 impl ReadInputStream {
     pub fn new<R: Read + Send + 'static>(read: R) -> ReadInputStream {
-        let obj: Self = glib::Object::new(&[]);
+        let obj: Self = glib::Object::new_default();
 
         *obj.imp().read.borrow_mut() = Some(imp::Reader::Read(AnyReader::new(read)));
 
@@ -154,7 +154,7 @@ impl ReadInputStream {
     }
 
     pub fn new_seekable<R: Read + Seek + Send + 'static>(read: R) -> ReadInputStream {
-        let obj: Self = glib::Object::new(&[]);
+        let obj: Self = glib::Object::new_default();
 
         *obj.imp().read.borrow_mut() = Some(imp::Reader::ReadSeek(AnyReader::new_seekable(read)));
 

--- a/gio/src/subclass/initable.rs
+++ b/gio/src/subclass/initable.rs
@@ -167,10 +167,9 @@ mod tests {
     #[should_panic = ""]
     fn test_initable_new_failure() {
         let value: u32 = 2;
-        let _ = Initable::new::<InitableTestType, Cancellable>(
-            &[("invalid-property", &value)],
-            Option::<&Cancellable>::None,
-        );
+        let _ = Initable::builder::<InitableTestType>()
+            .property("invalid-property", value)
+            .build(Option::<&Cancellable>::None);
         unreachable!();
     }
 

--- a/gio/src/task.rs
+++ b/gio/src/task.rs
@@ -500,7 +500,7 @@ mod test {
 
         impl MySimpleObject {
             pub fn new() -> Self {
-                glib::Object::new(&[])
+                glib::Object::new_default()
             }
 
             #[doc(alias = "get_size")]

--- a/gio/src/write_output_stream.rs
+++ b/gio/src/write_output_stream.rs
@@ -169,14 +169,14 @@ glib::wrapper! {
 
 impl WriteOutputStream {
     pub fn new<W: Write + Send + Any + 'static>(write: W) -> WriteOutputStream {
-        let obj: Self = glib::Object::new(&[]);
+        let obj: Self = glib::Object::new_default();
 
         *obj.imp().write.borrow_mut() = Some(imp::Writer::Write(AnyWriter::new(write)));
         obj
     }
 
     pub fn new_seekable<W: Write + Seek + Send + Any + 'static>(write: W) -> WriteOutputStream {
-        let obj: Self = glib::Object::new(&[]);
+        let obj: Self = glib::Object::new_default();
 
         *obj.imp().write.borrow_mut() =
             Some(imp::Writer::WriteSeek(AnyWriter::new_seekable(write)));

--- a/glib/src/boxed_any_object.rs
+++ b/glib/src/boxed_any_object.rs
@@ -90,7 +90,7 @@ impl BoxedAnyObject {
     // rustdoc-stripper-ignore-next
     /// Creates a new `BoxedAnyObject` containing `value`
     pub fn new<T: 'static>(value: T) -> Self {
-        let obj: Self = Object::new(&[]);
+        let obj: Self = Object::new_default();
         obj.replace(value);
         obj
     }

--- a/glib/src/gobject/binding.rs
+++ b/glib/src/gobject/binding.rs
@@ -279,7 +279,7 @@ mod test {
 
     impl Default for TestObject {
         fn default() -> Self {
-            crate::Object::new(&[])
+            crate::Object::new_default()
         }
     }
 

--- a/glib/src/gobject/binding_group.rs
+++ b/glib/src/gobject/binding_group.rs
@@ -479,7 +479,7 @@ mod test {
 
     impl Default for TestObject {
         fn default() -> Self {
-            crate::Object::new(&[])
+            crate::Object::new_default()
         }
     }
 

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -176,7 +176,7 @@
 //! impl SimpleObject {
 //!     // Create an object instance of the new type.
 //!     pub fn new() -> Self {
-//!         glib::Object::new(&[])
+//!         glib::Object::new_default()
 //!     }
 //! }
 //!

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -431,7 +431,7 @@ mod test {
 
     #[test]
     fn test_create_child_object() {
-        let obj: ChildObject = Object::new(&[]);
+        let obj: ChildObject = Object::new_default();
 
         assert_eq!(&obj, obj.imp().obj().as_ref());
     }

--- a/glib/tests/subclass_compiletest/01-auto-send-sync.rs
+++ b/glib/tests/subclass_compiletest/01-auto-send-sync.rs
@@ -21,7 +21,7 @@ glib::wrapper! {
 
 impl Default for TestObject {
     fn default() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 }
 

--- a/glib/tests/subclass_compiletest/02-no-auto-send-sync.rs
+++ b/glib/tests/subclass_compiletest/02-no-auto-send-sync.rs
@@ -22,7 +22,7 @@ glib::wrapper! {
 
 impl Default for TestObject {
     fn default() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 }
 

--- a/glib/tests/subclass_compiletest/04-auto-send-sync-with-send-sync-parent.rs
+++ b/glib/tests/subclass_compiletest/04-auto-send-sync-with-send-sync-parent.rs
@@ -25,7 +25,7 @@ unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for Te
 
 impl Default for TestParent {
     fn default() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 }
 
@@ -54,7 +54,7 @@ glib::wrapper! {
 
 impl Default for TestObject {
     fn default() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 }
 

--- a/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs
+++ b/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs
@@ -26,7 +26,7 @@ unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for Te
 
 impl Default for TestParent {
     fn default() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 }
 
@@ -55,7 +55,7 @@ glib::wrapper! {
 
 impl Default for TestObject {
     fn default() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 }
 

--- a/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs
+++ b/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs
@@ -39,7 +39,7 @@ glib::wrapper! {
 
 impl Default for TestObject {
     fn default() -> Self {
-        glib::Object::new(&[])
+        glib::Object::new_default()
     }
 }
 


### PR DESCRIPTION
Nicer than writing `Object::new(&[])`.

Also optimize the object builder a bit.