### PR TITLE
glib: Allow using `Path` / `PathBuf` in `glib::Value`s

### DIFF
--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -1,6 +1,11 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::{char::CharTryFromError, convert::TryFrom, ffi::CStr};
+use std::{
+    char::CharTryFromError,
+    convert::TryFrom,
+    ffi::CStr,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     object::{Interface, InterfaceRef, IsClass, IsInterface, ObjectClass},
@@ -2137,6 +2142,24 @@ impl HasParamSpec for Vec<String> {
     type ParamSpec = ParamSpecBoxed;
     type SetValue = Self;
     type BuilderFn = fn(&str) -> ParamSpecBoxedBuilder<Self>;
+
+    fn param_spec_builder() -> Self::BuilderFn {
+        Self::ParamSpec::builder
+    }
+}
+impl HasParamSpec for Path {
+    type ParamSpec = ParamSpecString;
+    type SetValue = Path;
+    type BuilderFn = fn(&str) -> ParamSpecStringBuilder;
+
+    fn param_spec_builder() -> Self::BuilderFn {
+        Self::ParamSpec::builder
+    }
+}
+impl HasParamSpec for PathBuf {
+    type ParamSpec = ParamSpecString;
+    type SetValue = Path;
+    type BuilderFn = fn(&str) -> ParamSpecStringBuilder;
 
     fn param_spec_builder() -> Self::BuilderFn {
         Self::ParamSpec::builder

--- a/glib/src/types.rs
+++ b/glib/src/types.rs
@@ -3,7 +3,13 @@
 // rustdoc-stripper-ignore-next
 //! Runtime type information.
 
-use std::{fmt, marker::PhantomData, mem, ptr};
+use std::{
+    fmt,
+    marker::PhantomData,
+    mem,
+    path::{Path, PathBuf},
+    ptr,
+};
 
 use crate::{translate::*, IntoGStr, Slice};
 
@@ -496,6 +502,8 @@ builtin!(f32, F32);
 builtin!(f64, F64);
 builtin!(str, STRING);
 builtin!(String, STRING);
+builtin!(PathBuf, STRING);
+builtin!(Path, STRING);
 builtin!(Pointer, POINTER);
 
 impl<'a> StaticType for [&'a str] {


### PR DESCRIPTION
There's no separate GType for that unfortunately and it's up to the caller to select whether this is an actual `String` or a `Path`. If getting this wrong it will fail the same way it would now already fail for strings.