### PR TITLE
Add a std_once_cell feature 

### DIFF
--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -58,6 +58,7 @@ log = ["rs-log"]
 log_macros = ["log"]
 compiletests = []
 gio = ["gio_ffi"]
+std_once_cell = []
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
That adds std::cell::OnceCell and std::sync::OnceLock support for the properties macro.