### PR TITLE
glib-macros: generate "From<Ident> for Value" on ValueDelegate

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -1013,6 +1013,14 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 /// }
+/// impl From<MyEnum> for u32 {
+///     fn from(v: MyEnum) -> Self {
+///         match v {
+///             MyEnum::Zero => 0,
+///             MyEnum::NotZero(x) => x
+///         }
+///     }
+/// }
 ///
 /// let myv = MyEnum::NotZero(34);
 /// let convertedv = myv.to_value();

--- a/glib-macros/src/value_delegate_derive.rs
+++ b/glib-macros/src/value_delegate_derive.rs
@@ -158,6 +158,7 @@ pub fn impl_value_delegate(input: ValueDelegateInput) -> syn::Result<proc_macro:
                 <#delegated_ty as #crate_ident::types::StaticType>::static_type()
             }
         }
+
         impl #crate_ident::value::ToValue for #ident {
             fn to_value(&self) -> #crate_ident::value::Value {
                 let this = self;
@@ -166,6 +167,12 @@ pub fn impl_value_delegate(input: ValueDelegateInput) -> syn::Result<proc_macro:
             fn value_type(&self) -> #crate_ident::types::Type {
                 let this = self;
                 #crate_ident::value::ToValue::value_type(&#delegate_value)
+            }
+        }
+
+        impl From<#ident> for #crate_ident::value::Value {
+            fn from(this: #ident) -> Self {
+                #crate_ident::value::Value::from(#delegate_value)
             }
         }
 

--- a/glib-macros/tests/value_delegate_derive.rs
+++ b/glib-macros/tests/value_delegate_derive.rs
@@ -1,15 +1,144 @@
-use glib::{value::FromValue, HasParamSpec, StaticType, ToValue};
+use glib::{value::FromValue, StaticType, ToValue, Value, ValueDelegate};
+
+#[test]
+fn into_value() {
+    fn test_func(_: impl Into<Value>) {}
+
+    #[derive(ValueDelegate)]
+    pub struct Test(i32);
+
+    #[derive(ValueDelegate)]
+    #[value_delegate(nullable)]
+    pub struct TestNullable(String);
+
+    #[derive(ValueDelegate)]
+    #[value_delegate(from = i64)]
+    pub struct TestManualFrom(i32);
+
+    impl From<i64> for TestManualFrom {
+        fn from(v: i64) -> Self {
+            Self(v as i32)
+        }
+    }
+    impl<'a> From<&'a TestManualFrom> for i64 {
+        fn from(v: &'a TestManualFrom) -> Self {
+            v.0 as i64
+        }
+    }
+    impl From<TestManualFrom> for i64 {
+        fn from(v: TestManualFrom) -> Self {
+            v.0 as i64
+        }
+    }
+
+    test_func(&Test(123));
+    test_func(Test(123));
+
+    test_func(&TestManualFrom(123));
+    test_func(TestManualFrom(123));
+
+    test_func(&TestNullable("foo".to_string()));
+    test_func(TestNullable("foo".to_string()));
+    test_func(Some(&TestNullable("foo".to_string())));
+    test_func(&Some(TestNullable("foo".to_string())));
+    test_func(Some(TestNullable("foo".to_string())));
+
+    assert_eq!(glib::Value::from(Test(123)).get::<Test>().unwrap().0, 123);
+    assert_eq!(glib::Value::from(123).get::<Test>().unwrap().0, 123);
+    assert_eq!(glib::Value::from(Test(123)).get::<i32>().unwrap(), 123);
+
+    assert_eq!(
+        glib::Value::from(TestManualFrom(123))
+            .get::<TestManualFrom>()
+            .unwrap()
+            .0,
+        123
+    );
+    assert_eq!(
+        glib::Value::from(123_i64)
+            .get::<TestManualFrom>()
+            .unwrap()
+            .0,
+        123
+    );
+    assert_eq!(
+        glib::Value::from(TestManualFrom(123)).get::<i64>().unwrap(),
+        123
+    );
+
+    // From TestNullable
+    assert_eq!(
+        glib::Value::from(TestNullable("foo".to_string()))
+            .get::<Option<TestNullable>>()
+            .unwrap()
+            .unwrap()
+            .0,
+        "foo"
+    );
+    assert_eq!(
+        glib::Value::from("foo")
+            .get::<Option<TestNullable>>()
+            .unwrap()
+            .unwrap()
+            .0,
+        "foo"
+    );
+    assert_eq!(
+        glib::Value::from(TestNullable("foo".to_string()))
+            .get::<Option<String>>()
+            .unwrap()
+            .unwrap(),
+        "foo"
+    );
+    // From Option<TestNullable> Some
+    assert_eq!(
+        glib::Value::from(Some(TestNullable("foo".to_string())))
+            .get::<Option<TestNullable>>()
+            .unwrap()
+            .unwrap()
+            .0,
+        "foo"
+    );
+    assert_eq!(
+        glib::Value::from(Some("foo"))
+            .get::<Option<TestNullable>>()
+            .unwrap()
+            .unwrap()
+            .0,
+        "foo"
+    );
+    assert_eq!(
+        glib::Value::from(Some(TestNullable("foo".to_string())))
+            .get::<Option<String>>()
+            .unwrap()
+            .unwrap(),
+        "foo"
+    );
+    // From Option<TestNullable> None
+    assert!(glib::Value::from(None::<TestNullable>)
+        .get::<Option<TestNullable>>()
+        .unwrap()
+        .is_none());
+    assert!(glib::Value::from(None::<String>)
+        .get::<Option<TestNullable>>()
+        .unwrap()
+        .is_none());
+    assert!(glib::Value::from(None::<TestNullable>)
+        .get::<Option<String>>()
+        .unwrap()
+        .is_none());
+}
 
 #[test]
 fn higher_level_types() {
-    #[derive(Debug, glib::ValueDelegate)]
+    #[derive(Debug, ValueDelegate)]
     pub struct MyVec(Vec<String>);
 
-    #[derive(Debug, glib::ValueDelegate)]
+    #[derive(Debug, ValueDelegate)]
     #[value_delegate(nullable)]
     pub struct MyString(Box<str>);
 
-    #[derive(Debug, glib::ValueDelegate)]
+    #[derive(Debug, ValueDelegate)]
     #[value_delegate(from = Option<String>)]
     struct MyVecManualFrom(Vec<String>);
 
@@ -21,6 +150,11 @@ fn higher_level_types() {
     impl<'a> From<&'a MyVecManualFrom> for Option<String> {
         fn from(v: &'a MyVecManualFrom) -> Self {
             v.0.iter().next().cloned()
+        }
+    }
+    impl From<MyVecManualFrom> for Option<String> {
+        fn from(v: MyVecManualFrom) -> Self {
+            v.0.into_iter().next()
         }
     }
 


### PR DESCRIPTION
This allows `Ident` (not only `&Ident`) to be allowed on functions that take in `Into<Value>`.