### PR TITLE
Fixed unit tests under macOS and possibly other *nix flavors

### DIFF
--- a/gio/src/socket.rs
+++ b/gio/src/socket.rs
@@ -925,12 +925,7 @@ mod tests {
 
         let mut fds = [0 as libc::c_int; 2];
         let (out_sock, in_sock) = unsafe {
-            let ret = libc::socketpair(
-                libc::AF_UNIX,
-                libc::SOCK_STREAM | libc::SOCK_CLOEXEC,
-                0,
-                fds.as_mut_ptr(),
-            );
+            let ret = libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr());
             if ret != 0 {
                 panic!("{}", io::Error::last_os_error());
             }

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -2812,10 +2812,10 @@ mod tests {
         // gives us useful results
         let dir_1 = tmp_dir.join("abcd");
         fs::create_dir(&dir_1).unwrap();
-        assert_eq!(crate::path_get_basename(&dir_1), Path::from("abcd"));
+        assert_eq!(crate::path_get_basename(&dir_1), Path::new("abcd"));
         assert_eq!(
             crate::path_get_basename(dir_1.canonicalize().unwrap()),
-            Path::from("abcd")
+            Path::new("abcd")
         );
         assert_eq!(
             crate::path_get_dirname(dir_1.canonicalize().unwrap()),


### PR DESCRIPTION
Fixes unit tests under macOS and possibly some other *nix flavors :

- Optional use of `SOCK_CLOEXEC` on platforms that do not support the flag
- Fixed `Path` constructor usage in macOS tests

About the `SOCK_CLOEXEC` option: I did a deep dive into libc codebase to find what are the supported platforms and I think I came with an exhaustive list (that includes enscriptem... I'm skeptical about that one, but libc defines the flag, so I did put it in). That said, I don't think there's a real need for the unit test to use `SOCK_CLOEXEC` (but I'm not the author of the test, so who knows), so another option is to just remove the flag for all platforms to reduce the clutter in the code.
