### PR TITLE
properties: Allow to omit set for construct_only properties

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -851,7 +851,7 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 
 /// This macro enables you to derive object properties in a quick way.
 ///
-/// # Supported #[property] attributes
+/// # Supported `#[property]` attributes
 /// | Attribute | Description | Default | Example |
 /// | --- | --- | --- | --- |
 /// | `name = "literal"` | The name of the property | field ident where `_` (leading and trailing `_` are trimmed) is replaced into `-` | `#[property(name = "prop-name")]` |
@@ -862,7 +862,8 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 /// | `override_interface = expr` | The type of interface of which to override the property from | | `#[property(override_interface = SomeInterface)]` |
 /// | `nullable` | Whether to use `Option<T>` in the wrapper's generated setter |  | `#[property(nullable)]` |
 /// | `member = ident` | Field of the nested type where property is retrieved and set | | `#[property(member = author)]` |
-/// | `builder(<required-params>)[.ident]*` | Used to input required params or add optional Param Spec builder fields | | `#[property(builder(SomeEnum::default()))]`, `#[builder().default_value(1).construct_only()]`, etc.  |
+/// | `construct_only` | Specify that the property is construct only. This will not generate a public setter and only allow the property to be set during object construction. The use of a custom internal setter is supported. | | `#[property(get, construct_only)]` or `#[property(get, set = set_prop, construct_only)]` |
+/// | `builder(<required-params>)[.ident]*` | Used to input required params or add optional Param Spec builder fields | | `#[property(builder(SomeEnum::default()))]`, `#[builder().default_value(1).minimum(0).maximum(5)]`, etc.  |
 /// | `default` | Sets the `default_value` field of the Param Spec builder | | `#[property(default = 1)]` |
 /// | `<optional-pspec-builder-fields> = expr` | Used to add optional Param Spec builder fields | | `#[property(minimum = 0)` , `#[property(minimum = 0, maximum = 1)]`, etc. |
 /// | `<optional-pspec-builder-fields>` | Used to add optional Param Spec builder fields | | `#[property(explicit_notify)]` , `#[property(construct_only)]`, etc. |
@@ -883,7 +884,7 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 ///
 /// # Internal getters and setters
 /// By default, they are generated for you. However, you can use a custom getter/setter
-/// by assigning an expression to `get`/`set` #[property] attributes: `#[property(get = |_| 2, set)]` or `#[property(get, set = custom_setter_func)]`.
+/// by assigning an expression to `get`/`set` `#[property]` attributes: `#[property(get = |_| 2, set)]` or `#[property(get, set = custom_setter_func)]`.
 ///
 /// # Supported types
 /// Every type implementing the trait `Property` is supported.

--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -259,16 +259,11 @@ impl PropDesc {
             builder_fields,
         } = attrs;
 
-        let is_construct_only = if builder_fields.iter().any(|(k, _)| *k == "construct_only") {
-            // Insert a default setter automatically
-            if set.is_none() {
-                set = Some(MaybeCustomFn::Default);
-            }
-
-            true
-        } else {
-            false
-        };
+        let is_construct_only = builder_fields.iter().any(|(k, _)| *k == "construct_only");
+        if is_construct_only && set.is_none() {
+            // Insert a default internal setter automatically
+            set = Some(MaybeCustomFn::Default);
+        }
 
         if get.is_none() && set.is_none() {
             return Err(syn::Error::new(

--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -236,6 +236,7 @@ struct PropDesc {
     member: Option<syn::Ident>,
     builder: Option<(Punctuated<syn::Expr, Token![,]>, TokenStream2)>,
     builder_fields: HashMap<syn::Ident, Option<syn::Expr>>,
+    is_construct_only: bool,
 }
 
 impl PropDesc {
@@ -248,7 +249,7 @@ impl PropDesc {
         let ReceivedAttrs {
             nullable,
             get,
-            set,
+            mut set,
             override_class,
             override_interface,
             ty,
@@ -257,6 +258,17 @@ impl PropDesc {
             builder,
             builder_fields,
         } = attrs;
+
+        let is_construct_only = if builder_fields.iter().any(|(k, _)| *k == "construct_only") {
+            // Insert a default setter automatically
+            if set.is_none() {
+                set = Some(MaybeCustomFn::Default);
+            }
+
+            true
+        } else {
+            false
+        };
 
         if get.is_none() && set.is_none() {
             return Err(syn::Error::new(
@@ -295,6 +307,7 @@ impl PropDesc {
             member,
             builder,
             builder_fields,
+            is_construct_only,
         })
     }
 }
@@ -534,8 +547,8 @@ fn expand_wrapper_getset_properties(props: &[PropDesc]) -> TokenStream2 {
                  self.property::<<#ty as #crate_ident::Property>::Value>(#stripped_name)
             })
         });
-        let is_construct_only = p.builder_fields.iter().any(|(k, _)| *k == "construct_only");
-        let setter = (p.set.is_some() && !is_construct_only).then(|| {
+
+        let setter = (p.set.is_some() && !p.is_construct_only).then(|| {
             let ident = format_ident!("set_{}", ident);
             let target_ty = quote!(<<#ty as #crate_ident::Property>::Value as #crate_ident::HasParamSpec>::SetValue);
             let set_ty = if p.nullable {


### PR DESCRIPTION
This allows to omit `set` for `construct_only` properties, as it is confusing from a semantic perspective, because we don't actually generate a public setter. It was required before, but didn't actually throw an error but panic at runtime.

Updates the docs about how to use `construct_only` and chooses a better example for the `builder()` attribute.

Closes #1088