### PR TITLE
Don't generate unit tuple in clone macro as default-return value

### DIFF
--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -25,5 +25,5 @@ proc-macro = true
 
 [dev-dependencies]
 glib = { path = "../glib" }
-trybuild2 = "1.0"
+trybuild2 = "1.1"
 once_cell = "1.9.0"

--- a/glib-macros/src/clone.rs
+++ b/glib-macros/src/clone.rs
@@ -195,6 +195,7 @@ let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
                 )
             }
             (BorrowKind::Weak, Some(WrapperKind::DefaultReturn(ref r))) => {
+                let not_unit_ret = r.chars().any(|c| c != '(' && c != ')' && c != ' ');
                 format!(
                     "\
 let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
@@ -210,7 +211,7 @@ let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
 }};",
                     name,
                     crate_ident_new(),
-                    r,
+                    if not_unit_ret { r } else { "" },
                 )
             }
             (BorrowKind::Weak, None) => {

--- a/glib-macros/tests/clone.rs
+++ b/glib-macros/tests/clone.rs
@@ -267,3 +267,24 @@ fn clone_failures() {
         t.compile_fail_inline_check_sub(&format!("test_{index}"), &output, err);
     }
 }
+
+const NO_WARNING: &[&str] = &[
+    "clone!(@weak v => @default-return (), move || println!(\"{}\", v);)",
+    "clone!(@weak v => @default-return (()), move || println!(\"{}\", v);)",
+    "clone!(@weak v => @default-return ( () ), move || println!(\"{}\", v);)",
+    "clone!(@weak v => @default-return (  ), move || println!(\"{}\", v);)",
+];
+
+// Ensures that no warning are emitted if the default-return is a unit tuple.
+#[test]
+fn clone_unit_tuple_return() {
+    let t = trybuild2::TestCases::new();
+
+    for (index, expr) in NO_WARNING.iter().enumerate() {
+        let prefix = "fn main() { use glib::clone; let v = std::rc::Rc::new(1); ";
+        let suffix = "; }";
+        let output = format!("{prefix}{expr}{suffix}");
+
+        t.pass_inline(&format!("test_{index}"), &output);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1102.