### PR TITLE
Add nullable attribute on properties macro

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -872,7 +872,8 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 /// `PropertySet` and `PropertySetNested` if possible.
 ///
 /// The type `Option<T>` is supported as a property only if `Option<T>` implements `ToValueOptional`.
-/// Optional types also require the `nullable` attribute.
+/// Optional types also require the `nullable` attribute: without it, the generated setter on the wrapper type
+/// will take `T` instead of `Option<T>`, preventing the user from ever calling the setter with a `None` value.
 /// If your type doesn't support `PropertySet`, you can't use the generated setter, but you can
 /// always define a custom one.
 ///

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -872,6 +872,7 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 /// `PropertySet` and `PropertySetNested` if possible.
 ///
 /// The type `Option<T>` is supported as a property only if `Option<T>` implements `ToValueOptional`.
+/// Optional types also require the `nullable` attribute.
 /// If your type doesn't support `PropertySet`, you can't use the generated setter, but you can
 /// always define a custom one.
 ///
@@ -913,7 +914,7 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 ///         numeric_builder: RefCell<u32>,
 ///         #[property(get, set, builder('c'))]
 ///         builder_with_required_param: RefCell<char>,
-///         #[property(get, set)]
+///         #[property(get, set, nullable)]
 ///         optional: RefCell<Option<String>>,
 ///         #[property(get, set)]
 ///         smart_pointer: Rc<RefCell<String>>,

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -137,9 +137,9 @@ mod foo {
             boxed: RefCell<SimpleBoxedString>,
             #[property(get, set, builder(SimpleEnum::One))]
             fenum: RefCell<SimpleEnum>,
-            #[property(get, set)]
+            #[property(get, set, nullable)]
             object: RefCell<Option<glib::Object>>,
-            #[property(get, set)]
+            #[property(get, set, nullable)]
             optional: RefCell<Option<String>>,
             #[property(get, set)]
             smart_pointer: Rc<RefCell<String>>,
@@ -297,11 +297,6 @@ fn props() {
         foo::SimpleBoxedString("".into())
     );
 
-    // optional
-    assert_eq!(myfoo.property::<Option<String>>("optional"), None,);
-
-    myfoo.connect_optional_notify(|_| println!("notified"));
-
     // Test `FooPropertiesExt`
     // getters
     {
@@ -341,9 +336,6 @@ fn props() {
             "setter working".to_string()
         );
 
-        // object subclass
-        myfoo.set_object(glib::BoxedAnyObject::new(""));
-
         // custom
         myfoo.set_fake_field("fake setter");
         assert_eq!(
@@ -366,4 +358,14 @@ fn props() {
         let not_overridden: u32 = myfoo.property("not-overridden");
         assert_eq!(not_overridden, 42);
     }
+
+    // optional
+    myfoo.set_optional(Some("Hello world"));
+    assert_eq!(myfoo.optional(), Some("Hello world".to_string()));
+    myfoo.connect_optional_notify(|_| println!("notified"));
+
+    // object subclass
+    let myobj = glib::BoxedAnyObject::new("");
+    myfoo.set_object(Some(myobj.upcast_ref()));
+    assert_eq!(myfoo.object(), Some(myobj.upcast()))
 }


### PR DESCRIPTION
Fixes #990

I know, if a `ParamSpecBuilder` has a method `nullable`, this attribute will now shadow it. But I don't know any ParamSpec with a method named `nullable`. And even if that exists, the builder pattern can always be used: `builder().nullable()`.

This change is backwards compatible (expect if someone is using a builder with a `nullable` method I guess...).

Any other solution doesn't seem to be more backward compatible than this.

Also, the `nullable` attribute is used already by other macros, such as `glib::Boxed`, so this behavior seems consistent to me. 

If this isn't enough, we will introduce something better, introducing breaking changes, for the next milestone.