### PR TITLE
pangocairo-sys: fix package.description in Cargo.toml

### DIFF
--- a/pangocairo/sys/Cargo.toml
+++ b/pangocairo/sys/Cargo.toml
@@ -29,7 +29,7 @@ name = "pango_cairo_sys"
 [package]
 authors = ["The gtk-rs Project Developers"]
 build = "build.rs"
-description = "FFI bindings to libgtk-3"
+description = "FFI bindings to PangoCairo"
 homepage = "http://gtk-rs.org/"
 keywords = ["gtk", "ffi", "gtk-rs", "gnome"]
 license = "MIT"


### PR DESCRIPTION
It appears that this was overwritten by accident at some point.