### PR TITLE
Props type support

### DIFF
--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -379,13 +379,24 @@ fn expand_property_fn(props: &[PropDesc]) -> TokenStream2 {
                 ),
                 (None, MaybeCustomFn::Default) => quote!(
                     DerivedPropertiesEnum::#enum_ident =>
-                        #crate_ident::PropertyGet::get(&self.#field_ident, |v| ::std::convert::From::from(v))
+                        #crate_ident::PropertyGet::get(
+                            &self.#field_ident,
+                            |v| #crate_ident::PropertyGet::get(
+                                v,
+                                |v| ::std::convert::From::from(v)
+                            )
+                        )
 
                 ),
                 (Some(member), MaybeCustomFn::Default) => quote!(
                     DerivedPropertiesEnum::#enum_ident =>
-                        #crate_ident::PropertyGet::get(&self.#field_ident, |v| ::std::convert::From::from(&v.#member))
-
+                        #crate_ident::PropertyGet::get(
+                            &self.#field_ident,
+                            |v| #crate_ident::PropertyGet::get(
+                                &v.#member,
+                                |v| ::std::convert::From::from(v)
+                            )
+                        )
                 ),
             };
             quote_spanned!(span=> #body)
@@ -415,6 +426,7 @@ fn expand_set_property_fn(props: &[PropDesc]) -> TokenStream2 {
             field_ident,
             member,
             set,
+            ty,
             ..
         } = p;
 
@@ -426,22 +438,28 @@ fn expand_set_property_fn(props: &[PropDesc]) -> TokenStream2 {
             let body = match (member, set) {
                 (_, MaybeCustomFn::Custom(expr)) => quote!(
                     DerivedPropertiesEnum::#enum_ident => {
-                        (#expr)(&self, #crate_ident::Value::get(value)#expect);
+                        let value: <#ty as #crate_ident::Property>::Value =
+                            #crate_ident::Value::get(value)#expect;
+                        (#expr)(&self, ::std::convert::From::from(value));
                     }
                 ),
                 (None, MaybeCustomFn::Default) => quote!(
                     DerivedPropertiesEnum::#enum_ident => {
+                        let value: <#ty as #crate_ident::Property>::Value =
+                            #crate_ident::Value::get(value)#expect;
                         #crate_ident::PropertySet::set(
                             &self.#field_ident,
-                            #crate_ident::Value::get(value)#expect
+                            ::std::convert::From::from(value)
                         );
                     }
                 ),
                 (Some(member), MaybeCustomFn::Default) => quote!(
                     DerivedPropertiesEnum::#enum_ident => {
+                        let value: <#ty as #crate_ident::Property>::Value =
+                            #crate_ident::Value::get(value)#expect;
                         #crate_ident::PropertySetNested::set_nested(
                             &self.#field_ident,
-                            move |v| v.#member = #crate_ident::Value::get(value)#expect
+                            move |v| v.#member = ::std::convert::From::from(value)
                         );
                     }
                 ),

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -86,6 +86,24 @@ mod foo {
         nick: String,
     }
 
+    // Custom type, behaving as the inner type
+    #[derive(Default)]
+    pub struct MyInt(i32);
+    impl glib::Property for MyInt {
+        type Value = i32;
+    }
+    impl glib::PropertyGet for MyInt {
+        type Value = i32;
+        fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {
+            f(&self.0)
+        }
+    }
+    impl From<i32> for MyInt {
+        fn from(v: i32) -> Self {
+            MyInt(v)
+        }
+    }
+
     pub mod imp {
         use glib::{ParamSpec, Value};
         use std::rc::Rc;
@@ -101,6 +119,8 @@ mod foo {
             double: RefCell<f64>,
             #[property(get = |_| 42.0, set)]
             infer_inline_type: RefCell<f64>,
+            #[property(get, set)]
+            custom_type: RefCell<MyInt>,
             // The following property doesn't store any data. The value of the property is calculated
             // when the value is accessed.
             #[property(get = Self::hello_world)]

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -68,6 +68,7 @@ mod foo {
     use std::sync::Mutex;
 
     use super::base::Base;
+    use glib::thread_guard::ThreadGuard;
 
     #[derive(Clone, Default, Debug, PartialEq, Eq, glib::Boxed)]
     #[boxed_type(name = "SimpleBoxedString")]
@@ -125,6 +126,10 @@ mod foo {
             // when the value is accessed.
             #[property(get = Self::hello_world)]
             _buzz: PhantomData<String>,
+            #[property(get, set)]
+            thread_guard_wrapped: Mutex<ThreadGuard<u32>>,
+            #[property(get, set)]
+            thread_guard_wrapping: ThreadGuard<Mutex<u32>>,
             #[property(get, set = Self::set_fizz, name = "fizz", nick = "fizz-nick",
                 blurb = "short description stored in the GLib type system"
             )]
@@ -239,6 +244,15 @@ fn props() {
     myfoo.set_property("author-nick", "freddy-nick".to_value());
     let author_name: String = myfoo.property("author-nick");
     assert_eq!(author_name, "freddy-nick".to_string());
+
+    // Complex wrapping
+    myfoo.set_property("thread-guard-wrapped", 2u32.to_value());
+    let v: u32 = myfoo.property("thread-guard-wrapped");
+    assert_eq!(v, 2);
+
+    myfoo.set_property("thread-guard-wrapping", 3u32.to_value());
+    let v: u32 = myfoo.property("thread-guard-wrapping");
+    assert_eq!(v, 3);
 
     // read_only
     assert_eq!(

--- a/glib/src/property.rs
+++ b/glib/src/property.rs
@@ -1,5 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::thread_guard::ThreadGuard;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -35,6 +36,9 @@ impl<T: Property> Property for Mutex<T> {
     type Value = T::Value;
 }
 impl<T: Property> Property for RwLock<T> {
+    type Value = T::Value;
+}
+impl<T: Property> Property for ThreadGuard<T> {
     type Value = T::Value;
 }
 impl<T: Property> Property for once_cell::sync::OnceCell<T> {
@@ -135,6 +139,19 @@ impl<T> PropertySetNested for RwLock<T> {
     type SetNestedValue = T;
     fn set_nested<F: FnOnce(&mut Self::SetNestedValue)>(&self, f: F) {
         f(&mut self.write().unwrap());
+    }
+}
+
+impl<T: PropertyGet> PropertyGet for ThreadGuard<T> {
+    type Value = T::Value;
+    fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {
+        self.get_ref().get(f)
+    }
+}
+impl<T: PropertySetNested> PropertySetNested for ThreadGuard<T> {
+    type SetNestedValue = T::SetNestedValue;
+    fn set_nested<F: FnOnce(&mut Self::SetNestedValue)>(&self, f: F) {
+        self.get_ref().set_nested(f)
     }
 }
 

--- a/glib/src/thread_guard.rs
+++ b/glib/src/thread_guard.rs
@@ -112,3 +112,15 @@ impl<T> Drop for ThreadGuard<T> {
 }
 
 unsafe impl<T> Send for ThreadGuard<T> {}
+
+impl<T: Default> Default for ThreadGuard<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for ThreadGuard<T> {
+    fn from(value: T) -> Self {
+        ThreadGuard::new(value)
+    }
+}


### PR DESCRIPTION
fixes #983 
enables support for a correct handling of `ThreadGuard`, therefore supersedes #968.

In general, this kinda enables two-level nesting: this makes supporting newtypes trivial (conceptually, they are a nested type). 

The change is backwards compatible