### PR TITLE
glib-macros: Specify quoted types explicitly

### DIFF
--- a/glib-macros/src/boxed_derive.rs
+++ b/glib-macros/src/boxed_derive.rs
@@ -9,8 +9,8 @@ use crate::utils::{crate_ident_new, find_attribute_meta, find_nested_meta, parse
 fn gen_option_to_ptr() -> TokenStream {
     quote! {
         match s {
-            Some(s) => ::std::boxed::Box::into_raw(::std::boxed::Box::new(s.clone())),
-            None => ::std::ptr::null_mut(),
+            ::core::option::Option::Some(s) => ::std::boxed::Box::into_raw(::std::boxed::Box::new(s.clone())),
+            ::core::option::Option::None => ::std::ptr::null_mut(),
         };
     }
 }
@@ -122,7 +122,7 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> TokenStream {
 
     quote! {
         impl #crate_ident::subclass::boxed::BoxedType for #name {
-            const NAME: &'static str = #gtype_name;
+            const NAME: &'static ::core::primitive::str = #gtype_name;
         }
 
         impl #crate_ident::StaticType for #name {
@@ -247,7 +247,7 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> TokenStream {
         impl #crate_ident::HasParamSpec for #name {
             type ParamSpec = #crate_ident::ParamSpecBoxed;
             type SetValue = Self;
-            type BuilderFn = fn(&str) -> #crate_ident::ParamSpecBoxedBuilder<Self>;
+            type BuilderFn = fn(&::core::primitive::str) -> #crate_ident::ParamSpecBoxedBuilder<Self>;
 
             fn param_spec_builder() -> Self::BuilderFn {
                 |name| Self::ParamSpec::builder(name)

--- a/glib-macros/src/downgrade_derive/enums.rs
+++ b/glib-macros/src/downgrade_derive/enums.rs
@@ -130,7 +130,7 @@ pub fn derive_downgrade_for_enum(
             type Strong = #ident #generics;
 
             fn upgrade(&self) -> ::core::option::Option<Self::Strong> {
-                Some(match self {#(
+                ::core::option::Option::Some(match self {#(
                     #upgrade_variants
                 ),*})
             }

--- a/glib-macros/src/downgrade_derive/structs.rs
+++ b/glib-macros/src/downgrade_derive/structs.rs
@@ -114,7 +114,7 @@ pub fn derive_downgrade_for_struct(
 
             fn upgrade(&self) -> ::core::option::Option<Self::Strong> {
                 let Self #destruct = self;
-                Some(#ident #upgrade)
+                ::core::option::Option::Some(#ident #upgrade)
             }
         }
     };

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -193,7 +193,7 @@ pub fn impl_enum(input: &syn::DeriveInput) -> TokenStream {
         impl #crate_ident::HasParamSpec for #name {
             type ParamSpec = #crate_ident::ParamSpecEnum;
             type SetValue = Self;
-            type BuilderFn = fn(&str, Self) -> #crate_ident::ParamSpecEnumBuilder<Self>;
+            type BuilderFn = fn(&::core::primitive::str, Self) -> #crate_ident::ParamSpecEnumBuilder<Self>;
 
             fn param_spec_builder() -> Self::BuilderFn {
                 |name, default_value| Self::ParamSpec::builder_with_default(name, default_value)

--- a/glib-macros/src/error_domain_derive.rs
+++ b/glib-macros/src/error_domain_derive.rs
@@ -35,7 +35,7 @@ pub fn impl_error_domain(input: &syn::DeriveInput) -> TokenStream {
 
                 static QUARK: #crate_ident::once_cell::sync::Lazy<#crate_ident::Quark> =
                     #crate_ident::once_cell::sync::Lazy::new(|| unsafe {
-                        from_glib(#crate_ident::ffi::g_quark_from_static_string(concat!(#domain_name, "\0") as *const str as *const _))
+                        from_glib(#crate_ident::ffi::g_quark_from_static_string(concat!(#domain_name, "\0") as *const ::core::primitive::str as *const _))
                     });
                 *QUARK
             }
@@ -48,7 +48,7 @@ pub fn impl_error_domain(input: &syn::DeriveInput) -> TokenStream {
             #[inline]
             fn from(value: i32) -> ::core::option::Option<Self>
             where
-                Self: Sized
+                Self: ::std::marker::Sized
             {
                 #from_glib
             }

--- a/glib-macros/src/flags_attribute.rs
+++ b/glib-macros/src/flags_attribute.rs
@@ -182,7 +182,7 @@ pub fn impl_flags(attrs: &NestedMeta, input: &DeriveInput) -> TokenStream {
         impl #crate_ident::HasParamSpec for #name {
             type ParamSpec = #crate_ident::ParamSpecFlags;
             type SetValue = Self;
-            type BuilderFn = fn(&str) -> #crate_ident::ParamSpecFlagsBuilder<Self>;
+            type BuilderFn = fn(&::core::primitive::str) -> #crate_ident::ParamSpecFlagsBuilder<Self>;
 
             fn param_spec_builder() -> Self::BuilderFn {
                 |name| Self::ParamSpec::builder(name)

--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -525,7 +525,7 @@ fn expand_wrapper_getset_properties(props: &[PropDesc]) -> TokenStream2 {
             let ident = format_ident!("set_{}", ident);
             let target_ty = quote!(<<#ty as #crate_ident::Property>::Value as #crate_ident::HasParamSpec>::SetValue);
             let set_ty = if p.nullable {
-               quote!(Option<impl std::borrow::Borrow<#target_ty>>)
+               quote!(::core::option::Option<impl std::borrow::Borrow<#target_ty>>)
             } else {
                quote!(impl std::borrow::Borrow<#target_ty>)
             };
@@ -558,7 +558,7 @@ fn expand_wrapper_connect_prop_notify(props: &[PropDesc]) -> TokenStream2 {
         let fn_ident = format_ident!("connect_{}_notify", name_to_ident(name));
         let span = p.attrs_span;
         quote_spanned!(span=> pub fn #fn_ident<F: Fn(&Self) + 'static>(&self, f: F) -> #crate_ident::SignalHandlerId {
-            self.connect_notify_local(Some(#name), move |this, _| {
+            self.connect_notify_local(::core::option::Option::Some(#name), move |this, _| {
                 f(this)
             })
         })
@@ -619,10 +619,10 @@ fn expand_properties_enum(props: &[PropDesc]) -> TokenStream2 {
         impl std::convert::TryFrom<usize> for DerivedPropertiesEnum {
             type Error = usize;
 
-            fn try_from(item: usize) -> Result<Self, Self::Error> {
+            fn try_from(item: usize) -> ::core::result::Result<Self, Self::Error> {
                 match item {
-                    #(#indices => Ok(Self::#properties),)*
-                    _ => Err(item)
+                    #(#indices => ::core::result::Result::Ok(Self::#properties),)*
+                    _ => ::core::result::Result::Err(item)
                 }
             }
         }

--- a/glib-macros/src/shared_boxed_derive.rs
+++ b/glib-macros/src/shared_boxed_derive.rs
@@ -16,8 +16,8 @@ fn gen_impl_to_value_optional(name: &Ident, crate_ident: &TokenStream) -> TokenS
                 let mut value = #crate_ident::Value::for_value_type::<Self>();
                 unsafe {
                     let ptr = match s {
-                        Some(s) => #refcounted_type_prefix::into_raw(s.0.clone()),
-                        None => ::std::ptr::null(),
+                        ::core::option::Option::Some(s) => #refcounted_type_prefix::into_raw(s.0.clone()),
+                        ::core::option::Option::None => ::std::ptr::null(),
                     };
 
                     #crate_ident::gobject_ffi::g_value_take_boxed(
@@ -133,7 +133,7 @@ pub fn impl_shared_boxed(input: &syn::DeriveInput) -> proc_macro2::TokenStream {
 
     quote! {
         impl #crate_ident::subclass::shared::SharedType for #name {
-            const NAME: &'static str = #gtype_name;
+            const NAME: &'static ::core::primitive::str = #gtype_name;
 
             type RefCountedType = #refcounted_type;
 
@@ -278,7 +278,7 @@ pub fn impl_shared_boxed(input: &syn::DeriveInput) -> proc_macro2::TokenStream {
         impl #crate_ident::HasParamSpec for #name {
             type ParamSpec = #crate_ident::ParamSpecBoxed;
             type SetValue = Self;
-            type BuilderFn = fn(&str) -> #crate_ident::ParamSpecBoxedBuilder<Self>;
+            type BuilderFn = fn(&::core::primitive::str) -> #crate_ident::ParamSpecBoxedBuilder<Self>;
 
             fn param_spec_builder() -> Self::BuilderFn {
                 |name| Self::ParamSpec::builder(name)

--- a/glib-macros/src/utils.rs
+++ b/glib-macros/src/utils.rs
@@ -153,12 +153,12 @@ pub fn gen_enum_from_glib(
         let name = &v.ident;
         quote_spanned! { v.span() =>
             if value == #enum_name::#name as i32 {
-                return Some(#enum_name::#name);
+                return ::core::option::Option::Some(#enum_name::#name);
             }
         }
     });
     quote! {
         #(#recurse)*
-        None
+        ::core::option::Option::None
     }
 }

--- a/glib-macros/src/value_delegate_derive.rs
+++ b/glib-macros/src/value_delegate_derive.rs
@@ -132,11 +132,11 @@ pub fn impl_value_delegate(input: ValueDelegateInput) -> syn::Result<proc_macro:
     let to_value_optional = nullable.then(|| {
         quote! {
             impl #crate_ident::value::ToValueOptional for #ident {
-                fn to_value_optional(s: Option<&Self>) -> #crate_ident::value::Value {
-                    if let Some(this) = s {
-                        #crate_ident::value::ToValue::to_value(&Some(&#delegate_value))
+                fn to_value_optional(s: ::core::option::Option<&Self>) -> #crate_ident::value::Value {
+                    if let ::core::option::Option::Some(this) = s {
+                        #crate_ident::value::ToValue::to_value(&::core::option::Option::Some(&#delegate_value))
                     } else {
-                        #crate_ident::value::ToValueOptional::to_value_optional(None::<&#delegated_ty>)
+                        #crate_ident::value::ToValueOptional::to_value_optional(::core::option::Option::None::<&#delegated_ty>)
                     }
                 }
             }


### PR DESCRIPTION
Having a custom eg. result type in scope will fail compilation, as the types don't match. Specify quoted types explicitly to not rely on the prelude.