### PR TITLE
ThreadGuard: Implement ToValue, Fromvalue and Default traits

### DIFF
--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -87,6 +87,7 @@ mod foo {
     }
 
     pub mod imp {
+        use glib::thread_guard::ThreadGuard;
         use glib::{ParamSpec, Value};
         use std::rc::Rc;
 
@@ -145,6 +146,8 @@ mod foo {
             cell: Cell<u8>,
             #[property(get = Self::overridden, override_class = Base)]
             overridden: PhantomData<u32>,
+            #[property(get, set)]
+            thread_guard: ThreadGuard<Mutex<String>>,
         }
 
         impl ObjectImpl for Foo {
@@ -194,6 +197,12 @@ fn props() {
     // Read bar
     let bar: String = myfoo.property("bar");
     assert_eq!(bar, "".to_string());
+
+    // Set the thread guard
+    myfoo.set_property("thread-guard", "foobar".to_value());
+    // And grab directly the string from the guard after
+    let bar: String = myfoo.property("thread-guard");
+    assert_eq!(bar, "foobar".to_string());
 
     // Set bar
     myfoo.set_property("bar", "epic".to_value());

--- a/glib/src/thread_guard.rs
+++ b/glib/src/thread_guard.rs
@@ -4,6 +4,7 @@ use std::{
     mem, ptr,
     sync::atomic::{AtomicUsize, Ordering},
 };
+
 fn next_thread_id() -> usize {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
     COUNTER.fetch_add(1, Ordering::SeqCst)
@@ -108,6 +109,12 @@ impl<T> Drop for ThreadGuard<T> {
             self.thread_id == thread_id(),
             "Value dropped on a different thread than where it was created"
         );
+    }
+}
+
+impl<T: Default> Default for ThreadGuard<T> {
+    fn default() -> Self {
+        Self::new(T::default())
     }
 }
 


### PR DESCRIPTION
This will also allow ThreadGuard to be used with the new property macro.