### PR TITLE
Make FileInfo bytestring methods use CStrings

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -822,6 +822,14 @@ status = "generate"
     name = "set_attribute_stringv"
     # use strv
     manual = true
+    [[object.function]]
+    name = "get_attribute_byte_string"
+    # use CString
+    manual = true
+    [[object.function]]
+    name = "set_attribute_byte_string"
+    # use CStr
+    manual = true
 
 [[object]]
 name = "Gio.FilterOutputStream"

--- a/gio/src/auto/file_info.rs
+++ b/gio/src/auto/file_info.rs
@@ -72,17 +72,6 @@ impl FileInfo {
         }
     }
 
-    #[doc(alias = "g_file_info_get_attribute_byte_string")]
-    #[doc(alias = "get_attribute_byte_string")]
-    pub fn attribute_byte_string(&self, attribute: &str) -> Option<glib::GString> {
-        unsafe {
-            from_glib_none(ffi::g_file_info_get_attribute_byte_string(
-                self.to_glib_none().0,
-                attribute.to_glib_none().0,
-            ))
-        }
-    }
-
     //#[doc(alias = "g_file_info_get_attribute_data")]
     //#[doc(alias = "get_attribute_data")]
     //pub fn attribute_data(&self, attribute: &str, value_pp: /*Unimplemented*/&mut Basic: Pointer) -> Option<(FileAttributeType, FileAttributeStatus)> {
@@ -337,17 +326,6 @@ impl FileInfo {
                 self.to_glib_none().0,
                 attribute.to_glib_none().0,
                 attr_value.into_glib(),
-            );
-        }
-    }
-
-    #[doc(alias = "g_file_info_set_attribute_byte_string")]
-    pub fn set_attribute_byte_string(&self, attribute: &str, attr_value: &str) {
-        unsafe {
-            ffi::g_file_info_set_attribute_byte_string(
-                self.to_glib_none().0,
-                attribute.to_glib_none().0,
-                attr_value.to_glib_none().0,
             );
         }
     }

--- a/gio/src/file_info.rs
+++ b/gio/src/file_info.rs
@@ -71,4 +71,30 @@ impl FileInfo {
             });
         }
     }
+
+    #[doc(alias = "g_file_info_get_attribute_byte_string")]
+    #[doc(alias = "get_attribute_byte_string")]
+    pub fn attribute_byte_string(&self, attribute: &str) -> Option<std::ffi::CString> {
+        unsafe {
+            from_glib_none(ffi::g_file_info_get_attribute_byte_string(
+                self.to_glib_none().0,
+                attribute.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "g_file_info_set_attribute_byte_string")]
+    pub fn set_attribute_byte_string(
+        &self,
+        attribute: &str,
+        attr_value: impl AsRef<std::ffi::CStr>,
+    ) {
+        unsafe {
+            ffi::g_file_info_set_attribute_byte_string(
+                self.to_glib_none().0,
+                attribute.to_glib_none().0,
+                attr_value.as_ref().to_glib_none().0,
+            );
+        }
+    }
 }

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -732,6 +732,14 @@ impl GlibPtrDefault for String {
     type GlibType = *mut c_char;
 }
 
+impl GlibPtrDefault for CStr {
+    type GlibType = *mut c_char;
+}
+
+impl GlibPtrDefault for CString {
+    type GlibType = *mut c_char;
+}
+
 #[cfg(not(windows))]
 pub(crate) fn path_to_c(path: &Path) -> CString {
     // GLib paths on UNIX are always in the local encoding, just like in Rust
@@ -1703,6 +1711,40 @@ impl FromGlibPtrNone<*mut c_char> for String {
 
 // TODO: Deprecate this
 impl FromGlibPtrFull<*mut c_char> for String {
+    #[inline]
+    unsafe fn from_glib_full(ptr: *mut c_char) -> Self {
+        let res = from_glib_none(ptr);
+        ffi::g_free(ptr as *mut _);
+        res
+    }
+}
+
+impl FromGlibPtrNone<*const c_char> for CString {
+    #[inline]
+    unsafe fn from_glib_none(ptr: *const c_char) -> Self {
+        debug_assert!(!ptr.is_null());
+        CStr::from_ptr(ptr).to_owned()
+    }
+}
+
+impl FromGlibPtrFull<*const c_char> for CString {
+    #[inline]
+    unsafe fn from_glib_full(ptr: *const c_char) -> Self {
+        let res = from_glib_none(ptr);
+        ffi::g_free(ptr as *mut _);
+        res
+    }
+}
+
+impl FromGlibPtrNone<*mut c_char> for CString {
+    #[inline]
+    unsafe fn from_glib_none(ptr: *mut c_char) -> Self {
+        debug_assert!(!ptr.is_null());
+        CStr::from_ptr(ptr).to_owned()
+    }
+}
+
+impl FromGlibPtrFull<*mut c_char> for CString {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut c_char) -> Self {
         let res = from_glib_none(ptr);


### PR DESCRIPTION
This is more correct for the optional attributes that store a path, i.e. `trash::orig-path`, `thumbnail::path`, etc.

For all current cases this should actually be a `Path`, but that should be handled upstream by a couple new methods: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3461