### PR TITLE
properties: correctly type check value returned by the getter fn

### DIFF
--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -312,6 +312,7 @@ fn expand_property_fn(props: &[PropDesc]) -> TokenStream2 {
             field_ident,
             member,
             get,
+            ty,
             ..
         } = p;
 
@@ -320,7 +321,10 @@ fn expand_property_fn(props: &[PropDesc]) -> TokenStream2 {
         get.as_ref().map(|get| {
             let body = match (member, get) {
                 (_, MaybeCustomFn::Custom(expr)) => quote!(
-                    DerivedPropertiesEnum::#enum_ident => ::std::convert::From::from((#expr)(&self))
+                    DerivedPropertiesEnum::#enum_ident => {
+                        let value: <#ty as #crate_ident::Property>::Value = (#expr)(&self);
+                        ::std::convert::From::from(value)
+                    }
                 ),
                 (None, MaybeCustomFn::Default) => quote!(
                     DerivedPropertiesEnum::#enum_ident =>

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -45,6 +45,8 @@ fn props() {
                 bar: Mutex<String>,
                 #[property(get, set)]
                 double: RefCell<f64>,
+                #[property(get = |_| 42.0, set)]
+                infer_inline_type: RefCell<f64>,
                 // The following property doesn't store any data. The value of the property is calculated
                 // when the value is accessed.
                 #[property(get = Self::hello_world)]
@@ -230,6 +232,9 @@ fn props() {
 
         myfoo.set_double(0.1);
         assert_eq!(myfoo.property::<f64>("double"), 0.1);
+
+        myfoo.set_infer_inline_type(42.0);
+        assert_eq!(myfoo.property::<f64>("infer-inline-type"), 42.0);
 
         // simple with various String types
         myfoo.set_bar(String::from("setter working"));


### PR DESCRIPTION
Fixes #960