### PR TITLE
Add object_subclass example

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -44,3 +44,7 @@ path = "gio_task/main.rs"
 [[bin]]
 name = "gio_cancellable_future"
 path = "gio_cancellable_future/main.rs"
+
+[[bin]]
+name = "object_subclass"
+path = "object_subclass/main.rs"

--- a/examples/object_subclass/author.rs
+++ b/examples/object_subclass/author.rs
@@ -1,0 +1,49 @@
+// You can copy/paste this file every time you need a simple GObject
+// to hold some data
+
+use glib::once_cell::sync::Lazy;
+use glib::prelude::*;
+use glib::subclass::prelude::*;
+use glib::subclass::Signal;
+use glib::Properties;
+use std::cell::RefCell;
+
+mod imp {
+    use super::*;
+
+    #[derive(Properties, Default)]
+    #[properties(wrapper_type = super::Author)]
+    pub struct Author {
+        #[property(get, set)]
+        name: RefCell<String>,
+        #[property(get, set)]
+        surname: RefCell<String>,
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for Author {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: Lazy<Vec<Signal>> =
+                Lazy::new(|| vec![Signal::builder("awarded").build()]);
+            SIGNALS.as_ref()
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Author {
+        const NAME: &'static str = "Author";
+        type Type = super::Author;
+    }
+}
+
+glib::wrapper! {
+    pub struct Author(ObjectSubclass<imp::Author>);
+}
+impl Author {
+    pub fn new(name: &str, surname: &str) -> Self {
+        glib::Object::builder()
+            .property("name", name)
+            .property("surname", surname)
+            .build()
+    }
+}

--- a/examples/object_subclass/main.rs
+++ b/examples/object_subclass/main.rs
@@ -1,0 +1,14 @@
+mod author;
+
+use glib::prelude::*;
+
+fn main() {
+    let author = author::Author::new("John", "Doe");
+    author.set_name("Jane");
+    author.connect("awarded", true, |_author| {
+        println!("Author received a new award!");
+        None
+    });
+
+    println!("Author: {} {}", author.name(), author.surname());
+}


### PR DESCRIPTION
I'd like having a copy/pastable file to use when I need a simple gobject to store some data. I think many people would find this useful.