### PR TITLE
Make `WeakRef` and `SendWeakRef` useable with the `Properties` derive macro

### DIFF
--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -149,6 +149,8 @@ mod foo {
             overridden: PhantomData<u32>,
             #[property(get, set)]
             weak_ref_prop: glib::WeakRef<glib::Object>,
+            #[property(get, set)]
+            send_weak_ref_prop: glib::SendWeakRef<glib::Object>,
         }
 
         impl ObjectImpl for Foo {

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -147,6 +147,8 @@ mod foo {
             cell: Cell<u8>,
             #[property(get = Self::overridden, override_class = Base)]
             overridden: PhantomData<u32>,
+            #[property(get, set)]
+            weak_ref_prop: glib::WeakRef<glib::Object>,
         }
 
         impl ObjectImpl for Foo {

--- a/glib/src/property.rs
+++ b/glib/src/property.rs
@@ -10,6 +10,9 @@ use std::sync::Mutex;
 use std::sync::RwLock;
 
 use crate::HasParamSpec;
+use crate::IsA;
+use crate::Object;
+use crate::WeakRef;
 
 // rustdoc-stripper-ignore-next
 /// A type that can be used as a property. It covers every type which have an associated `ParamSpec`
@@ -49,6 +52,9 @@ impl<T: Property> Property for Rc<T> {
 }
 impl<T: Property> Property for Arc<T> {
     type Value = T::Value;
+}
+impl<T: IsA<Object> + HasParamSpec> Property for WeakRef<T> {
+    type Value = Option<T>;
 }
 
 // rustdoc-stripper-ignore-next
@@ -166,6 +172,21 @@ impl<T> PropertySet for once_cell::unsync::OnceCell<T> {
         if let Err(_v) = self.set(v) {
             panic!("can't set value of OnceCell multiple times")
         };
+    }
+}
+
+impl<T: IsA<Object>> PropertyGet for WeakRef<T> {
+    type Value = Option<T>;
+
+    fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {
+        f(&self.upgrade())
+    }
+}
+impl<T: IsA<Object>> PropertySet for WeakRef<T> {
+    type SetValue = Option<T>;
+
+    fn set(&self, v: Self::SetValue) {
+        self.set(v.as_ref())
     }
 }
 

--- a/glib/src/property.rs
+++ b/glib/src/property.rs
@@ -12,6 +12,7 @@ use std::sync::RwLock;
 use crate::HasParamSpec;
 use crate::IsA;
 use crate::Object;
+use crate::SendWeakRef;
 use crate::WeakRef;
 
 // rustdoc-stripper-ignore-next
@@ -54,6 +55,9 @@ impl<T: Property> Property for Arc<T> {
     type Value = T::Value;
 }
 impl<T: IsA<Object> + HasParamSpec> Property for WeakRef<T> {
+    type Value = Option<T>;
+}
+impl<T: IsA<Object> + HasParamSpec> Property for SendWeakRef<T> {
     type Value = Option<T>;
 }
 
@@ -187,6 +191,20 @@ impl<T: IsA<Object>> PropertySet for WeakRef<T> {
 
     fn set(&self, v: Self::SetValue) {
         self.set(v.as_ref())
+    }
+}
+impl<T: IsA<Object>> PropertyGet for SendWeakRef<T> {
+    type Value = Option<T>;
+
+    fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {
+        f(&self.upgrade())
+    }
+}
+impl<T: IsA<Object>> PropertySet for SendWeakRef<T> {
+    type SetValue = Option<T>;
+
+    fn set(&self, v: Self::SetValue) {
+        WeakRef::set(self, v.as_ref());
     }
 }
 


### PR DESCRIPTION
There's still some things to do, but I'm not sure how to do them:

1. How should I test these?
2. I'm not sure how to implement `PropertySetNested` for them

Closes #980 
