### PR TITLE
Update rust-version = 1.65

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.64.0"
+          - "1.65.0"
         conf:
           - { name: "cairo", features: "png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface", nightly: "--features 'png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface'", test_sys: true }
           - { name: "gdk-pixbuf", features: "v2_42", nightly: "--all-features", test_sys: true }
@@ -104,7 +104,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.64.0"
+          - "1.65.0"
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ information about each crate, please refer to their `README.md` file in their di
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Documentation
 

--- a/cairo/Cargo.toml
+++ b/cairo/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.18.0"
 description = "Rust bindings for the Cairo library"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [lib]
 name = "cairo"

--- a/cairo/README.md
+++ b/cairo/README.md
@@ -8,7 +8,7 @@ Cairo __1.14__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Default-on features
 

--- a/cairo/sys/Cargo.toml
+++ b/cairo/sys/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["cairo", "ffi", "gtk-rs", "gnome"]
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 build = "build.rs"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.system-deps.cairo]
 name = "cairo"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,7 +3,7 @@ name = "gtk-rs-examples"
 version = "0.0.1"
 authors = ["The gtk-rs Project Developers"]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 futures = "0.3"

--- a/gdk-pixbuf/Cargo.toml
+++ b/gdk-pixbuf/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [lib]
 name = "gdk_pixbuf"

--- a/gdk-pixbuf/README.md
+++ b/gdk-pixbuf/README.md
@@ -6,7 +6,7 @@ GDK-PixBuf __2.36.8__ is the lowest supported version for the underlying library
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Documentation
 

--- a/gdk-pixbuf/sys/Cargo.toml
+++ b/gdk-pixbuf/sys/Cargo.toml
@@ -38,7 +38,7 @@ name = "gdk-pixbuf-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.18.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 build = "build.rs"
 
 [lib]

--- a/gio/README.md
+++ b/gio/README.md
@@ -6,7 +6,7 @@ GIO __2.56__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Documentation
 

--- a/gio/sys/Cargo.toml
+++ b/gio/sys/Cargo.toml
@@ -46,7 +46,7 @@ name = "gio-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.18.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/glib-build-tools/Cargo.toml
+++ b/glib-build-tools/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.18.0"
 description = "Rust bindings for the Gio library, build script utils crate"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 gio = { path = "../gio", optional = true }

--- a/glib-build-tools/README.md
+++ b/glib-build-tools/README.md
@@ -4,7 +4,7 @@ Crate containing helpers for building GIO-based applications.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Documentation
 

--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["glib", "gtk-rs", "gnome", "GUI"]
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 anyhow = "1"

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [lib]
 name = "glib"

--- a/glib/README.md
+++ b/glib/README.md
@@ -16,7 +16,7 @@ crates.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Dynamic typing
 

--- a/glib/gobject-sys/Cargo.toml
+++ b/glib/gobject-sys/Cargo.toml
@@ -36,7 +36,7 @@ name = "gobject-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.18.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/glib/sys/Cargo.toml
+++ b/glib/sys/Cargo.toml
@@ -35,7 +35,7 @@ name = "glib-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.18.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/graphene/Cargo.toml
+++ b/graphene/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [lib]
 name = "graphene"

--- a/graphene/README.md
+++ b/graphene/README.md
@@ -6,7 +6,7 @@ Graphene __1.10__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Documentation
 

--- a/graphene/sys/Cargo.toml
+++ b/graphene/sys/Cargo.toml
@@ -27,7 +27,7 @@ name = "graphene-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.18.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [features]
 v1_42 = ["ffi/v1_42"]

--- a/pango/README.md
+++ b/pango/README.md
@@ -6,7 +6,7 @@ Pango __1.40__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Documentation
 

--- a/pango/sys/Cargo.toml
+++ b/pango/sys/Cargo.toml
@@ -38,7 +38,7 @@ name = "pango-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.18.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pangocairo/Cargo.toml
+++ b/pangocairo/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "gir-files/*",
 ]
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pangocairo/README.md
+++ b/pangocairo/README.md
@@ -7,7 +7,7 @@ PangoCairo __1.40__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.64.0`.
+Currently, the minimum supported Rust version is `1.65.0`.
 
 ## Documentation
 

--- a/pangocairo/sys/Cargo.toml
+++ b/pangocairo/sys/Cargo.toml
@@ -34,7 +34,7 @@ name = "pangocairo-sys"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.18.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
+++ b/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
@@ -6,7 +6,7 @@ description = "crate that depends on a glib-rs dependent crate for validation of
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 # Use `gstreamer` as a simulation of an identified crate re-exporting `glib`.

--- a/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
@@ -7,7 +7,7 @@ description = "gstreamer simulator as a glib dependent crate for validation of g
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 glib = { path = "../../../glib" }

--- a/tests/two-levels-glib-dependent/gtk/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gtk/Cargo.toml
@@ -7,7 +7,7 @@ description = "gtk simulator as a glib dependent crate for validation of glib re
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 glib = { path = "../../../glib" }


### PR DESCRIPTION
closes #1097 
So that we can use GATs (which could be useful for the Properties macro) and `let-else` statements.

Rust versions between `1.65..=1.69` don't introduce significant changes to justify an upgrade to an higher version.