### PR TITLE
glib: implement WatchedObject for BorrowedObject

### DIFF
--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -685,6 +685,7 @@ fn closure() {
 
         let inc_by = {
             let obj = glib::Object::new::<SendObject>();
+            let obj = obj.imp().obj();
             let inc_by = glib::closure!(@watch obj => move |x: i32| {
                 let old = obj.value();
                 obj.set_value(x + old);

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -3118,6 +3118,16 @@ impl<T: ObjectType> Watchable<T> for T {
 }
 
 #[doc(hidden)]
+impl<'a, T: ObjectType> Watchable<T> for BorrowedObject<'a, T> {
+    fn watched_object(&self) -> WatchedObject<T> {
+        WatchedObject::new(self)
+    }
+    fn watch_closure(&self, closure: &impl AsRef<Closure>) {
+        ObjectExt::watch_closure(&**self, closure)
+    }
+}
+
+#[doc(hidden)]
 impl<T: ObjectType> Watchable<T> for &T {
     fn watched_object(&self) -> WatchedObject<T> {
         WatchedObject::new(*self)


### PR DESCRIPTION
Allows using `@watch` on `imp.obj()`.

cc @YaLTeR 