### PR TITLE
strv: Implement From for constant GStr slices

### DIFF
--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -358,6 +358,21 @@ impl<'a, const N: usize> From<[&'a str; N]> for StrV {
     }
 }
 
+impl<'a, const N: usize> From<[&'a GStr; N]> for StrV {
+    #[inline]
+    fn from(value: [&'a GStr; N]) -> Self {
+        unsafe {
+            let mut s = Self::with_capacity(value.len());
+            for (i, item) in value.iter().enumerate() {
+                *s.ptr.as_ptr().add(i) = GString::from(*item).into_glib_ptr();
+            }
+            s.len = value.len();
+            *s.ptr.as_ptr().add(s.len) = ptr::null_mut();
+            s
+        }
+    }
+}
+
 impl<'a> From<&'a [&'a str]> for StrV {
     #[inline]
     fn from(value: &'a [&'a str]) -> Self {
@@ -1396,6 +1411,20 @@ mod test {
         for (a, b) in Iterator::zip(items.iter(), slice.iter()) {
             assert_eq!(a, b);
         }
+    }
+
+    #[test]
+    fn test_from_slice() {
+        let items = [
+            crate::gstr!("str1"),
+            crate::gstr!("str2"),
+            crate::gstr!("str3"),
+        ];
+
+        let slice1 = StrV::from(&items[..]);
+        let slice2 = StrV::from(items);
+        assert_eq!(slice1.len(), 3);
+        assert_eq!(slice1, slice2);
     }
 
     #[test]


### PR DESCRIPTION
This was implemented for GString and &str but not for &GStr.