### PR TITLE
Revert "SimpleAction: take state by value"

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -1157,21 +1157,6 @@ status = "generate"
     name = "state"
     #value glib::VariantTy
     ignore = true
-    [[object.function]]
-    name = "new_stateful"
-        [[object.function.parameter]]
-        name = "state"
-        move = true
-    [[object.function]]
-    name = "set_state"
-        [[object.function.parameter]]
-        name = "value"
-        move = true
-    [[object.function]]
-    name = "set_state_hint"
-        [[object.function.parameter]]
-        name = "state_hint"
-        move = true
 
 [[object]]
 name = "Gio.SimpleIOStream"

--- a/gio/src/action_map.rs
+++ b/gio/src/action_map.rs
@@ -15,7 +15,7 @@ impl<O: IsA<ActionMap>> ActionMapExtManual for O {
     fn add_action_entries(&self, entries: impl IntoIterator<Item = ActionEntry<Self>>) {
         for entry in entries.into_iter() {
             let action = if let Some(state) = entry.state() {
-                SimpleAction::new_stateful(entry.name(), entry.parameter_type(), state.clone())
+                SimpleAction::new_stateful(entry.name(), entry.parameter_type(), state)
             } else {
                 SimpleAction::new(entry.name(), entry.parameter_type())
             };

--- a/gio/src/auto/simple_action.rs
+++ b/gio/src/auto/simple_action.rs
@@ -34,13 +34,13 @@ impl SimpleAction {
     pub fn new_stateful(
         name: &str,
         parameter_type: Option<&glib::VariantTy>,
-        state: glib::Variant,
+        state: &glib::Variant,
     ) -> SimpleAction {
         unsafe {
             from_glib_full(ffi::g_simple_action_new_stateful(
                 name.to_glib_none().0,
                 parameter_type.to_glib_none().0,
-                state.into_glib_ptr(),
+                state.to_glib_none().0,
             ))
         }
     }
@@ -53,16 +53,16 @@ impl SimpleAction {
     }
 
     #[doc(alias = "g_simple_action_set_state")]
-    pub fn set_state(&self, value: glib::Variant) {
+    pub fn set_state(&self, value: &glib::Variant) {
         unsafe {
-            ffi::g_simple_action_set_state(self.to_glib_none().0, value.into_glib_ptr());
+            ffi::g_simple_action_set_state(self.to_glib_none().0, value.to_glib_none().0);
         }
     }
 
     #[doc(alias = "g_simple_action_set_state_hint")]
-    pub fn set_state_hint(&self, state_hint: Option<glib::Variant>) {
+    pub fn set_state_hint(&self, state_hint: Option<&glib::Variant>) {
         unsafe {
-            ffi::g_simple_action_set_state_hint(self.to_glib_none().0, state_hint.into_glib_ptr());
+            ffi::g_simple_action_set_state_hint(self.to_glib_none().0, state_hint.to_glib_none().0);
         }
     }
 


### PR DESCRIPTION
This reverts commit 42c72aa9bfd40016e5b497c50950df19325b2f55.

The generated bindings are leaking the state parameter