### PR TITLE
Fix required features not shown in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ jobs:
         0.15=0.15
         0.14=0.14
       RUSTFLAGS: --cfg docsrs
+      RUSTDOCFLAGS: --cfg docsrs
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,7 +39,26 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: -p cairo-rs -p cairo-sys-rs -p gdk-pixbuf -p gdk-pixbuf-sys -p gio -p gio-sys -p glib -p gobject-sys -p glib-sys -p glib-macros -p glib-build-tools -p graphene-rs -p graphene-sys -p pango -p pango-sys -p pangocairo -p pangocairo-sys --no-deps --all-features
+          args: >
+            -p cairo-rs 
+            -p cairo-sys-rs
+            -p gdk-pixbuf
+            -p gdk-pixbuf-sys
+            -p gio
+            -p gio-sys
+            -p glib
+            -p gobject-sys
+            -p glib-sys
+            -p glib-macros
+            -p glib-build-tools
+            -p graphene-rs
+            -p graphene-sys
+            -p pango
+            -p pango-sys
+            -p pangocairo
+            -p pangocairo-sys
+            --no-deps
+            --all-features
       - run: echo "RELEASE=$(echo '${{ github.event.release.tag_name }}' | grep -Po '(\d+)\.(\d+)')" >> ${GITHUB_ENV}
       - run: echo "DEST=$(if [ "$GITHUB_EVENT_NAME" == "release" ]; then echo 'stable/${{ env.RELEASE }}'; else echo 'git'; fi)" >> ${GITHUB_ENV}
       - name: Grab gtk-rs LOGO

--- a/cairo/Cargo.toml
+++ b/cairo/Cargo.toml
@@ -31,6 +31,8 @@ xlib = ["ffi/xlib"]
 win32-surface = ["ffi/win32-surface"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies.glib]

--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -207,7 +207,10 @@ pub use pdf::PdfSurface;
 #[cfg_attr(docsrs, doc(cfg(feature = "ps")))]
 pub use ps::PsSurface;
 #[cfg(any(feature = "pdf", feature = "svg", feature = "ps"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "pdf", feature = "svg", feature = "ps")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "pdf", feature = "svg", feature = "ps")))
+)]
 pub use stream::StreamWithError;
 #[cfg(feature = "svg")]
 #[cfg_attr(docsrs, doc(cfg(feature = "svg")))]

--- a/gdk-pixbuf/Cargo.toml
+++ b/gdk-pixbuf/Cargo.toml
@@ -23,6 +23,8 @@ v2_40 = ["ffi/v2_40"]
 v2_42 = ["v2_40", "ffi/v2_42"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/gdk-pixbuf/sys/Cargo.toml
+++ b/gdk-pixbuf/sys/Cargo.toml
@@ -41,6 +41,9 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.gdk_pixbuf_2_0]

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -32,6 +32,8 @@ v2_74 = ["v2_72", "ffi/v2_74", "glib/v2_74"]
 v2_76 = ["v2_74", "ffi/v2_76", "glib/v2_76"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/gio/sys/Cargo.toml
+++ b/gio/sys/Cargo.toml
@@ -49,6 +49,9 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.gio_2_0]

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -60,6 +60,8 @@ compiletests = []
 gio = ["gio_ffi"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [[test]]

--- a/glib/gobject-sys/Cargo.toml
+++ b/glib/gobject-sys/Cargo.toml
@@ -39,6 +39,9 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.gobject_2_0]

--- a/glib/sys/Cargo.toml
+++ b/glib/sys/Cargo.toml
@@ -37,6 +37,9 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.glib_2_0]

--- a/graphene/Cargo.toml
+++ b/graphene/Cargo.toml
@@ -19,6 +19,8 @@ rust-version = "1.64"
 name = "graphene"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/graphene/sys/Cargo.toml
+++ b/graphene/sys/Cargo.toml
@@ -30,6 +30,9 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.graphene_gobject_1_0]

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -24,6 +24,8 @@ v1_50 = ["v1_48", "ffi/v1_50"]
 v1_52 = ["v1_50", "ffi/v1_52"]
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/pango/sys/Cargo.toml
+++ b/pango/sys/Cargo.toml
@@ -41,6 +41,9 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.pango]

--- a/pangocairo/Cargo.toml
+++ b/pangocairo/Cargo.toml
@@ -16,6 +16,8 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/pangocairo/sys/Cargo.toml
+++ b/pangocairo/sys/Cargo.toml
@@ -37,6 +37,9 @@ edition = "2021"
 rust-version = "1.64"
 
 [package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 features = []
 
 [package.metadata.system-deps.pangocairo]


### PR DESCRIPTION
Fix for https://github.com/gtk-rs/gtk-rs-core/issues/1090 on the gtk-rs-core side

It seems like you need both RUSTFLAGS and RUSTDOCFLAGS because `build.rs` doesn't care about the doc flags and cargo only passes RUSTDOCFLAGS to rustdoc...