### PR TITLE
Reduce size of the crates by excluding unnecessary files 

### DIFF
--- a/gdk-pixbuf/Cargo.toml
+++ b/gdk-pixbuf/Cargo.toml
@@ -9,9 +9,7 @@ documentation = "https://gtk-rs.org/gtk-rs-core/stable/latest/docs/gdk_pixbuf/"
 version = "0.19.0"
 description = "Rust bindings for the GdkPixbuf library"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["tests", "Gir.toml", "docs.md", "versions.txt"]
 edition = "2021"
 rust-version = "1.70"
 

--- a/gdk-pixbuf/sys/Cargo.toml
+++ b/gdk-pixbuf/sys/Cargo.toml
@@ -39,6 +39,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.19.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["tests", "Gir.toml", "versions.txt"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -9,9 +9,7 @@ documentation = "https://gtk-rs.org/gtk-rs-core/stable/latest/docs/gio/"
 version = "0.19.0"
 description = "Rust bindings for the Gio library"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["tests", "docs.md", "Gir.toml"]
 edition = "2021"
 rust-version = "1.70"
 build = "build.rs"

--- a/gio/sys/Cargo.toml
+++ b/gio/sys/Cargo.toml
@@ -48,6 +48,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.19.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["tests", "Gir.toml", "versions.txt"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["tests"]
 
 [dependencies]
 heck = "0.4"

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -9,9 +9,7 @@ version = "0.19.0"
 keywords = ["glib", "gtk-rs", "gnome", "GUI"]
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["benches", "tests", "docs.md", "Gir_GObject.toml", "Gir.toml"]
 edition = "2021"
 rust-version = "1.70"
 
@@ -31,7 +29,11 @@ ffi = { package = "glib-sys", path = "sys" }
 gobject_ffi = { package = "gobject-sys", path = "gobject-sys" }
 glib-macros = { path = "../glib-macros" }
 rs-log = { package = "log", version = "0.4", optional = true }
-smallvec = { version = "1.0", features = ["union", "const_generics", "const_new"] }
+smallvec = { version = "1.0", features = [
+    "union",
+    "const_generics",
+    "const_new",
+] }
 thiserror = "1"
 gio_ffi = { package = "gio-sys", path = "../gio/sys", optional = true }
 memchr = "2.5.0"

--- a/glib/gobject-sys/Cargo.toml
+++ b/glib/gobject-sys/Cargo.toml
@@ -38,6 +38,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.19.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["tests", "Gir.toml", "versions.txt"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/glib/sys/Cargo.toml
+++ b/glib/sys/Cargo.toml
@@ -36,6 +36,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.19.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["tests", "Gir.toml", "versions.txt"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/graphene/Cargo.toml
+++ b/graphene/Cargo.toml
@@ -9,9 +9,7 @@ documentation = "https://gtk-rs.org/gtk-rs-core/stable/latest/docs/graphene/"
 version = "0.19.0"
 description = "Rust bindings for the Graphene library"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["tests", "docs.md", "Gir.toml"]
 edition = "2021"
 rust-version = "1.70"
 

--- a/graphene/sys/Cargo.toml
+++ b/graphene/sys/Cargo.toml
@@ -28,6 +28,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.19.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["tests", "Gir.toml", "versions.txt"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -9,9 +9,7 @@ version = "0.19.0"
 description = "Rust bindings for the Pango library"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["tests", "docs.md", "Gir.toml"]
 edition = "2021"
 rust-version = "1.70"
 

--- a/pango/sys/Cargo.toml
+++ b/pango/sys/Cargo.toml
@@ -39,6 +39,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.19.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["tests", "Gir.toml", "versions.txt"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pangocairo/Cargo.toml
+++ b/pangocairo/Cargo.toml
@@ -9,9 +9,7 @@ version = "0.19.0"
 description = "Rust bindings for the PangoCairo library"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["tests", "docs.md", "Gir.toml"]
 edition = "2021"
 rust-version = "1.70"
 

--- a/pangocairo/sys/Cargo.toml
+++ b/pangocairo/sys/Cargo.toml
@@ -35,6 +35,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 version = "0.19.0"
 edition = "2021"
 rust-version = "1.70"
+exclude = ["Gir.toml", "versions.txt"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
The size of the crates can be reduced by excluding the `tests` folder and the `Gir.toml`, `docs.md` and `versions.txt` files from being published to crates.io.

The size could be reduced even more by excluding the LICENSE and COPYRIGHT files but I did not do that.

The `sys` folders do not need to be excluded. Apparently cargo is smart enough to recognize that they are independent crates. The `gir-files` folder also does not need to be excluded, because it is one level higher than the crates so cargo does not try to include it anyways.

You can see which files will be included without publishing the crates by running `cargo package --list`.