### PR TITLE
impl PropertyGet for T: `HasParamSpec`

### DIFF
--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -117,6 +117,8 @@ mod foo {
                 get = |t: &Self| t.author.borrow().name.to_owned(),
                 set = Self::set_author_name)]
             fake_field: PhantomData<String>,
+            #[property(get)]
+            read_only_text: String,
             #[property(get, set, explicit_notify, lax_validation)]
             custom_flags: RefCell<String>,
             #[property(get, set, default = "hello")]
@@ -217,6 +219,12 @@ fn props() {
     myfoo.set_property("author-nick", "freddy-nick".to_value());
     let author_name: String = myfoo.property("author-nick");
     assert_eq!(author_name, "freddy-nick".to_string());
+
+    // read_only
+    assert_eq!(
+        myfoo.find_property("read_only_text").unwrap().flags(),
+        ParamFlags::READABLE
+    );
 
     // custom flags
     assert_eq!(

--- a/glib/src/property.rs
+++ b/glib/src/property.rs
@@ -80,6 +80,13 @@ impl<T: PropertySetNested> PropertySet for T {
     }
 }
 
+impl<T: HasParamSpec> PropertyGet for T {
+    type Value = T;
+    fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {
+        f(self)
+    }
+}
+
 impl<T: Copy> PropertyGet for Cell<T> {
     type Value = T;
     fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {


### PR DESCRIPTION
Before it wasn't possible to create a property without a wrapper like `RefCell` or `Mutex`