### PR TITLE
Bump the gir-format-check dev-dependency to 0.1.2

### DIFF
--- a/gdk-pixbuf/Cargo.toml
+++ b/gdk-pixbuf/Cargo.toml
@@ -36,4 +36,4 @@ gio = { path = "../gio" }
 once_cell = "1"
 
 [dev-dependencies]
-gir-format-check = "^0.1"
+gir-format-check = "^0.1.2"

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -53,5 +53,5 @@ smallvec = "1"
 [dev-dependencies]
 futures = "0.3"
 futures-util = { version = "0.3", features = ["io"] }
-gir-format-check = "^0.1"
+gir-format-check = "^0.1.2"
 serial_test = "1"

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -38,7 +38,7 @@ memchr = "2.5.0"
 
 [dev-dependencies]
 tempfile = "3"
-gir-format-check = "^0.1"
+gir-format-check = "^0.1.2"
 trybuild2 = "1"
 criterion = "0.4.0"
 

--- a/graphene/Cargo.toml
+++ b/graphene/Cargo.toml
@@ -29,4 +29,4 @@ glib = { path = "../glib" }
 ffi = { package = "graphene-sys", path = "sys" }
 
 [dev-dependencies]
-gir-format-check = "^0.1"
+gir-format-check = "^0.1.2"

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -37,4 +37,4 @@ glib = { path = "../glib" }
 gio = { path = "../gio" }
 
 [dev-dependencies]
-gir-format-check = "^0.1"
+gir-format-check = "^0.1.2"

--- a/pangocairo/Cargo.toml
+++ b/pangocairo/Cargo.toml
@@ -29,4 +29,4 @@ pango = { path = "../pango" }
 cairo-rs = { path = "../cairo" }
 
 [dev-dependencies]
-gir-format-check = "^0.1"
+gir-format-check = "^0.1.2"


### PR DESCRIPTION
In the commit 272bba5f2f159f5c15e1f0fea6e491038f427cf6 the removal of the to_string() call is only valid if the Errors struct implements Display, which is available in gir-format-check 0.1.2 on.

Fixes: 272bba5f2f15 ("Fix various 1.58 (beta) clippy warnings or silence them")

We've been hitting this issue when packaging the various crates for Debian and Ubuntu.