### PR TITLE
graphene: fix alignment of graphene_simd4f_t on armhf and s390x

### DIFF
--- a/graphene/sys/src/lib.rs
+++ b/graphene/sys/src/lib.rs
@@ -227,7 +227,9 @@ impl ::std::fmt::Debug for graphene_rect_t {
     }
 }
 
-#[repr(align(16))]
+#[cfg_attr(target_arch = "arm", repr(align(4)))]
+#[cfg_attr(target_arch = "s390x", repr(align(8)))]
+#[cfg_attr(not(any(target_arch = "arm", target_arch = "s390x")), repr(align(16)))]
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct graphene_simd4f_t {


### PR DESCRIPTION
On systems with the armhf ABI as used by Debian and Ubuntu (amdv7 + VFP, but without NEON), graphene falls back to the scalar definition of graphene_simd4f_t, which has the same alignment as its base type, float.

On s390x, the underlying type is a generic float
__attribute__((vector_size(16)). Surprinsingly, the s390x ABI does not mandate alignment bigger than 8 for the vector types.

Without these patches, the layout tests fail on those architectures. The armhf case is notable because there are a fair number of Raspberry Pis out there that use that ABI, either because their SoC isn't 64-bit ready or just because they have low memory.

Ideally, we could specifiy this in the Gir.toml file, but it doesn't seem like the tool is flexible enough to express this kind of nuances,