### PR TITLE
Update syn: v2.0

### DIFF
--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -17,7 +17,7 @@ heck = "0.4"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "2.0", features = ["full"] }
 proc-macro-crate = "1.0"
 
 [lib]

--- a/glib-macros/src/error_domain_derive.rs
+++ b/glib-macros/src/error_domain_derive.rs
@@ -5,7 +5,7 @@ use proc_macro_error::abort_call_site;
 use quote::quote;
 use syn::Data;
 
-use crate::utils::{crate_ident_new, gen_enum_from_glib, parse_name};
+use crate::utils::{crate_ident_new, gen_enum_from_glib, parse_nested_meta_items, NestedMetaItem};
 
 pub fn impl_error_domain(input: &syn::DeriveInput) -> TokenStream {
     let name = &input.ident;
@@ -15,14 +15,21 @@ pub fn impl_error_domain(input: &syn::DeriveInput) -> TokenStream {
         _ => abort_call_site!("#[derive(glib::ErrorDomain)] only supports enums"),
     };
 
-    let domain_name = match parse_name(input, "error_domain") {
-        Ok(name) => name,
-        Err(e) => abort_call_site!(
-            "{}: #[derive(glib::ErrorDomain)] requires #[error_domain(name = \"domain-name\")]",
-            e
-        ),
-    };
+    let mut domain_name = NestedMetaItem::<syn::LitStr>::new("name")
+        .required()
+        .value_required();
+    let found = parse_nested_meta_items(&input.attrs, "error_domain", &mut [&mut domain_name]);
 
+    match found {
+        Ok(None) => {
+            abort_call_site!(
+                "#[derive(glib::ErrorDomain)] requires #[error_domain(name = \"domain-name\")]"
+            )
+        }
+        Err(e) => return e.to_compile_error(),
+        Ok(_) => (),
+    };
+    let domain_name = domain_name.value.unwrap();
     let crate_ident = crate_ident_new();
 
     let from_glib = gen_enum_from_glib(name, enum_variants);

--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -15,7 +15,7 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
     let mut has_class = false;
     for item in &input.items {
         match item {
-            syn::ImplItem::Method(method) => {
+            syn::ImplItem::Fn(method) => {
                 let name = &method.sig.ident;
                 if name == "new" || name == "with_class" {
                     has_new = true;

--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -42,7 +42,7 @@ impl Parse for PropsMacroInput {
         let wrapper_ty = derive_input
             .attrs
             .iter()
-            .find(|x| x.path.is_ident("properties"))
+            .find(|x| x.path().is_ident("properties"))
             .ok_or_else(|| {
                 syn::Error::new(
                     derive_input.span(),
@@ -141,7 +141,7 @@ impl Parse for PropAttr {
                 "builder" => {
                     let content;
                     parenthesized!(content in input);
-                    let required = content.parse_terminated(syn::Expr::parse)?;
+                    let required = content.parse_terminated(syn::Expr::parse, Token![,])?;
                     let rest: TokenStream2 = input.parse()?;
                     PropAttr::Builder(required, rest)
                 }
@@ -502,7 +502,7 @@ fn parse_fields(fields: syn::Fields) -> syn::Result<Vec<PropDesc>> {
             } = field;
             attrs
                 .into_iter()
-                .filter(|a| a.path.is_ident("property"))
+                .filter(|a| a.path().is_ident("property"))
                 .map(move |prop_attrs| {
                     let span = prop_attrs.span();
                     PropDesc::new(

--- a/glib-macros/src/utils.rs
+++ b/glib-macros/src/utils.rs
@@ -1,112 +1,167 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use anyhow::{bail, Result};
 use proc_macro2::{Ident, Span, TokenStream};
 use proc_macro_crate::crate_name;
-use quote::{quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{
-    punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, DeriveInput, Lit, Meta,
-    MetaList, NestedMeta, Variant,
+    meta::ParseNestedMeta, parse::Parse, punctuated::Punctuated, spanned::Spanned, token::Comma,
+    Token, Variant,
 };
 
-// find the #[@attr_name] attribute in @attrs
-pub fn find_attribute_meta(attrs: &[Attribute], attr_name: &str) -> Result<Option<MetaList>> {
-    let meta = match attrs.iter().find(|a| a.path.is_ident(attr_name)) {
-        Some(a) => a.parse_meta(),
-        _ => return Ok(None),
-    };
-    match meta? {
-        Meta::List(n) => Ok(Some(n)),
-        _ => bail!("wrong meta type"),
+pub trait ParseNestedMetaItem {
+    fn get_name(&self) -> &'static str;
+    fn get_found(&self) -> bool;
+    fn get_required(&self) -> bool;
+    fn parse_nested(&mut self, meta: &ParseNestedMeta) -> Option<syn::Result<()>>;
+}
+
+#[derive(Default)]
+pub struct NestedMetaItem<T> {
+    pub name: &'static str,
+    pub value_required: bool,
+    pub found: bool,
+    pub required: bool,
+    pub value: Option<T>,
+}
+
+impl<T: Parse + ToTokens> std::fmt::Debug for NestedMetaItem<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NestedMetaItem")
+            .field("name", &self.name)
+            .field("required", &self.required)
+            .field("value_required", &self.value_required)
+            .field("found", &self.found)
+            .field("value", &self.value.as_ref().map(|v| quote!(#v)))
+            .finish()
     }
 }
 
-// parse a single meta like: ident = "value"
-fn parse_attribute(meta: &NestedMeta) -> Result<(String, String)> {
-    let meta = match &meta {
-        NestedMeta::Meta(m) => m,
-        _ => bail!("wrong meta type"),
-    };
-    let meta = match meta {
-        Meta::NameValue(n) => n,
-        _ => bail!("wrong meta type"),
-    };
-    let value = match &meta.lit {
-        Lit::Str(s) => s.value(),
-        _ => bail!("wrong meta type"),
-    };
-
-    let ident = match meta.path.get_ident() {
-        None => bail!("missing ident"),
-        Some(ident) => ident,
-    };
-
-    Ok((ident.to_string(), value))
+impl<T: Parse> NestedMetaItem<T> {
+    pub const fn new(name: &'static str) -> Self {
+        Self {
+            required: false,
+            name,
+            found: false,
+            value_required: false,
+            value: None,
+        }
+    }
+    pub fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+    // Note: this flags the `value` as required, that is,
+    // the parameter after the equal: `name = value`.
+    pub const fn value_required(mut self) -> Self {
+        self.value_required = true;
+        self
+    }
+    pub const fn value_optional(mut self) -> Self {
+        self.value_required = false;
+        self
+    }
+    fn parse_nested_forced(&mut self, meta: &ParseNestedMeta) -> syn::Result<()> {
+        if self.value_required || meta.input.peek(Token![=]) {
+            let _eq: Token![=] = meta.input.parse()?;
+            self.value = Some(meta.input.parse()?);
+        }
+        Ok(())
+    }
 }
-
-pub fn find_nested_meta<'a>(meta: &'a MetaList, name: &str) -> Option<&'a NestedMeta> {
-    meta.nested.iter().find(|n| match n {
-        NestedMeta::Meta(m) => m.path().is_ident(name),
-        _ => false,
-    })
-}
-
-pub fn parse_name_attribute(meta: &NestedMeta) -> Result<String> {
-    let (ident, v) = parse_attribute(meta)?;
-
-    match ident.as_ref() {
-        "name" => Ok(v),
-        s => bail!("Unknown meta {}", s),
+impl<T: Parse> ParseNestedMetaItem for NestedMetaItem<T> {
+    fn get_name(&self) -> &'static str {
+        self.name
+    }
+    fn parse_nested(&mut self, meta: &ParseNestedMeta) -> Option<syn::Result<()>> {
+        if meta.path.is_ident(self.name) {
+            self.found = true;
+            Some(self.parse_nested_forced(meta))
+        } else {
+            None
+        }
+    }
+    fn get_found(&self) -> bool {
+        self.found
+    }
+    fn get_required(&self) -> bool {
+        self.required
     }
 }
 
-// Parse attribute such as:
-// #[enum_type(name = "TestAnimalType")]
-pub fn parse_name(input: &DeriveInput, attr_name: &str) -> Result<String> {
-    let meta = match find_attribute_meta(&input.attrs, attr_name)? {
-        Some(meta) => meta,
-        _ => bail!("Missing '{}' attribute", attr_name),
-    };
-
-    let meta = match find_nested_meta(&meta, "name") {
-        Some(meta) => meta,
-        _ => bail!("Missing meta 'name'"),
-    };
-
-    parse_name_attribute(meta)
-}
-
-#[derive(Debug)]
-pub enum ItemAttribute {
-    Name(String),
-    Nick(String),
-}
-
-fn parse_item_attribute(meta: &NestedMeta) -> Result<ItemAttribute> {
-    let (ident, v) = parse_attribute(meta)?;
-
-    match ident.as_ref() {
-        "name" => Ok(ItemAttribute::Name(v)),
-        "nick" => Ok(ItemAttribute::Nick(v)),
-        s => bail!("Unknown item meta {}", s),
+pub fn check_meta_items(span: Span, items: &mut [&mut dyn ParseNestedMetaItem]) -> syn::Result<()> {
+    let mut err: Option<syn::Error> = None;
+    for item in &mut *items {
+        if item.get_required() && !item.get_found() {
+            let nerr = syn::Error::new(
+                span,
+                format!("attribute `{}` must be specified", item.get_name()),
+            );
+            if let Some(ref mut err) = err {
+                err.combine(nerr);
+            } else {
+                err = Some(nerr);
+            }
+        }
+    }
+    match err {
+        Some(err) => Err(err),
+        None => Ok(()),
     }
 }
+fn parse_nested_meta_items_from_fn(
+    parse_nested_meta: impl FnOnce(
+        &mut dyn FnMut(ParseNestedMeta) -> syn::Result<()>,
+    ) -> syn::Result<()>,
+    items: &mut [&mut dyn ParseNestedMetaItem],
+) -> syn::Result<()> {
+    parse_nested_meta(&mut |meta| {
+        for item in &mut *items {
+            if let Some(res) = item.parse_nested(&meta) {
+                return res;
+            }
+        }
+        Err(meta.error(format!(
+            "unknown attribute `{}`. Possible attributes are {}",
+            meta.path.get_ident().unwrap(),
+            items
+                .iter()
+                .map(|i| format!("`{}`", i.get_name()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )))
+    })?;
+    Ok(())
+}
 
-// Parse optional enum item attributes such as:
-// #[enum_value(name = "My Name", nick = "my-nick")]
-pub fn parse_item_attributes(attr_name: &str, attrs: &[Attribute]) -> Result<Vec<ItemAttribute>> {
-    let meta = find_attribute_meta(attrs, attr_name)?;
+pub fn parse_nested_meta_items_from_stream(
+    input: TokenStream,
+    items: &mut [&mut dyn ParseNestedMetaItem],
+) -> syn::Result<()> {
+    parse_nested_meta_items_from_fn(
+        |f| {
+            let p = syn::meta::parser(f);
+            syn::parse::Parser::parse(p, input.into())
+        },
+        items,
+    )?;
+    check_meta_items(Span::call_site(), items)
+}
 
-    let v = match meta {
-        Some(meta) => meta
-            .nested
-            .iter()
-            .map(parse_item_attribute)
-            .collect::<Result<Vec<_>, _>>()?,
-        None => Vec::new(),
-    };
-
-    Ok(v)
+pub fn parse_nested_meta_items<'a>(
+    attrs: impl IntoIterator<Item = &'a syn::Attribute>,
+    attr_name: &str,
+    items: &mut [&mut dyn ParseNestedMetaItem],
+) -> syn::Result<Option<&'a syn::Attribute>> {
+    let attr = attrs
+        .into_iter()
+        .find(|attr| attr.path().is_ident(attr_name));
+    if let Some(attr) = attr {
+        parse_nested_meta_items_from_fn(|x| attr.parse_nested_meta(x), items)?;
+        check_meta_items(attr.span(), items)?;
+        Ok(Some(attr))
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn crate_ident_new() -> TokenStream {
@@ -160,5 +215,62 @@ pub fn gen_enum_from_glib(
     quote! {
         #(#recurse)*
         ::core::option::Option::None
+    }
+}
+
+// These tests are useful to pinpoint the exact location of a macro panic
+// by running `cargo test --lib`
+#[cfg(test)]
+mod tests {
+    use syn::{parse_quote, DeriveInput};
+
+    use super::*;
+
+    fn boxed_stub() -> DeriveInput {
+        parse_quote!(
+            #[boxed_type(name = "Author")]
+            struct Author {
+                name: String,
+            }
+        )
+    }
+
+    #[test]
+    fn check_attr_found() {
+        let input = boxed_stub();
+        let found = parse_nested_meta_items(&input.attrs, "boxed_type", &mut []);
+        matches!(found, Ok(Some(_)));
+    }
+    #[test]
+    fn required_name_present() {
+        let input = boxed_stub();
+        let mut gtype_name = NestedMetaItem::<syn::LitStr>::new("name")
+            .required()
+            .value_required();
+        let _ = parse_nested_meta_items(&input.attrs, "boxed_type", &mut [&mut gtype_name]);
+        assert_eq!(gtype_name.get_found(), true);
+        assert_eq!(
+            gtype_name.value.map(|x| x.value()),
+            Some("Author".to_string())
+        );
+    }
+    #[test]
+    fn required_name_none() {
+        let input: DeriveInput = parse_quote!(
+            #[boxed_type(name)]
+            struct Author {
+                name: String,
+            }
+        );
+        let mut gtype_name = NestedMetaItem::<syn::LitStr>::new("name")
+            .required()
+            .value_required();
+        let found = parse_nested_meta_items(&input.attrs, "boxed_type", &mut [&mut gtype_name]);
+        // The argument value was specified as required, so an error is returned
+        matches!(found, Err(_));
+        assert!(gtype_name.value.is_none());
+
+        // The argument key must be found though
+        assert_eq!(gtype_name.get_found(), true);
     }
 }

--- a/glib-macros/src/value_delegate_derive.rs
+++ b/glib-macros/src/value_delegate_derive.rs
@@ -67,7 +67,7 @@ impl Parse for ValueDelegateInput {
         let args: Option<Args> = if let Some(attr) = derive_input
             .attrs
             .iter()
-            .find(|x| x.path.is_ident("value_delegate"))
+            .find(|x| x.path().is_ident("value_delegate"))
         {
             let args: Args = attr.parse_args()?;
             Some(args)


### PR DESCRIPTION
closes #1061 

**Problem**
syn 2.0 removed the type `NestedMeta`, that was extensively used by gtk-rs-core to parse macro attributes, without providing a direct replacement type.
Instead, the suggested way to parse an attribute is now to use [`Attribute::parse_nested_meta`](https://docs.rs/syn/latest/syn/struct.Attribute.html#method.parse_nested_meta), which iterates over the arguments of an attribute and forces you to parse them. `parse_nested_meta` tracks the spans of the arguments being parsed, so in the case an error is returned, it provides good error messages.

Most of the glib-macros depended on utility functions defined in `glib-macros::utils`. Those functions often tried to retrieve a single argument inside an attribute, without caring about the other arguments. This is not possible when using `Attribute::parse_nested_meta`, because it requires to handle _every possible argument_ in a single place. We can't just parse the argument `name = "value"` and skip  `nick = "nick"`, because `parse_nested_meta` will consider `nick` as an unexpected value and will throw an error.

**Proposed solution**
Rewriting the parsing of attributes taking advantage of `parse_nested_meta`, which is now the suggested way to parse attribute arguments (also see https://docs.rs/syn/latest/syn/meta/struct.ParseNestedMeta.html). A new set of utilities have been implemented in `glib-macro::utils` to ease the parsing process.

**To do**
implement some tests for the new parsing utility functions, to polish their interface and ensure correctness.

**Observations**
I would consider using the crate https://github.com/jf2048/deluxe (by @jf2048, #970) to handle attribute parsing.

**Conclusions**
- Improvements from syn 1.0:
  - We are up to date!
  - the errors from the macro should now be improved, because `parse_nested_meta` keeps track of argument spans and ensures every argument is parsed correctly.
- Drawbacks: even though the tests are passing, rewriting the parsing system can easily introduce some bugs. I fear I've missed some corner cases.

