### PR TITLE
glib-macros: enable default features of syn

### DIFF
--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -17,7 +17,7 @@ heck = "0.4"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"], default-features = false }
+syn = { version = "1.0", features = ["full"] }
 proc-macro-crate = "1.0"
 
 [lib]


### PR DESCRIPTION
The code in this crate uses features of "syn" which are only present
when the default features are enabled. This previously worked "by
accident" because other crates in the dependency tree pulled in the
"default" feature of syn, but these crates have started moving to
syn v2, so this is no longer the case.
