### PR TITLE
RFC: cairo-rs: add Context API to enforce stack correctness

### DIFF
--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -210,7 +210,7 @@ pub use xcb::{
 };
 
 pub use crate::{
-    context::{Context, RectangleList},
+    context::{Context, ContextRef, RectangleList},
     device::Device,
     enums::*,
     error::{BorrowError, Error, IoError, Result},


### PR DESCRIPTION
(This is a pattern I implement with a trait in my applications.)

This pull requests proposes a simple API to make sure Context stacks are correct on compile-time. The following is an example usage:

```rust
pub fn draw_stuff(area: &gtk::DrawingArea, mut cr: ContextRef, flag: bool) {
    cr.set_source_rgba(1.0, 1.0, 1.0, 1.0);
    let mut cr1 = cr.push(); // mut is necessary in order to create new stacks from cr1.

    if flag {
        let cr2 = cr1.push();
        // Use cr2 as a regular cairo::Context reference, since it derefs to it automatically.
        let mut m = cairo::Matrix::new();
        m.translate(234.0, 324.0);
        cr2.transform(matrix);

        cr2.rectangle(
            0.0,
            0.0,
            1.0,
            1.0,
        );
        cr2.fill().unwrap();
    } // cr2 drops here

    cr1.move_to(0.0, 0.5);
    cr2.set_source_rgba(1.0, 0.0, 0.0, 1.0);
    cr1.line_to(0.5, 15.0);
    cr1.stroke().unwrap();
    drop(cr1);
    cr.arc(
        0.0,
        0.0,
        5.0,
        0.0,
        2.0 * std::f64::consts::PI,
    );
    cr.fill().unwrap();
    // cr drops, all stacks have been restored.
}
``` 

Commit message:

`Context` has the `Context::save` and `Context::restore` methods to save the current Context state, do changes to the new state, and be able to restore the original state. If a save() is not followed by a restore() the result is visual bugs (at least in my experience).

In C there's no way to prevent a user from forgetting a restore().

In Rust you can nest stack levels naturally using the borrowing rules. Since a mutable reference of a variable prevents the variable to be used while the reference is still alive, we can ensure the user cannot create a new stack level and forget about the previous one. The restore() is performed inside the Drop implementation. That means that if it compiles, the stacking is correct, and since this is on the type level it is a zero-cost abstraction.

Questions:
- should `Context` be available to the user without `unsafe`? As long as it is, the user can create as many `ContextRef`s as they wish and bypass this API.
- If restore().unwrap() in the Drop impl panics, the process aborts. Is that acceptable?