### PR TITLE
glib: Enable various smallvec features

### DIFF
--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -31,7 +31,7 @@ ffi = { package = "glib-sys", path = "sys" }
 gobject_ffi = { package = "gobject-sys", path = "gobject-sys" }
 glib-macros = { path = "../glib-macros" }
 rs-log = { package = "log", version = "0.4", optional = true }
-smallvec = "1.0"
+smallvec = { version = "1.0", features = ["union", "const_generics", "const_new"] }
 thiserror = "1"
 gio_ffi = { package = "gio-sys", path = "../gio/sys", optional = true }
 memchr = "2.5.0"


### PR DESCRIPTION
This all require a newer rustc than what smallvec depends on, but much older than glib's minimum supported Rust version.

Enabling these features enables smallvec to use less space, work with any array size and provide some more const functions.

----

Another reason why conservative MSRV are the plague.
