### PR TITLE
glib: Fix building for architectures without 64-bit atomics

### DIFF
--- a/glib/src/property.rs
+++ b/glib/src/property.rs
@@ -258,7 +258,9 @@ macro_rules! impl_atomic {
 impl_atomic!(std::sync::atomic::AtomicBool, bool);
 impl_atomic!(std::sync::atomic::AtomicI8, i8);
 impl_atomic!(std::sync::atomic::AtomicI32, i32);
+#[cfg(target_has_atomic = "64")]
 impl_atomic!(std::sync::atomic::AtomicI64, i64);
 impl_atomic!(std::sync::atomic::AtomicU8, u8);
 impl_atomic!(std::sync::atomic::AtomicU32, u32);
+#[cfg(target_has_atomic = "64")]
 impl_atomic!(std::sync::atomic::AtomicU64, u64);


### PR DESCRIPTION
I have been building gst-plugins-rs 0.9 for a while for a mips32 chip, but when bumping to 0.10 I got issues compiling due to that chip not supporting 64-bit atomics. The following patch fixes compilation on that target.