### PR TITLE
glib-macros: allow properties macro generated functions to be unused

### DIFF
--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -628,6 +628,7 @@ pub fn impl_derive_props(input: PropsMacroInput) -> TokenStream {
             #fn_set_property
         }
 
+        #[allow(dead_code)]
         impl #wrapper_type {
             #getset_properties
             #connect_prop_notify


### PR DESCRIPTION
Without this I am getting warnings about unused `connect_blah_notify` @ranfdev 