### PR TITLE
Implement Default trait for vectors

### DIFF
--- a/graphene/src/box_.rs
+++ b/graphene/src/box_.rs
@@ -79,6 +79,12 @@ impl Box {
     }
 }
 
+impl Default for Box {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
 impl fmt::Debug for Box {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Box")

--- a/graphene/src/matrix.rs
+++ b/graphene/src/matrix.rs
@@ -213,6 +213,12 @@ impl fmt::Debug for Matrix {
     }
 }
 
+impl Default for Matrix {
+    fn default() -> Self {
+        Self::new_identity()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Matrix;

--- a/graphene/src/point.rs
+++ b/graphene/src/point.rs
@@ -57,3 +57,9 @@ impl fmt::Debug for Point {
             .finish()
     }
 }
+
+impl Default for Point {
+    fn default() -> Self {
+        Self::zero()
+    }
+}

--- a/graphene/src/point3_d.rs
+++ b/graphene/src/point3_d.rs
@@ -68,3 +68,9 @@ impl fmt::Debug for Point3D {
             .finish()
     }
 }
+
+impl Default for Point3D {
+    fn default() -> Self {
+        Self::zero()
+    }
+}

--- a/graphene/src/rect.rs
+++ b/graphene/src/rect.rs
@@ -39,6 +39,12 @@ impl fmt::Debug for Rect {
     }
 }
 
+impl Default for Rect {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/graphene/src/vec2.rs
+++ b/graphene/src/vec2.rs
@@ -46,3 +46,9 @@ impl fmt::Debug for Vec2 {
             .finish()
     }
 }
+
+impl Default for Vec2 {
+    fn default() -> Self {
+        Self::zero()
+    }
+}

--- a/graphene/src/vec3.rs
+++ b/graphene/src/vec3.rs
@@ -47,3 +47,9 @@ impl fmt::Debug for Vec3 {
             .finish()
     }
 }
+
+impl Default for Vec3 {
+    fn default() -> Self {
+        Self::zero()
+    }
+}

--- a/graphene/src/vec4.rs
+++ b/graphene/src/vec4.rs
@@ -70,3 +70,9 @@ impl fmt::Debug for Vec4 {
             .finish()
     }
 }
+
+impl Default for Vec4 {
+    fn default() -> Self {
+        Self::zero()
+    }
+}


### PR DESCRIPTION
I made a gtk widget that uses graphene::Vec3 internally, 
https://github.com/yuraiz/telegrand/blob/animated-background/src/session/content/gradient_bg.rs
and because vectors doesn't implement Default I can't derive Default for widget implementation 

also it would be useful to have gdk::RGBA to vector conversions but that's compicated because those libraries are independent