### PR TITLE
param_spec: add ParamSpecEnumBuilder::default_value()

### DIFF
--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -1086,6 +1086,11 @@ impl<'a, T: StaticType + FromGlib<i32> + IntoGlib<GlibType = i32>> ParamSpecEnum
         }
     }
 
+    pub fn default_value(mut self, default: T) -> Self {
+        self.default_value = default;
+        self
+    }
+
     #[must_use]
     pub fn build(self) -> ParamSpec {
         unsafe {


### PR DESCRIPTION
Make the API more symetric and may be useful if builder has been created with builder().