### PR TITLE
glib: Only optimize `IntoGStr` for `String` when capacity allows

### DIFF
--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -40,6 +40,7 @@ memchr = "2.5.0"
 tempfile = "3"
 gir-format-check = "^0.1"
 trybuild2 = "1"
+criterion = "0.4.0"
 
 [features]
 default = ["gio"]
@@ -65,3 +66,7 @@ features = ["dox"]
 [[test]]
 name = "subclass_compiletest"
 required-features = ["compiletests"]
+
+[[bench]]
+name = "gstring"
+harness = false

--- a/glib/benches/gstring.rs
+++ b/glib/benches/gstring.rs
@@ -1,0 +1,46 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use glib::IntoGStr;
+
+pub fn str_into_gstr(c: &mut Criterion) {
+    c.bench_function("str as IntoGStr", |b| {
+        b.iter(|| {
+            "abcdefg".run_with_gstr(|g| {
+                black_box(g);
+            })
+        })
+    });
+}
+
+pub fn string_into_gstr(c: &mut Criterion) {
+    c.bench_function("String as IntoGStr", |b| {
+        b.iter(|| {
+            let mut s = String::from("abcdefg");
+            s.shrink_to_fit();
+            assert_eq!(s.capacity(), s.len());
+            s.run_with_gstr(|g| {
+                black_box(g);
+            })
+        })
+    });
+}
+
+pub fn string_with_capacity_into_gstr(c: &mut Criterion) {
+    c.bench_function("String::with_capacity as IntoGStr", |b| {
+        b.iter(|| {
+            let mut s = String::with_capacity(100);
+            s.push_str("abcdefg");
+            assert!(s.capacity() > s.len());
+            s.run_with_gstr(|g| {
+                black_box(g);
+            })
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    str_into_gstr,
+    string_into_gstr,
+    string_with_capacity_into_gstr
+);
+criterion_main!(benches);


### PR DESCRIPTION
And add a bench too, for me it shows this is faster for the small string case.