### PR TITLE
pango: Lower pkg-config version requirement for v1_52

### DIFF
--- a/pango/sys/Cargo.toml
+++ b/pango/sys/Cargo.toml
@@ -64,4 +64,4 @@ version = "1.48"
 version = "1.49.2"
 
 [package.metadata.system-deps.pango.v1_52]
-version = "1.52"
+version = "1.51"


### PR DESCRIPTION
Still not released APIs