### PR TITLE
add support of module types

### DIFF
--- a/glib-macros/src/object_interface_attribute.rs
+++ b/glib-macros/src/object_interface_attribute.rs
@@ -2,12 +2,214 @@
 
 use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
-use quote::quote;
+use quote::{quote, ToTokens};
+
+pub const WRONG_EXPRESSION_MSG: &str =
+    "This macro's attributes should be a sequence of assign expressions punctuated by comma";
+
+pub const UNSUPPORTED_EXPRESSION_MSG: &str =
+    "This macro's supported attributes are: `plugin_type = <subclass_of_glib::TypePlugin>, lazy_registration = true|false`";
 
 pub const WRONG_PLACE_MSG: &str =
     "This macro should be used on `impl` block for `glib::ObjectInterface` trait";
 
 pub fn impl_object_interface(input: &syn::ItemImpl) -> TokenStream {
+    let crate_ident = crate::utils::crate_ident_new();
+    let syn::ItemImpl { self_ty, .. } = &input;
+
+    // registers the interface on first use (lazy registration).
+    let register_interface = quote! {
+        impl #self_ty {
+            /// Registers the interface only once.
+            #[inline]
+            fn register_interface() -> #crate_ident::Type {
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
+                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
+
+                ONCE.call_once(|| unsafe {
+                    TYPE = #crate_ident::subclass::register_interface::<Self>();
+                });
+
+                unsafe {
+                    TYPE
+                }
+            }
+        }
+    };
+
+    impl_object_interface_(register_interface, input)
+}
+
+pub fn impl_dynamic_object_interface(
+    attrs: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
+    input: &syn::ItemImpl,
+) -> TokenStream {
+    let crate_ident = crate::utils::crate_ident_new();
+    let syn::ItemImpl { self_ty, .. } = &input;
+
+    let mut plugin_type_opt: Option<syn::Path> = None;
+    let mut lazy_registration_opt: Option<bool> = None;
+
+    for attr in attrs {
+        match attr {
+            // attribute must be one of supported assign expressions.
+            syn::Expr::Assign(syn::ExprAssign { left, right, .. }) => {
+                match (*left.to_owned(), *right.to_owned()) {
+                    // `plugin_type = <subclass_of_TypePlugin>`
+                    (
+                        syn::Expr::Path(syn::ExprPath { path: path1, .. }),
+                        syn::Expr::Path(syn::ExprPath { path: path2, .. }),
+                    ) if path1.is_ident(&"plugin_type") => plugin_type_opt = Some(path2),
+                    // `lazy_registration = true|false`
+                    (
+                        syn::Expr::Path(syn::ExprPath { path, .. }),
+                        syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Bool(syn::LitBool { value, .. }),
+                            ..
+                        }),
+                    ) if path.is_ident(&"lazy_registration") => lazy_registration_opt = Some(value),
+                    _ => abort_call_site!(UNSUPPORTED_EXPRESSION_MSG),
+                };
+            }
+            _ => abort_call_site!(WRONG_EXPRESSION_MSG),
+        };
+    }
+
+    let (plugin_ty, lazy_registration) = match (plugin_type_opt, lazy_registration_opt) {
+        (Some(type_plugin), lazy_registration_opt) => (
+            type_plugin.into_token_stream(),
+            lazy_registration_opt.unwrap_or_default(),
+        ),
+        (None, lazy_registration_opt) => (
+            quote!(#crate_ident::TypeModule),
+            lazy_registration_opt.unwrap_or_default(),
+        ),
+    };
+
+    // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt::unuse`]).
+    // An object interface can be reregistered as a dynamic type (see [`TypePluginExt::register_type`]).
+    let register_interface = if lazy_registration {
+        // registers the object interface as a dynamic type on the first use (lazy registration).
+        // a weak reference on the plugin is stored and will be used later on the first use of the object interface.
+        // this implementation relies on a static storage of a weak reference on the plugin and of the glib type to know if the object interface has been registered.
+        quote! {
+            impl #self_ty {
+                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the glib type.
+                /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the data.
+                #[inline]
+                fn get_registration_status_ref_mut() -> &'static mut Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)> {
+                    static mut REGISTRATION_STATUS: ::std::sync::Mutex<Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)>> = ::std::sync::Mutex::new(None);
+                    unsafe { REGISTRATION_STATUS.get_mut().unwrap() }
+                }
+
+                /// Registers the object interface as a dynamic type within the plugin only once.
+                /// Plugin must have been used at least once.
+                /// Do nothing if plugin has never been used or if the object interface is already registered as a dynamic type.
+                #[inline]
+                fn register_interface() -> #crate_ident::Type {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used, so the object interface cannot be registered as a dynamic type.
+                        None => #crate_ident::Type::INVALID,
+                        // plugin has been used and the object interface has not been registered yet, so registers it as a dynamic type.
+                        Some((type_plugin, type_)) if !type_.is_valid() => {
+                            *type_ = #crate_ident::subclass::register_dynamic_interface::<#plugin_ty, Self>(&(type_plugin.upgrade().unwrap()));
+                            *type_
+                        },
+                        // plugin has been used and the object interface has already been registered as a dynamic type.
+                        Some((_, type_)) => *type_
+                    }
+                }
+
+                /// Depending on the plugin lifecycle state and on the registration status of the object interface:
+                /// If plugin is used (and has loaded the implementation) for the first time, postpones the registration and stores a weak reference on the plugin.
+                /// If plugin is reused (and has reloaded the implementation) and the object interface has been already registered as a dynamic type, reregisters it.
+                /// An object interface can be reregistered several times as a dynamic type.
+                /// If plugin is reused (and has reloaded the implementation) and the object interface has not been registered yet as a dynamic type, do nothing.
+                #[inline]
+                pub fn on_implementation_load(type_plugin: &#plugin_ty) -> bool {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used (this is the first time), so postpones registration of the object interface as a dynamic type on the first use.
+                        None => {
+                            *registration_status_ref_mut = Some((#crate_ident::clone::Downgrade::downgrade(type_plugin), #crate_ident::Type::INVALID));
+                            true
+                        },
+                        // plugin has been used at least one time and the object interface has been registered as a dynamic type at least one time, so re-registers it.
+                        Some((_, type_)) if type_.is_valid() => {
+                            *type_ = #crate_ident::subclass::register_dynamic_interface::<#plugin_ty, Self>(type_plugin);
+                            type_.is_valid()
+                        },
+                        // plugin has been used at least one time but the object interface has not been registered yet as a dynamic type, so keeps postponed registration.
+                        Some(_) => {
+                            true
+                        }
+                    }
+                }
+
+                /// Depending on the plugin lifecycle state and on the registration status of the object interface:
+                /// If plugin has been used (or reused) but the object interface has not been registered yet as a dynamic type, cancels the postponed registration by deleting the weak reference on the plugin.
+                /// Else do nothing.
+                #[inline]
+                pub fn on_implementation_unload(type_plugin_: &#plugin_ty) -> bool {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used, so unload implementation is unexpected.
+                        None => false,
+                        // plugin has been used at least one time and the object interface has been registered as a dynamic type at least one time.
+                        Some((_, type_)) if type_.is_valid() => true,
+                        // plugin has been used at least one time but the object interface has not been registered yet as a dynamic type, so cancels the postponed registration.
+                        Some(_) => {
+                            *registration_status_ref_mut = None;
+                            true
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        // registers immediately the object interface as a dynamic type.
+        quote! {
+            impl #self_ty {
+                /// Returns a mutable reference to the glib type.
+                /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the atomic data.
+                #[inline]
+                fn get_type_mut() -> &'static mut #crate_ident::ffi::GType {
+                    static mut TYPE: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(#crate_ident::gobject_ffi::G_TYPE_INVALID);
+                    unsafe { TYPE.get_mut() }
+                }
+
+                /// Do nothing as the object interface has been registered on implementation load.
+                #[inline]
+                fn register_interface() -> #crate_ident::Type {
+                    unsafe { <#crate_ident::Type as #crate_ident::translate::FromGlib<#crate_ident::ffi::GType>>::from_glib(*Self::get_type_mut()) }
+                }
+
+                /// Registers the object interface as a dynamic type within the plugin.
+                /// The object interface can be registered several times as a dynamic type.
+                #[inline]
+                pub fn on_implementation_load(type_plugin: &#plugin_ty) -> bool {
+                    let type_mut = Self::get_type_mut();
+                    *type_mut = #crate_ident::translate::IntoGlib::into_glib(#crate_ident::subclass::register_dynamic_interface::<#plugin_ty, Self>(type_plugin));
+                    *type_mut != #crate_ident::gobject_ffi::G_TYPE_INVALID
+                }
+
+                /// Do nothing as object interfaces registered as dynamic types are never unregistered.
+                #[inline]
+                pub fn on_implementation_unload(type_plugin_: &#plugin_ty) -> bool {
+                    true
+                }
+            }
+        }
+    };
+
+    impl_object_interface_(register_interface, input)
+}
+
+pub fn impl_object_interface_(
+    register_interface: TokenStream,
+    input: &syn::ItemImpl,
+) -> TokenStream {
     let mut has_prerequisites = false;
     for item in &input.items {
         if let syn::ImplItem::Type(type_) = item {
@@ -53,20 +255,10 @@ pub fn impl_object_interface(input: &syn::ItemImpl) -> TokenStream {
         unsafe impl #crate_ident::subclass::interface::ObjectInterfaceType for #self_ty {
             #[inline]
             fn type_() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
-
-                ONCE.call_once(|| {
-                    let type_ = #crate_ident::subclass::register_interface::<Self>();
-                    unsafe {
-                        TYPE = type_;
-                    }
-                });
-
-                unsafe {
-                    TYPE
-                }
+                Self::register_interface()
             }
         }
+
+        #register_interface
     }
 }

--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -2,12 +2,194 @@
 
 use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
-use quote::quote;
+use quote::{quote, ToTokens};
+
+pub const WRONG_EXPRESSION_MSG: &str =
+    "This macro's attributes should be a sequence of assign expressions punctuated by comma";
+
+pub const UNSUPPORTED_EXPRESSION_MSG: &str =
+    "This macro's supported attributes are: `plugin_type = <subclass_of_glib::TypePlugin>, lazy_registration = true|false`";
 
 pub const WRONG_PLACE_MSG: &str =
     "This macro should be used on `impl` block for `glib::ObjectSubclass` trait";
 
 pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
+    let crate_ident = crate::utils::crate_ident_new();
+    let syn::ItemImpl { self_ty, .. } = &input;
+
+    // registers the type on first use (lazy registration).
+    let register_type = quote! {
+        impl #self_ty {
+            /// Registers the type only once.
+            #[inline]
+            fn register_type() {
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
+
+                ONCE.call_once(|| {
+                    #crate_ident::subclass::register_type::<Self>();
+                })
+            }
+        }
+    };
+
+    impl_object_subclass_(register_type, input)
+}
+
+pub fn impl_dynamic_object_subclass(
+    attrs: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
+    input: &syn::ItemImpl,
+) -> TokenStream {
+    let crate_ident = crate::utils::crate_ident_new();
+    let syn::ItemImpl { self_ty, .. } = &input;
+
+    let mut plugin_type_opt: Option<syn::Path> = None;
+    let mut lazy_registration_opt: Option<bool> = None;
+
+    for attr in attrs {
+        match attr {
+            // attribute must be one of supported assign expressions.
+            syn::Expr::Assign(syn::ExprAssign { left, right, .. }) => {
+                match (*left.to_owned(), *right.to_owned()) {
+                    // `plugin_type = <subclass_of_TypePlugin>`
+                    (
+                        syn::Expr::Path(syn::ExprPath { path: path1, .. }),
+                        syn::Expr::Path(syn::ExprPath { path: path2, .. }),
+                    ) if path1.is_ident(&"plugin_type") => plugin_type_opt = Some(path2),
+                    // `lazy_registration = true|false`
+                    (
+                        syn::Expr::Path(syn::ExprPath { path, .. }),
+                        syn::Expr::Lit(syn::ExprLit {
+                            lit: syn::Lit::Bool(syn::LitBool { value, .. }),
+                            ..
+                        }),
+                    ) if path.is_ident(&"lazy_registration") => lazy_registration_opt = Some(value),
+                    _ => abort_call_site!(UNSUPPORTED_EXPRESSION_MSG),
+                };
+            }
+            _ => abort_call_site!(WRONG_EXPRESSION_MSG),
+        };
+    }
+
+    let (plugin_ty, lazy_registration) = match (plugin_type_opt, lazy_registration_opt) {
+        (Some(type_plugin), lazy_registration_opt) => (
+            type_plugin.into_token_stream(),
+            lazy_registration_opt.unwrap_or_default(),
+        ),
+        (None, lazy_registration_opt) => (
+            quote!(#crate_ident::TypeModule),
+            lazy_registration_opt.unwrap_or_default(),
+        ),
+    };
+
+    // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt::unuse`]).
+    // An object subclass can be reregistered as a dynamic type (see [`TypePluginExt::register_type`]).
+    let register_type = if lazy_registration {
+        // registers the object subclass as a dynamic type on the first use (lazy registration).
+        // a weak reference on the plugin is stored and will be used later on the first use of the object subclass.
+        // this implementation relies on a static storage of a weak reference on the plugin and of the glib type to know if the object subclass has been registered.
+        quote! {
+            impl #self_ty {
+                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the glib type.
+                /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the data.
+                #[inline]
+                fn get_registration_status_ref_mut() -> &'static mut Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)> {
+                    static mut REGISTRATION_STATUS: ::std::sync::Mutex<Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)>> = ::std::sync::Mutex::new(None);
+                    unsafe { REGISTRATION_STATUS.get_mut().unwrap() }
+                }
+
+                /// Registers the object subclass as a dynamic type within the plugin only once.
+                /// Plugin must have been used at least once.
+                /// Do nothing if plugin has never been used or if the object subclass is already registered as a dynamic type.
+                #[inline]
+                fn register_type() {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used, so the object subclass cannot be registered as a dynamic type.
+                        None => (),
+                        // plugin has been used and the object subclass has not been registered yet, so registers it as a dynamic type.
+                        Some((type_plugin, type_)) if !type_.is_valid() => {
+                            *type_ = #crate_ident::subclass::register_dynamic_type::<#plugin_ty, Self>(&(type_plugin.upgrade().unwrap()));
+                        },
+                        // plugin has been used and the object subclass has already been registered as a dynamic type.
+                        Some(_) => ()
+                    }
+                }
+
+                /// Depending on the plugin lifecycle state and on the registration status of the object subclass:
+                /// If plugin is used (and has loaded the implementation) for the first time, postpones the registration and stores a weak reference on the plugin.
+                /// If plugin is reused (and has reloaded the implementation) and the object subclass has been already registered as a dynamic type, reregisters it.
+                /// An object subclass can be reregistered several times as a dynamic type.
+                /// If plugin is reused (and has reloaded the implementation) and the object subclass has not been registered yet as a dynamic type, do nothing.
+                #[inline]
+                pub fn on_implementation_load(type_plugin: &#plugin_ty) -> bool {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used (this is the first time), so postpones registration of the object subclass as a dynamic type on the first use.
+                        None => {
+                            *registration_status_ref_mut = Some((#crate_ident::clone::Downgrade::downgrade(type_plugin), #crate_ident::Type::INVALID));
+                            true
+                        },
+                        // plugin has been used at least one time and the object subclass has been registered as a dynamic type at least one time, so re-registers it.
+                        Some((_, type_)) if type_.is_valid() => {
+                            *type_ = #crate_ident::subclass::register_dynamic_type::<#plugin_ty, Self>(type_plugin);
+                            type_.is_valid()
+                        },
+                        // plugin has been used at least one time but the object subclass has not been registered yet as a dynamic type, so keeps postponed registration.
+                        Some(_) => {
+                            true
+                        }
+                    }
+                }
+
+                /// Depending on the plugin lifecycle state and on the registration status of the object subclass:
+                /// If plugin has been used (or reused) but the object subclass has not been registered yet as a dynamic type, cancels the postponed registration by deleting the weak reference on the plugin.
+                /// Else do nothing.
+                #[inline]
+                pub fn on_implementation_unload(type_plugin_: &#plugin_ty) -> bool {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used, so unload implementation is unexpected.
+                        None => false,
+                        // plugin has been used at least one time and the object subclass has been registered as a dynamic type at least one time.
+                        Some((_, type_)) if type_.is_valid() => true,
+                        // plugin has been used at least one time but the object subclass has not been registered yet as a dynamic type, so cancels the postponed registration.
+                        Some(_) => {
+                            *registration_status_ref_mut = None;
+                            true
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        // registers immediately the object subclass as a dynamic type.
+        quote! {
+            impl #self_ty {
+                /// Do nothing as the object subclass has been registered on implementation load.
+                #[inline]
+                fn register_type() { }
+
+                /// Registers the object subclass as a dynamic type within the plugin.
+                /// The object subclass can be registered several times as a dynamic type.
+                #[inline]
+                pub fn on_implementation_load(type_plugin: &#plugin_ty) -> bool {
+                    let type_ = #crate_ident::subclass::register_dynamic_type::<#plugin_ty, Self>(type_plugin);
+                    type_ != #crate_ident::Type::INVALID
+                }
+
+                /// Do nothing as object subclasses registered as dynamic types are never unregistered.
+                #[inline]
+                pub fn on_implementation_unload(type_plugin_: &#plugin_ty) -> bool {
+                    true
+                }
+            }
+        }
+    };
+
+    impl_object_subclass_(register_type, input)
+}
+
+fn impl_object_subclass_(register_type: TokenStream, input: &syn::ItemImpl) -> TokenStream {
     let mut has_new = false;
     let mut has_parent_type = false;
     let mut has_interfaces = false;
@@ -101,11 +283,7 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
 
             #[inline]
             fn type_() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-
-                ONCE.call_once(|| {
-                    #crate_ident::subclass::register_type::<Self>();
-                });
+                Self::register_type();
 
                 unsafe {
                     let data = Self::type_data();
@@ -115,6 +293,8 @@ pub fn impl_object_subclass(input: &syn::ItemImpl) -> TokenStream {
                 }
             }
         }
+
+        #register_type
 
         #[doc(hidden)]
         impl #crate_ident::subclass::types::FromObject for #self_ty {

--- a/glib-macros/tests/dynamic_objects.rs
+++ b/glib-macros/tests/dynamic_objects.rs
@@ -1,0 +1,606 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::{subclass::prelude::*, Cast};
+
+mod static_ {
+    use super::*;
+
+    pub mod imp {
+        use super::*;
+
+        // impl for an object interface to register as a static type.
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        pub struct MyStaticInterface {
+            parent: glib::gobject_ffi::GTypeInterface,
+        }
+
+        #[glib::object_interface]
+        unsafe impl ObjectInterface for MyStaticInterface {
+            const NAME: &'static str = "MyStaticInterface";
+        }
+
+        pub trait MyStaticInterfaceImpl: ObjectImpl + ObjectSubclass {}
+
+        // impl for an object subclass to register as a static type and that implements `MyStaticInterface`.
+        #[derive(Default)]
+        pub struct MyStaticType;
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for MyStaticType {
+            const NAME: &'static str = "MyStaticType";
+            type Type = super::MyStaticType;
+            type Interfaces = (super::MyStaticInterface,);
+        }
+
+        impl ObjectImpl for MyStaticType {}
+
+        impl MyStaticInterfaceImpl for MyStaticType {}
+
+        pub trait MyStaticTypeImpl: ObjectImpl + ObjectSubclass {}
+    }
+
+    // an object interface to register as a static type.
+    glib::wrapper! {
+        pub struct MyStaticInterface(ObjectInterface<imp::MyStaticInterface>);
+    }
+
+    unsafe impl<T: imp::MyStaticInterfaceImpl> IsImplementable<T> for MyStaticInterface {}
+
+    // an object subclass to register as a static type and that implements `MyStaticInterface`.
+    glib::wrapper! {
+        pub struct MyStaticType(ObjectSubclass<imp::MyStaticType>) @implements MyStaticInterface;
+    }
+
+    unsafe impl<T: imp::MyStaticTypeImpl> IsSubclassable<T> for MyStaticType {}
+}
+
+use static_::{
+    imp::{MyStaticInterfaceImpl, MyStaticTypeImpl},
+    *,
+};
+
+mod module {
+    use super::*;
+
+    mod imp {
+        use super::*;
+
+        // impl for a object interface to register as a dynamic type and that extends `MyStaticInterface`.
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        pub struct MyModuleInterface {
+            parent: glib::gobject_ffi::GTypeInterface,
+        }
+
+        #[glib::dynamic_object_interface]
+        unsafe impl ObjectInterface for MyModuleInterface {
+            const NAME: &'static str = "MyModuleInterface";
+            type Prerequisites = (MyStaticInterface,);
+        }
+
+        pub trait MyModuleInterfaceImpl: ObjectImpl + ObjectSubclass {}
+
+        // impl for an object subclass to register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyModuleInterface`.
+        #[derive(Default)]
+        pub struct MyModuleType;
+
+        #[glib::dynamic_object_subclass]
+        impl ObjectSubclass for MyModuleType {
+            const NAME: &'static str = "MyModuleType";
+            type Type = super::MyModuleType;
+            type ParentType = MyStaticType;
+            type Interfaces = (MyStaticInterface, super::MyModuleInterface);
+        }
+
+        impl ObjectImpl for MyModuleType {}
+
+        impl MyStaticTypeImpl for MyModuleType {}
+
+        impl MyStaticInterfaceImpl for MyModuleType {}
+
+        impl MyModuleInterfaceImpl for MyModuleType {}
+
+        // impl for an object interface to lazy register as a dynamic type and that extends `MyStaticInterface`.
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        pub struct MyModuleInterfaceLazy {
+            parent: glib::gobject_ffi::GTypeInterface,
+        }
+
+        #[glib::dynamic_object_interface(lazy_registration = true)]
+        unsafe impl ObjectInterface for MyModuleInterfaceLazy {
+            const NAME: &'static str = "MyModuleInterfaceLazy";
+            type Prerequisites = (MyStaticInterface,);
+        }
+
+        pub trait MyModuleInterfaceLazyImpl: ObjectImpl + ObjectSubclass {}
+
+        // impl for an object subclass to lazy register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyModuleInterfaceLazy`.
+        #[derive(Default)]
+        pub struct MyModuleTypeLazy;
+
+        #[glib::dynamic_object_subclass(lazy_registration = true)]
+        impl ObjectSubclass for MyModuleTypeLazy {
+            const NAME: &'static str = "MyModuleTypeLazy";
+            type Type = super::MyModuleTypeLazy;
+            type ParentType = MyStaticType;
+            type Interfaces = (MyStaticInterface, super::MyModuleInterfaceLazy);
+        }
+
+        impl ObjectImpl for MyModuleTypeLazy {}
+
+        impl MyStaticTypeImpl for MyModuleTypeLazy {}
+
+        impl MyStaticInterfaceImpl for MyModuleTypeLazy {}
+
+        impl MyModuleInterfaceLazyImpl for MyModuleTypeLazy {}
+
+        // impl for a type module (must extend `glib::TypeModule` and must implement `glib::TypePlugin`).
+        #[derive(Default)]
+        pub struct MyModule;
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for MyModule {
+            const NAME: &'static str = "MyModule";
+            type Type = super::MyModule;
+            type ParentType = glib::TypeModule;
+            type Interfaces = (glib::TypePlugin,);
+        }
+
+        impl ObjectImpl for MyModule {}
+
+        impl TypePluginImpl for MyModule {}
+
+        impl TypeModuleImpl for MyModule {
+            fn load(&self) -> bool {
+                // registers object subclasses and interfaces as dynamic types.
+                let my_module = self.obj();
+                let type_module: &glib::TypeModule = my_module.upcast_ref();
+                MyModuleInterface::on_implementation_load(type_module)
+                    && MyModuleType::on_implementation_load(type_module)
+                    && MyModuleInterfaceLazy::on_implementation_load(type_module)
+                    && MyModuleTypeLazy::on_implementation_load(type_module)
+            }
+
+            fn unload(&self) {
+                // marks object subclasses and interfaces as unregistered.
+                let my_module = self.obj();
+                let type_module: &glib::TypeModule = my_module.upcast_ref();
+                MyModuleTypeLazy::on_implementation_unload(type_module);
+                MyModuleInterfaceLazy::on_implementation_unload(type_module);
+                MyModuleType::on_implementation_unload(type_module);
+                MyModuleInterface::on_implementation_unload(type_module);
+            }
+        }
+    }
+
+    // an object interface to register as a dynamic type and that extends `MyStaticInterface`.
+    glib::wrapper! {
+        pub struct MyModuleInterface(ObjectInterface<imp::MyModuleInterface>) @requires MyStaticInterface;
+    }
+
+    unsafe impl<T: imp::MyModuleInterfaceImpl> IsImplementable<T> for MyModuleInterface {}
+
+    // an object subclass to register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyModuleInterface`.
+    glib::wrapper! {
+        pub struct MyModuleType(ObjectSubclass<imp::MyModuleType>) @extends MyStaticType, @implements MyStaticInterface, MyModuleInterface;
+    }
+
+    // an object interface to lazy register as a dynamic type and that extends `MyStaticInterface`.
+    glib::wrapper! {
+        pub struct MyModuleInterfaceLazy(ObjectInterface<imp::MyModuleInterfaceLazy>) @requires MyStaticInterface;
+    }
+
+    unsafe impl<T: imp::MyModuleInterfaceLazyImpl> IsImplementable<T> for MyModuleInterfaceLazy {}
+
+    // an object subclass to lazy register as a dynamic type and that extends `MyStaticType` that implements `MyStaticInterface` and `MyModuleInterfaceLazy`.
+    glib::wrapper! {
+        pub struct MyModuleTypeLazy(ObjectSubclass<imp::MyModuleTypeLazy>) @extends MyStaticType, @implements MyStaticInterface, MyModuleInterfaceLazy;
+    }
+
+    // a module (must extend `glib::TypeModule` and must implement `glib::TypePlugin`).
+    glib::wrapper! {
+        pub struct MyModule(ObjectSubclass<imp::MyModule>)
+        @extends glib::TypeModule, @implements glib::TypePlugin;
+    }
+
+    #[test]
+    fn dynamic_types() {
+        use glib::prelude::TypeModuleExt;
+
+        // checks types of object subclasses and of object interfaces to register as dynamic types are invalid (module is not loaded yet).
+        assert!(!imp::MyModuleInterface::type_().is_valid());
+        assert!(!imp::MyModuleType::type_().is_valid());
+        assert!(!imp::MyModuleInterfaceLazy::type_().is_valid());
+        assert!(!imp::MyModuleTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to load/unload the module.
+        let module = glib::Object::new::<MyModule>();
+        TypeModuleExt::use_(&module);
+        TypeModuleExt::unuse(&module);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are valid (module is unloaded).
+        assert!(imp::MyModuleInterface::type_().is_valid());
+        assert!(imp::MyModuleType::type_().is_valid());
+        // checks types of object subclasses and of object interfaces that are lazy registered as dynamic types are still invalid (module is unloaded).
+        assert!(!imp::MyModuleInterfaceLazy::type_().is_valid());
+        assert!(!imp::MyModuleTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to load the module.
+        TypeModuleExt::use_(&module);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are valid (module is loaded).
+        let iface_type = imp::MyModuleInterface::type_();
+        assert!(iface_type.is_valid());
+        let obj_type = imp::MyModuleType::type_();
+        assert!(obj_type.is_valid());
+        let iface_lazy_type = imp::MyModuleInterfaceLazy::type_();
+        assert!(iface_lazy_type.is_valid());
+        let obj_lazy_type = imp::MyModuleTypeLazy::type_();
+        assert!(obj_lazy_type.is_valid());
+
+        // checks plugin of object subclasses and of object interfaces is `MyModule`.
+        assert_eq!(
+            iface_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            obj_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            iface_lazy_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            obj_lazy_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+
+        // simulates the glib type system to unload the module.
+        TypeModuleExt::unuse(&module);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid (should have been marked as unloaded by the glib type system but this cannot be checked).
+        assert!(imp::MyModuleInterface::type_().is_valid());
+        assert!(imp::MyModuleType::type_().is_valid());
+        assert!(imp::MyModuleInterfaceLazy::type_().is_valid());
+        assert!(imp::MyModuleTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to reload the module.
+        TypeModuleExt::use_(&module);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid (should have been marked as unloaded by the glib type system but this cannot be checked).
+        assert!(imp::MyModuleInterface::type_().is_valid());
+        assert!(imp::MyModuleType::type_().is_valid());
+        assert!(imp::MyModuleInterfaceLazy::type_().is_valid());
+        assert!(imp::MyModuleTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to unload the module.
+        TypeModuleExt::unuse(&module);
+    }
+}
+
+pub mod plugin {
+    use super::*;
+
+    pub mod imp {
+        use super::*;
+        use std::cell::Cell;
+
+        // impl for a object interface to register as a dynamic type and that extends `MyStaticInterface`.
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        pub struct MyPluginInterface {
+            parent: glib::gobject_ffi::GTypeInterface,
+        }
+
+        #[glib::dynamic_object_interface(plugin_type = super::MyPlugin)]
+        unsafe impl ObjectInterface for MyPluginInterface {
+            const NAME: &'static str = "MyPluginInterface";
+            type Prerequisites = (MyStaticInterface,);
+        }
+
+        pub trait MyPluginInterfaceImpl: ObjectImpl + ObjectSubclass {}
+
+        // impl for an object subclass to register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyPluginInterface`.
+        #[derive(Default)]
+        pub struct MyPluginType;
+
+        #[glib::dynamic_object_subclass(plugin_type = super::MyPlugin)]
+        impl ObjectSubclass for MyPluginType {
+            const NAME: &'static str = "MyPluginType";
+            type Type = super::MyPluginType;
+            type ParentType = MyStaticType;
+            type Interfaces = (MyStaticInterface, super::MyPluginInterface);
+        }
+
+        impl ObjectImpl for MyPluginType {}
+
+        impl MyStaticTypeImpl for MyPluginType {}
+
+        impl MyStaticInterfaceImpl for MyPluginType {}
+
+        impl MyPluginInterfaceImpl for MyPluginType {}
+
+        // impl for an object interface to lazy register as a dynamic type and that extends `MyStaticInterface`.
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        pub struct MyPluginInterfaceLazy {
+            parent: glib::gobject_ffi::GTypeInterface,
+        }
+
+        #[glib::dynamic_object_interface(plugin_type = super::MyPlugin, lazy_registration = true)]
+        unsafe impl ObjectInterface for MyPluginInterfaceLazy {
+            const NAME: &'static str = "MyPluginInterfaceLazy";
+            type Prerequisites = (MyStaticInterface,);
+        }
+
+        pub trait MyPluginInterfaceLazyImpl: ObjectImpl + ObjectSubclass {}
+
+        // impl for an object subclass to lazy register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyPluginInterfaceLazy`.
+        #[derive(Default)]
+        pub struct MyPluginTypeLazy;
+
+        #[glib::dynamic_object_subclass(plugin_type = super::MyPlugin, lazy_registration = true)]
+        impl ObjectSubclass for MyPluginTypeLazy {
+            const NAME: &'static str = "MyPluginTypeLazy";
+            type Type = super::MyPluginTypeLazy;
+            type ParentType = MyStaticType;
+            type Interfaces = (MyStaticInterface, super::MyPluginInterfaceLazy);
+        }
+
+        impl ObjectImpl for MyPluginTypeLazy {}
+
+        impl MyStaticTypeImpl for MyPluginTypeLazy {}
+
+        impl MyStaticInterfaceImpl for MyPluginTypeLazy {}
+
+        impl MyPluginInterfaceLazyImpl for MyPluginTypeLazy {}
+
+        // impl for a type plugin (must implement `glib::TypePlugin`).
+        #[derive(Default)]
+        pub struct MyPlugin {
+            my_interface_type_info: Cell<Option<glib::TypeInfo>>,
+            my_interface_iface_info: Cell<Option<glib::InterfaceInfo>>,
+            my_type_type_info: Cell<Option<glib::TypeInfo>>,
+            my_interface_lazy_type_info: Cell<Option<glib::TypeInfo>>,
+            my_interface_lazy_iface_info: Cell<Option<glib::InterfaceInfo>>,
+            my_type_lazy_type_info: Cell<Option<glib::TypeInfo>>,
+        }
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for MyPlugin {
+            const NAME: &'static str = "MyPlugin";
+            type Type = super::MyPlugin;
+            type Interfaces = (glib::TypePlugin,);
+        }
+
+        impl ObjectImpl for MyPlugin {}
+
+        impl TypePluginImpl for MyPlugin {
+            fn use_plugin(&self) {
+                // registers object subclasses and interfaces as dynamic types.
+                let my_plugin = self.obj();
+                MyPluginInterface::on_implementation_load(my_plugin.as_ref());
+                MyPluginType::on_implementation_load(my_plugin.as_ref());
+                MyPluginInterfaceLazy::on_implementation_load(my_plugin.as_ref());
+                MyPluginTypeLazy::on_implementation_load(my_plugin.as_ref());
+            }
+
+            fn unuse_plugin(&self) {
+                // marks object subclasses and interfaces as unregistered.
+                let my_plugin = self.obj();
+                MyPluginTypeLazy::on_implementation_unload(my_plugin.as_ref());
+                MyPluginInterfaceLazy::on_implementation_unload(my_plugin.as_ref());
+                MyPluginType::on_implementation_unload(my_plugin.as_ref());
+                MyPluginInterface::on_implementation_unload(my_plugin.as_ref());
+            }
+
+            fn complete_type_info(
+                &self,
+                type_: glib::Type,
+            ) -> (glib::TypeInfo, glib::TypeValueTable) {
+                let info = match type_ {
+                    type_ if type_ == MyPluginType::type_() => self.my_type_type_info.get(),
+                    type_ if type_ == MyPluginInterface::type_() => {
+                        self.my_interface_type_info.get()
+                    }
+                    type_ if type_ == MyPluginTypeLazy::type_() => {
+                        self.my_type_lazy_type_info.get()
+                    }
+                    type_ if type_ == MyPluginInterfaceLazy::type_() => {
+                        self.my_interface_lazy_type_info.get()
+                    }
+                    _ => panic!("unexpected"),
+                };
+                match info {
+                    Some(info) => (info, glib::TypeValueTable::default()),
+                    _ => panic!("unexpected"),
+                }
+            }
+
+            fn complete_interface_info(
+                &self,
+                _instance_type: glib::Type,
+                interface_type: glib::Type,
+            ) -> glib::InterfaceInfo {
+                let info = match interface_type {
+                    type_ if type_ == MyPluginInterface::type_() => {
+                        self.my_interface_iface_info.get()
+                    }
+                    type_ if type_ == MyPluginInterfaceLazy::type_() => {
+                        self.my_interface_lazy_iface_info.get()
+                    }
+                    _ => panic!("unexpected"),
+                };
+                match info {
+                    Some(info) => info,
+                    _ => panic!("unexpected"),
+                }
+            }
+        }
+
+        impl TypePluginRegisterImpl for MyPlugin {
+            fn add_dynamic_interface(
+                &self,
+                instance_type: glib::Type,
+                interface_type: glib::Type,
+                interface_info: &glib::InterfaceInfo,
+            ) {
+                if !instance_type.is_a(interface_type) {
+                    instance_type.add_interface_dynamic(
+                        interface_type,
+                        self.obj().upcast_ref::<glib::TypePlugin>(),
+                    );
+                }
+                match interface_type {
+                    type_ if type_ == imp::MyPluginInterface::type_() => {
+                        self.my_interface_iface_info.set(Some(*interface_info))
+                    }
+                    type_ if type_ == imp::MyPluginInterfaceLazy::type_() => {
+                        self.my_interface_lazy_iface_info.set(Some(*interface_info))
+                    }
+                    _ => panic!("unexpected"),
+                };
+            }
+
+            fn register_dynamic_type(
+                &self,
+                parent_type: glib::Type,
+                type_name: &str,
+                type_info: &glib::TypeInfo,
+                flags: glib::TypeFlags,
+            ) -> glib::Type {
+                let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
+                    glib::Type::register_dynamic(
+                        parent_type,
+                        type_name,
+                        self.obj().upcast_ref::<glib::TypePlugin>(),
+                        flags,
+                    )
+                });
+                if type_.is_valid() {
+                    match type_name {
+                        imp::MyPluginType::NAME => self.my_type_type_info.set(Some(*type_info)),
+                        imp::MyPluginInterface::NAME => {
+                            self.my_interface_type_info.set(Some(*type_info))
+                        }
+                        imp::MyPluginTypeLazy::NAME => {
+                            self.my_type_lazy_type_info.set(Some(*type_info))
+                        }
+                        imp::MyPluginInterfaceLazy::NAME => {
+                            self.my_interface_lazy_type_info.set(Some(*type_info))
+                        }
+                        _ => panic!("unexpected"),
+                    };
+                }
+                type_
+            }
+        }
+    }
+
+    // an object interface to register as a dynamic type and that extends `MyStaticInterface`.
+    glib::wrapper! {
+        pub struct MyPluginInterface(ObjectInterface<imp::MyPluginInterface>) @requires MyStaticInterface;
+    }
+
+    unsafe impl<T: imp::MyPluginInterfaceImpl> IsImplementable<T> for MyPluginInterface {}
+
+    // an object subclass to register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyPluginInterface`.
+    glib::wrapper! {
+        pub struct MyPluginType(ObjectSubclass<imp::MyPluginType>) @implements MyPluginInterface;
+    }
+
+    // an object interface to lazy register as a dynamic type and that extends `MyStaticInterface`.
+    glib::wrapper! {
+        pub struct MyPluginInterfaceLazy(ObjectInterface<imp::MyPluginInterfaceLazy>) @requires MyStaticInterface;
+    }
+
+    unsafe impl<T: imp::MyPluginInterfaceLazyImpl> IsImplementable<T> for MyPluginInterfaceLazy {}
+
+    // an object subclass to lazy register as a dynamic type and that extends `MyStaticType` that implements `MyStaticInterface` and `MyPluginInterfaceLazy`.
+    glib::wrapper! {
+        pub struct MyPluginTypeLazy(ObjectSubclass<imp::MyPluginTypeLazy>) @implements MyPluginInterfaceLazy;
+    }
+
+    // a plugin (must implement `glib::TypePlugin`).
+    glib::wrapper! {
+        pub struct MyPlugin(ObjectSubclass<imp::MyPlugin>) @implements glib::TypePlugin;
+    }
+
+    #[test]
+    fn dynamic_types() {
+        use glib::prelude::TypePluginExt;
+
+        // checks types of object subclasses and of object interfaces to register as dynamic types are invalid (plugin is not used yet).
+        assert!(!imp::MyPluginInterface::type_().is_valid());
+        assert!(!imp::MyPluginType::type_().is_valid());
+        assert!(!imp::MyPluginInterfaceLazy::type_().is_valid());
+        assert!(!imp::MyPluginTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to use/unuse the plugin.
+        let plugin = glib::Object::new::<MyPlugin>();
+        TypePluginExt::use_(&plugin);
+        TypePluginExt::unuse(&plugin);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are valid (plugin is unused).
+        assert!(imp::MyPluginInterface::type_().is_valid());
+        assert!(imp::MyPluginType::type_().is_valid());
+        // check types of object subclasses and of object interfaces that are lazy registered as dynamic types are still invalid (plugin is unused)
+        assert!(!imp::MyPluginInterfaceLazy::type_().is_valid());
+        assert!(!imp::MyPluginTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to use the plugin.
+        TypePluginExt::use_(&plugin);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are valid (plugin is used).
+        let iface_type = imp::MyPluginInterface::type_();
+        assert!(iface_type.is_valid());
+        let obj_type = imp::MyPluginType::type_();
+        assert!(obj_type.is_valid());
+        let iface_lazy_type = imp::MyPluginInterfaceLazy::type_();
+        assert!(iface_lazy_type.is_valid());
+        let obj_lazy_type = imp::MyPluginTypeLazy::type_();
+        assert!(obj_lazy_type.is_valid());
+
+        // checks plugin of object subclasses and of object interfaces is `MyPlugin`.
+        assert_eq!(
+            iface_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            obj_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            iface_lazy_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            obj_lazy_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+
+        // simulates the glib type system to unuse the plugin.
+        TypePluginExt::unuse(&plugin);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid.
+        assert!(imp::MyPluginInterface::type_().is_valid());
+        assert!(imp::MyPluginType::type_().is_valid());
+        assert!(imp::MyPluginInterfaceLazy::type_().is_valid());
+        assert!(imp::MyPluginTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to reuse the plugin.
+        TypePluginExt::use_(&plugin);
+
+        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid.
+        assert!(imp::MyPluginInterface::type_().is_valid());
+        assert!(imp::MyPluginType::type_().is_valid());
+        assert!(imp::MyPluginInterfaceLazy::type_().is_valid());
+        assert!(imp::MyPluginTypeLazy::type_().is_valid());
+
+        // simulates the glib type system to unuse the plugin.
+        TypePluginExt::unuse(&plugin);
+    }
+}

--- a/glib/Gir_GObject.toml
+++ b/glib/Gir_GObject.toml
@@ -14,6 +14,7 @@ girs_directories = ["../gir-files"]
 generate = [
     "GObject.BindingFlags",
     "GObject.SignalFlags",
+    "GObject.TypeFlags",
 ]
 
 ignore = [
@@ -23,6 +24,7 @@ manual = [
     "GLib.Quark",
     "GObject.Object",
     "GObject.Value",
+    "GObject.TypeValueTable",
     "GObject.ParamFlags",
     "GObject.ParamSpec",
     "GObject.ParamSpecChar",
@@ -48,6 +50,10 @@ manual = [
     "GObject.ParamSpecOverride",
     "GObject.ParamSpecGType",
     "GObject.ParamSpecVariant",
+    "GObject.InterfaceInfo",
+    "GObject.TypeInfo",
+    "GObject.TypePlugin",
+    "GObject.TypeModule",
 ]
 
 [[object]]

--- a/glib/src/gobject/auto/flags.rs
+++ b/glib/src/gobject/auto/flags.rs
@@ -137,3 +137,38 @@ impl FromGlib<gobject_ffi::GSignalFlags> for SignalFlags {
         Self::from_bits_truncate(value)
     }
 }
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    #[doc(alias = "GTypeFlags")]
+    pub struct TypeFlags: u32 {
+        #[doc(alias = "G_TYPE_FLAG_NONE")]
+        const NONE = gobject_ffi::G_TYPE_FLAG_NONE as _;
+        #[doc(alias = "G_TYPE_FLAG_ABSTRACT")]
+        const ABSTRACT = gobject_ffi::G_TYPE_FLAG_ABSTRACT as _;
+        #[doc(alias = "G_TYPE_FLAG_VALUE_ABSTRACT")]
+        const VALUE_ABSTRACT = gobject_ffi::G_TYPE_FLAG_VALUE_ABSTRACT as _;
+        #[doc(alias = "G_TYPE_FLAG_FINAL")]
+        const FINAL = gobject_ffi::G_TYPE_FLAG_FINAL as _;
+        #[doc(alias = "G_TYPE_FLAG_DEPRECATED")]
+        const DEPRECATED = gobject_ffi::G_TYPE_FLAG_DEPRECATED as _;
+    }
+}
+
+#[doc(hidden)]
+impl IntoGlib for TypeFlags {
+    type GlibType = gobject_ffi::GTypeFlags;
+
+    #[inline]
+    fn into_glib(self) -> gobject_ffi::GTypeFlags {
+        self.bits()
+    }
+}
+
+#[doc(hidden)]
+impl FromGlib<gobject_ffi::GTypeFlags> for TypeFlags {
+    #[inline]
+    unsafe fn from_glib(value: gobject_ffi::GTypeFlags) -> Self {
+        Self::from_bits_truncate(value)
+    }
+}

--- a/glib/src/gobject/auto/mod.rs
+++ b/glib/src/gobject/auto/mod.rs
@@ -22,3 +22,4 @@ pub use self::signal_group::SignalGroup;
 mod flags;
 pub use self::flags::BindingFlags;
 pub use self::flags::SignalFlags;
+pub use self::flags::TypeFlags;

--- a/glib/src/gobject/dynamic_object.rs
+++ b/glib/src/gobject/dynamic_object.rs
@@ -1,0 +1,75 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{
+    prelude::*, subclass::prelude::*, InterfaceInfo, IsA, TypeFlags, TypeInfo, TypeModule,
+    TypePlugin,
+};
+
+mod sealed {
+    pub trait Sealed {}
+    impl<T: super::IsA<super::TypePlugin>> Sealed for T {}
+}
+
+pub trait DynamicObjectRegisterExt: AsRef<TypePlugin> + sealed::Sealed + 'static {
+    fn add_dynamic_interface(
+        &self,
+        instance_type: crate::types::Type,
+        interface_type: crate::types::Type,
+        interface_info: &InterfaceInfo,
+    );
+
+    fn register_dynamic_type(
+        &self,
+        parent_type: crate::types::Type,
+        type_name: &str,
+        type_info: &TypeInfo,
+        flags: TypeFlags,
+    ) -> crate::types::Type;
+}
+
+impl<O: IsA<TypePlugin> + ObjectSubclassIsExt> DynamicObjectRegisterExt for O
+where
+    O::Subclass: TypePluginRegisterImpl,
+{
+    fn add_dynamic_interface(
+        &self,
+        instance_type: crate::types::Type,
+        interface_type: crate::types::Type,
+        interface_info: &InterfaceInfo,
+    ) {
+        self.imp()
+            .add_dynamic_interface(instance_type, interface_type, interface_info);
+    }
+
+    fn register_dynamic_type(
+        &self,
+        parent_type: crate::types::Type,
+        type_name: &str,
+        type_info: &TypeInfo,
+        flags: TypeFlags,
+    ) -> crate::types::Type {
+        self.imp()
+            .register_dynamic_type(parent_type, type_name, type_info, flags)
+    }
+}
+
+impl DynamicObjectRegisterExt for TypeModule {
+    fn add_dynamic_interface(
+        &self,
+        instance_type: crate::types::Type,
+        interface_type: crate::types::Type,
+        interface_info: &InterfaceInfo,
+    ) {
+        <Self as TypeModuleExt>::add_interface(self, instance_type, interface_type, interface_info);
+    }
+
+    fn register_dynamic_type(
+        &self,
+        parent_type: crate::types::Type,
+        type_name: &str,
+        type_info: &TypeInfo,
+        flags: TypeFlags,
+    ) -> crate::types::Type {
+        <Self as TypeModuleExt>::register_type(self, parent_type, type_name, type_info, flags)
+    }
+}

--- a/glib/src/gobject/interface_info.rs
+++ b/glib/src/gobject/interface_info.rs
@@ -1,0 +1,38 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[derive(Debug, Copy, Clone)]
+#[doc(alias = "GInterfaceInfo")]
+#[repr(transparent)]
+pub struct InterfaceInfo(pub(crate) gobject_ffi::GInterfaceInfo);
+
+impl InterfaceInfo {
+    // rustdoc-stripper-ignore-next
+    /// Returns a `GInterfaceInfo` pointer.
+    #[doc(hidden)]
+    #[inline]
+    pub fn as_ptr(&self) -> *mut gobject_ffi::GInterfaceInfo {
+        &self.0 as *const gobject_ffi::GInterfaceInfo as *mut _
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Borrows the underlying C value mutably.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn from_glib_ptr_borrow_mut<'a>(
+        ptr: *mut gobject_ffi::GInterfaceInfo,
+    ) -> &'a mut Self {
+        &mut *(ptr as *mut Self)
+    }
+}
+
+impl Default for InterfaceInfo {
+    // rustdoc-stripper-ignore-next
+    /// Creates a new InterfaceInfo with default value.
+    fn default() -> Self {
+        Self(gobject_ffi::GInterfaceInfo {
+            interface_init: None,
+            interface_finalize: None,
+            interface_data: ::std::ptr::null_mut(),
+        })
+    }
+}

--- a/glib/src/gobject/mod.rs
+++ b/glib/src/gobject/mod.rs
@@ -20,3 +20,27 @@ pub use binding_group::BindingGroupBuilder;
 
 pub use self::{auto::*, flags::*};
 //pub use self::auto::functions::*;
+
+mod interface_info;
+pub use interface_info::InterfaceInfo;
+
+mod type_info;
+pub use type_info::TypeInfo;
+
+mod type_value_table;
+pub use type_value_table::TypeValueTable;
+
+mod type_module;
+pub use self::type_module::TypeModule;
+
+mod type_plugin;
+pub use self::type_plugin::TypePlugin;
+
+mod dynamic_object;
+
+#[doc(hidden)]
+pub mod traits {
+    pub use super::dynamic_object::DynamicObjectRegisterExt;
+    pub use super::type_module::TypeModuleExt;
+    pub use super::type_plugin::TypePluginExt;
+}

--- a/glib/src/gobject/type_info.rs
+++ b/glib/src/gobject/type_info.rs
@@ -1,0 +1,43 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[derive(Debug, Copy, Clone)]
+#[doc(alias = "GTypeInfo")]
+#[repr(transparent)]
+pub struct TypeInfo(pub(crate) gobject_ffi::GTypeInfo);
+
+impl TypeInfo {
+    // rustdoc-stripper-ignore-next
+    /// Returns a `GTypeInfo` pointer.
+    #[doc(hidden)]
+    #[inline]
+    pub fn as_ptr(&self) -> *mut gobject_ffi::GTypeInfo {
+        &self.0 as *const gobject_ffi::GTypeInfo as *mut _
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Borrows the underlying C value mutably.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn from_glib_ptr_borrow_mut<'a>(ptr: *mut gobject_ffi::GTypeInfo) -> &'a mut Self {
+        &mut *(ptr as *mut Self)
+    }
+}
+
+impl Default for TypeInfo {
+    // rustdoc-stripper-ignore-next
+    /// Creates a new TypeInfo with default value.
+    fn default() -> Self {
+        Self(gobject_ffi::GTypeInfo {
+            class_size: 0u16,
+            base_init: None,
+            base_finalize: None,
+            class_init: None,
+            class_finalize: None,
+            class_data: ::std::ptr::null(),
+            instance_size: 0,
+            n_preallocs: 0,
+            instance_init: None,
+            value_table: ::std::ptr::null(),
+        })
+    }
+}

--- a/glib/src/gobject/type_module.rs
+++ b/glib/src/gobject/type_module.rs
@@ -1,0 +1,88 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{prelude::*, translate::*, InterfaceInfo, TypeFlags, TypeInfo, TypePlugin};
+
+crate::wrapper! {
+    #[doc(alias = "GTypeModule")]
+    pub struct TypeModule(Object<gobject_ffi::GTypeModule, gobject_ffi::GTypeModuleClass>) @implements TypePlugin;
+
+    match fn {
+        type_ => || gobject_ffi::g_type_module_get_type(),
+    }
+}
+
+impl TypeModule {
+    pub const NONE: Option<&'static TypeModule> = None;
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl<T: super::IsA<super::TypeModule>> Sealed for T {}
+}
+
+pub trait TypeModuleExt: IsA<TypeModule> + sealed::Sealed + 'static {
+    #[doc(alias = "g_type_module_add_interface")]
+    fn add_interface(
+        &self,
+        instance_type: crate::types::Type,
+        interface_type: crate::types::Type,
+        interface_info: &InterfaceInfo,
+    ) {
+        unsafe {
+            gobject_ffi::g_type_module_add_interface(
+                self.as_ref().to_glib_none().0,
+                instance_type.into_glib(),
+                interface_type.into_glib(),
+                interface_info.as_ptr(),
+            );
+        }
+    }
+
+    #[doc(alias = "g_type_module_register_type")]
+    fn register_type(
+        &self,
+        parent_type: crate::types::Type,
+        type_name: &str,
+        type_info: &TypeInfo,
+        flags: TypeFlags,
+    ) -> crate::types::Type {
+        unsafe {
+            from_glib(gobject_ffi::g_type_module_register_type(
+                self.as_ref().to_glib_none().0,
+                parent_type.into_glib(),
+                type_name.to_glib_none().0,
+                type_info.as_ptr(),
+                flags.into_glib(),
+            ))
+        }
+    }
+
+    #[doc(alias = "g_type_module_set_name")]
+    fn set_name(&self, name: &str) {
+        unsafe {
+            gobject_ffi::g_type_module_set_name(
+                self.as_ref().to_glib_none().0,
+                name.to_glib_none().0,
+            );
+        }
+    }
+
+    #[doc(alias = "g_type_module_unuse")]
+    fn unuse(&self) {
+        unsafe {
+            gobject_ffi::g_type_module_unuse(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    #[doc(alias = "g_type_module_use")]
+    #[doc(alias = "use")]
+    fn use_(&self) -> bool {
+        unsafe {
+            from_glib(gobject_ffi::g_type_module_use(
+                self.as_ref().to_glib_none().0,
+            ))
+        }
+    }
+}
+
+impl<O: IsA<TypeModule>> TypeModuleExt for O {}

--- a/glib/src/gobject/type_plugin.rs
+++ b/glib/src/gobject/type_plugin.rs
@@ -1,0 +1,73 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{prelude::*, translate::*, InterfaceInfo, TypeInfo, TypeValueTable};
+
+crate::wrapper! {
+    #[doc(alias = "GTypePlugin")]
+    pub struct TypePlugin(Interface<gobject_ffi::GTypePlugin, gobject_ffi::GTypePluginClass>);
+
+    match fn {
+        type_ => || gobject_ffi::g_type_plugin_get_type(),
+    }
+}
+
+impl TypePlugin {
+    pub const NONE: Option<&'static TypePlugin> = None;
+}
+
+mod sealed {
+    pub trait Sealed {}
+    impl<T: super::IsA<super::TypePlugin>> Sealed for T {}
+}
+
+pub trait TypePluginExt: IsA<TypePlugin> + sealed::Sealed + 'static {
+    #[doc(alias = "g_type_plugin_complete_interface_info")]
+    fn complete_interface_info(
+        &self,
+        instance_type: crate::types::Type,
+        interface_type: crate::types::Type,
+    ) -> InterfaceInfo {
+        let info = InterfaceInfo::default();
+        unsafe {
+            gobject_ffi::g_type_plugin_complete_interface_info(
+                self.as_ref().to_glib_none().0,
+                instance_type.into_glib(),
+                interface_type.into_glib(),
+                info.as_ptr(),
+            );
+        }
+        info
+    }
+
+    #[doc(alias = "g_type_plugin_complete_type_info")]
+    fn complete_type_info(&self, g_type: crate::types::Type) -> (TypeInfo, TypeValueTable) {
+        let info = TypeInfo::default();
+        let value_table = TypeValueTable::default();
+        unsafe {
+            gobject_ffi::g_type_plugin_complete_type_info(
+                self.as_ref().to_glib_none().0,
+                g_type.into_glib(),
+                info.as_ptr(),
+                value_table.as_ptr(),
+            );
+        }
+        (info, value_table)
+    }
+
+    #[doc(alias = "g_type_plugin_unuse")]
+    fn unuse(&self) {
+        unsafe {
+            gobject_ffi::g_type_plugin_unuse(self.as_ref().to_glib_none().0);
+        }
+    }
+
+    #[doc(alias = "g_type_plugin_use")]
+    #[doc(alias = "use")]
+    fn use_(&self) {
+        unsafe {
+            gobject_ffi::g_type_plugin_use(self.as_ref().to_glib_none().0);
+        }
+    }
+}
+
+impl<O: IsA<TypePlugin>> TypePluginExt for O {}

--- a/glib/src/gobject/type_value_table.rs
+++ b/glib/src/gobject/type_value_table.rs
@@ -1,0 +1,43 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[derive(Debug, Copy, Clone)]
+#[doc(alias = "GTypeValueTable")]
+#[repr(transparent)]
+pub struct TypeValueTable(pub(crate) gobject_ffi::GTypeValueTable);
+
+impl TypeValueTable {
+    // rustdoc-stripper-ignore-next
+    /// Returns a `GTypeValueTable` pointer.
+    #[doc(hidden)]
+    #[inline]
+    pub fn as_ptr(&self) -> *mut gobject_ffi::GTypeValueTable {
+        &self.0 as *const gobject_ffi::GTypeValueTable as *mut _
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Borrows the underlying C value mutably.
+    #[doc(hidden)]
+    #[inline]
+    pub unsafe fn from_glib_ptr_borrow_mut<'a>(
+        ptr: *mut gobject_ffi::GTypeValueTable,
+    ) -> &'a mut Self {
+        &mut *(ptr as *mut Self)
+    }
+}
+
+impl Default for TypeValueTable {
+    // rustdoc-stripper-ignore-next
+    /// Creates a new TypeValueTable with default value.
+    fn default() -> Self {
+        Self(gobject_ffi::GTypeValueTable {
+            value_init: None,
+            value_free: None,
+            value_copy: None,
+            value_peek_pointer: None,
+            collect_format: ::std::ptr::null(),
+            collect_value: None,
+            lcopy_format: ::std::ptr::null(),
+            lcopy_value: None,
+        })
+    }
+}

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -9,8 +9,9 @@ pub use ffi;
 #[doc(hidden)]
 pub use glib_macros::cstr_bytes;
 pub use glib_macros::{
-    clone, closure, closure_local, derived_properties, flags, object_interface, object_subclass,
-    Boxed, Downgrade, Enum, ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
+    clone, closure, closure_local, derived_properties, dynamic_object_interface,
+    dynamic_object_subclass, flags, object_interface, object_subclass, Boxed, Downgrade, Enum,
+    ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
 };
 pub use gobject_ffi;
 pub use once_cell;
@@ -115,7 +116,17 @@ pub use self::auto::*;
 #[allow(non_upper_case_globals)]
 mod auto;
 
-pub use self::gobject::*;
+#[cfg(feature = "v2_74")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v2_74")))]
+pub use self::gobject::SignalGroup;
+pub use self::gobject::{
+    Binding, BindingFlags, InterfaceInfo, ParamFlags, SignalFlags, TypeFlags, TypeInfo, TypeModule,
+    TypePlugin, TypeValueTable,
+};
+#[cfg(feature = "v2_72")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v2_72")))]
+pub use self::gobject::{BindingGroup, BindingGroupBuilder};
+
 mod gobject;
 
 mod byte_array;

--- a/glib/src/prelude.rs
+++ b/glib/src/prelude.rs
@@ -4,6 +4,8 @@
 //! Traits and essential types intended for blanket imports.
 
 pub use crate::{
-    param_spec::ParamSpecBuilderExt, Cast, CastNone, IsA, ObjectClassExt, ObjectExt, ObjectType,
-    ParamSpecType, StaticType, StaticTypeExt, StaticVariantType, ToSendValue, ToValue, ToVariant,
+    gobject::traits::{DynamicObjectRegisterExt, TypeModuleExt, TypePluginExt},
+    param_spec::ParamSpecBuilderExt,
+    Cast, CastNone, IsA, ObjectClassExt, ObjectExt, ObjectType, ParamSpecType, StaticType,
+    StaticTypeExt, StaticVariantType, ToSendValue, ToValue, ToVariant,
 };

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -197,7 +197,204 @@
 //! }
 //! ```
 //!
-//! # Example for registering a boxed type for a Rust struct
+//! # Example for registering a `glib::Object` subclass within a module
+//!
+//! The following code implements a subclass of `glib::Object` and registers it as
+//! a dynamic type.
+//!
+//! ```rust
+//! use glib::prelude::*;
+//! use glib::subclass::prelude::*;
+//!
+//! pub mod imp {
+//!     use super::*;
+//!
+//!     // SimpleModuleObject is a dynamic type.
+//!     #[derive(Default)]
+//!     pub struct SimpleModuleObject;
+//!
+//!     #[glib::dynamic_object_subclass]
+//!     impl ObjectSubclass for SimpleModuleObject {
+//!         const NAME: &'static str = "SimpleModuleObject";
+//!         type Type = super::SimpleModuleObject;
+//!     }
+//!
+//!     impl ObjectImpl for SimpleModuleObject {}
+//!
+//!     // SimpleTypeModule is the type module within the object subclass is registered as a dynamic type.
+//!     #[derive(Default)]
+//!     pub struct SimpleTypeModule;
+//!
+//!     #[glib::object_subclass]
+//!     impl ObjectSubclass for SimpleTypeModule {
+//!         const NAME: &'static str = "SimpleTypeModule";
+//!         type Type = super::SimpleTypeModule;
+//!         type ParentType = glib::TypeModule;
+//!         type Interfaces = (glib::TypePlugin,);
+//!     }
+//!
+//!     impl ObjectImpl for SimpleTypeModule {}
+//!
+//!     impl TypeModuleImpl for SimpleTypeModule {
+//!         /// Loads the module and registers the object subclass as a dynamic type.
+//!         fn load(&self) -> bool {
+//!             SimpleModuleObject::on_implementation_load(self.obj().upcast_ref::<glib::TypeModule>())
+//!         }
+//!
+//!         /// Unloads the module.
+//!         fn unload(&self) {
+//!             SimpleModuleObject::on_implementation_unload(self.obj().upcast_ref::<glib::TypeModule>());
+//!         }
+//!     }
+//!
+//!     impl TypePluginImpl for SimpleTypeModule {}
+//! }
+//!
+//! // Optionally, defines a wrapper type to make SimpleModuleObject more ergonomic to use from Rust.
+//! glib::wrapper! {
+//!     pub struct SimpleModuleObject(ObjectSubclass<imp::SimpleModuleObject>);
+//! }
+//!
+//! // Optionally, defines a wrapper type to make SimpleTypeModule more ergonomic to use from Rust.
+//! glib::wrapper! {
+//!     pub struct SimpleTypeModule(ObjectSubclass<imp::SimpleTypeModule>)
+//!     @extends glib::TypeModule, @implements glib::TypePlugin;
+//! }
+//!
+//! impl SimpleTypeModule {
+//!     // Creates an object instance of the new type.
+//!     pub fn new() -> Self {
+//!         glib::Object::new()
+//!     }
+//! }
+//!
+//! pub fn main() {
+//!     let simple_type_module = SimpleTypeModule::new();
+//!     // at this step, SimpleTypeModule has not been loaded therefore
+//!     // SimpleModuleObject must not be registered yet.
+//!     let simple_module_object_type = imp::SimpleModuleObject::type_();
+//!     assert!(!simple_module_object_type.is_valid());
+//!
+//!     // simulates the glib type system to load the module.
+//!     TypeModuleExt::use_(&simple_type_module);
+//!
+//!     // at this step, SimpleModuleObject must have been registered.
+//!     let simple_module_object_type = imp::SimpleModuleObject::type_();
+//!     assert!(simple_module_object_type.is_valid());
+//! }
+//! ```
+//!
+//! # Example for registering a `glib::Object` subclass within a plugin
+//!
+//! The following code implements a subclass of `glib::Object` and registers it as
+//! a dynamic type.
+//!
+//! ```rust
+//! use glib::prelude::*;
+//! use glib::subclass::prelude::*;
+//!
+//! pub mod imp {
+//!     use super::*;
+//!
+//!     // SimplePluginObject is a dynamic type.
+//!     #[derive(Default)]
+//!     pub struct SimplePluginObject;
+//!
+//!     #[glib::dynamic_object_subclass(plugin_type = super::SimpleTypePlugin)]
+//!     impl ObjectSubclass for SimplePluginObject {
+//!         const NAME: &'static str = "SimplePluginObject";
+//!         type Type = super::SimplePluginObject;
+//!     }
+//!
+//!     impl ObjectImpl for SimplePluginObject {}
+//!
+//!     // SimpleTypePlugin is the type plugin within the object subclass is registered as a dynamic type.
+//!     #[derive(Default)]
+//!     pub struct SimpleTypePlugin {
+//!         type_info: std::cell::Cell<Option<glib::TypeInfo>>
+//!     }
+//!
+//!     #[glib::object_subclass]
+//!     impl ObjectSubclass for SimpleTypePlugin {
+//!         const NAME: &'static str = "SimpleTypePlugin";
+//!         type Type = super::SimpleTypePlugin;
+//!         type Interfaces = (glib::TypePlugin,);
+//!     }
+//!
+//!     impl ObjectImpl for SimpleTypePlugin {}
+//!
+//!     impl TypePluginImpl for SimpleTypePlugin {
+//!         /// Uses the plugin and registers the object subclass as a dynamic type.
+//!         fn use_plugin(&self) {
+//!             SimplePluginObject::on_implementation_load(self.obj().as_ref());
+//!         }
+//!
+//!         /// Unuses the plugin.
+//!         fn unuse_plugin(&self) {
+//!             SimplePluginObject::on_implementation_unload(self.obj().as_ref());
+//!         }
+//!
+//!         /// Returns type information about the object subclass registered as a dynamic type.
+//!         fn complete_type_info(&self, _type_: glib::Type) -> (glib::TypeInfo, glib::TypeValueTable) {
+//!             assert!(self.type_info.get().is_some());
+//!             // returns type info.
+//!             (self.type_info.get().unwrap(), glib::TypeValueTable::default())
+//!         }
+//!     }
+//!
+//!     impl TypePluginRegisterImpl for SimpleTypePlugin {
+//!         fn add_dynamic_interface(&self, _: glib::Type, _: glib::Type, _: &glib::InterfaceInfo) {
+//!             unimplemented!()
+//!         }
+//!
+//!         fn register_dynamic_type(&self, parent_type: glib::Type, type_name: &str, type_info: &glib::TypeInfo, flags: glib::TypeFlags) -> glib::Type {
+//!             let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
+//!                 glib::Type::register_dynamic(parent_type, type_name, self.obj().upcast_ref::<glib::TypePlugin>(), flags)
+//!             });
+//!             if type_.is_valid() {
+//!                 // saves type info.
+//!                 self.type_info.set(Some(*type_info));
+//!             }
+//!             type_
+//!         }
+//!     }
+//! }
+//!
+//! // Optionally, defines a wrapper type to make SimplePluginObject more ergonomic to use from Rust.
+//! glib::wrapper! {
+//!     pub struct SimplePluginObject(ObjectSubclass<imp::SimplePluginObject>);
+//! }
+//!
+//! // Optionally, defines a wrapper type to make SimpleTypePlugin more ergonomic to use from Rust.
+//! glib::wrapper! {
+//!     pub struct SimpleTypePlugin(ObjectSubclass<imp::SimpleTypePlugin>)
+//!     @implements glib::TypePlugin;
+//! }
+//!
+//! impl SimpleTypePlugin {
+//!     // Creates an object instance of the new type.
+//!     pub fn new() -> Self {
+//!         glib::Object::new()
+//!     }
+//! }
+//!
+//! pub fn main() {
+//!     let simple_type_plugin = SimpleTypePlugin::new();
+//!     // at this step, SimpleTypePlugin has not been used therefore
+//!     // SimplePluginObject must not be registered yet.
+//!     let simple_plugin_object_type = imp::SimplePluginObject::type_();
+//!     assert!(!simple_plugin_object_type.is_valid());
+//!
+//!     // simulates the glib type system to use the plugin.
+//!     TypePluginExt::use_(&simple_type_plugin);
+//!
+//!     // at this step, SimplePluginObject must have been registered.
+//!     let simple_plugin_object_type = imp::SimplePluginObject::type_();
+//!     assert!(simple_plugin_object_type.is_valid());
+//! }
+//! ```
+//!
+//!//! # Example for registering a boxed type for a Rust struct
 //!
 //! The following code boxed type for a tuple struct around `String` and uses it in combination
 //! with `glib::Value`.
@@ -241,6 +438,10 @@ pub mod signal;
 mod object_impl_ref;
 pub use object_impl_ref::{ObjectImplRef, ObjectImplWeakRef};
 
+pub mod type_module;
+
+pub mod type_plugin;
+
 pub mod prelude {
     // rustdoc-stripper-ignore-next
     //! Prelude that re-exports all important traits from this crate.
@@ -249,6 +450,8 @@ pub mod prelude {
         interface::{ObjectInterface, ObjectInterfaceExt, ObjectInterfaceType},
         object::{DerivedObjectProperties, ObjectClassSubclassExt, ObjectImpl, ObjectImplExt},
         shared::{RefCounted, SharedType},
+        type_module::{TypeModuleImpl, TypeModuleImplExt},
+        type_plugin::{TypePluginImpl, TypePluginImplExt, TypePluginRegisterImpl},
         types::{
             ClassStruct, InstanceStruct, InstanceStructExt, IsImplementable, IsSubclassable,
             IsSubclassableExt, ObjectSubclass, ObjectSubclassExt, ObjectSubclassIsExt,
@@ -259,9 +462,9 @@ pub mod prelude {
 
 pub use self::{
     boxed::register_boxed_type,
-    interface::register_interface,
+    interface::{register_dynamic_interface, register_interface},
     signal::{
         Signal, SignalClassHandlerToken, SignalId, SignalInvocationHint, SignalQuery, SignalType,
     },
-    types::{register_type, InitializingObject, InitializingType, TypeData},
+    types::{register_dynamic_type, register_type, InitializingObject, InitializingType, TypeData},
 };

--- a/glib/src/subclass/type_module.rs
+++ b/glib/src/subclass/type_module.rs
@@ -1,0 +1,164 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{subclass::prelude::*, translate::*, Cast, TypeModule};
+
+pub trait TypeModuleImpl: ObjectImpl + TypeModuleImplExt {
+    // rustdoc-stripper-ignore-next
+    /// Loads the module, registers one or more object subclasses using
+    /// [`register_dynamic_type`] and registers one or more object interfaces
+    /// using [`register_dynamic_interface`] (see [`TypeModule`]).
+    ///
+    /// [`register_dynamic_type`]: ../types/fn.register_dynamic_type.html
+    /// [`register_dynamic_interface`]: ../interface/fn.register_dynamic_interface.html
+    /// [`TypeModule`]: ../../gobject/auto/type_module/struct.TypeModule.html
+    fn load(&self) -> bool;
+    // rustdoc-stripper-ignore-next
+    /// Unloads the module (see [`TypeModuleExt::unuse`]).
+    ///
+    /// [`TypeModuleExt::unuse`]: ../../gobject/auto/type_module/trait.TypeModuleExt.html#method.unuse
+    fn unload(&self);
+}
+
+pub trait TypeModuleImplExt: ObjectSubclass {
+    fn parent_load(&self) -> bool;
+    fn parent_unload(&self);
+}
+
+impl<T: TypeModuleImpl> TypeModuleImplExt for T {
+    fn parent_load(&self) -> bool {
+        unsafe {
+            let data = T::type_data();
+            let parent_class = data.as_ref().parent_class() as *const gobject_ffi::GTypeModuleClass;
+
+            let f = (*parent_class)
+                .load
+                .expect("No parent class implementation for \"load\"");
+
+            from_glib(f(self
+                .obj()
+                .unsafe_cast_ref::<TypeModule>()
+                .to_glib_none()
+                .0))
+        }
+    }
+
+    fn parent_unload(&self) {
+        unsafe {
+            let data = T::type_data();
+            let parent_class = data.as_ref().parent_class() as *const gobject_ffi::GTypeModuleClass;
+
+            let f = (*parent_class)
+                .unload
+                .expect("No parent class implementation for \"unload\"");
+
+            f(self.obj().unsafe_cast_ref::<TypeModule>().to_glib_none().0);
+        }
+    }
+}
+
+unsafe impl<T: TypeModuleImpl> IsSubclassable<T> for TypeModule {
+    fn class_init(class: &mut crate::Class<Self>) {
+        Self::parent_class_init::<T>(class);
+
+        let klass = class.as_mut();
+        klass.load = Some(load::<T>);
+        klass.unload = Some(unload::<T>);
+    }
+}
+
+unsafe extern "C" fn load<T: TypeModuleImpl>(
+    type_module: *mut gobject_ffi::GTypeModule,
+) -> ffi::gboolean {
+    let instance = &*(type_module as *mut T::Instance);
+    let imp = instance.imp();
+
+    let res = imp.load();
+    // GLib type system expects a module to never be disposed if types has been
+    // successfully loaded.
+    // The following code prevents the Rust wrapper (`glib::TypeModule` subclass)
+    // to dispose the module when dropped by ensuring the reference count is > 1.
+    // Nothing is done if loading types has failed, allowing application to drop
+    // and dispose the invalid module.
+    if res && (*(type_module as *const gobject_ffi::GObject)).ref_count == 1 {
+        unsafe {
+            gobject_ffi::g_object_ref(type_module as _);
+        }
+    }
+
+    res.into_glib()
+}
+
+unsafe extern "C" fn unload<T: TypeModuleImpl>(type_module: *mut gobject_ffi::GTypeModule) {
+    let instance = &*(type_module as *mut T::Instance);
+    let imp = instance.imp();
+
+    imp.unload();
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{self as glib, prelude::TypeModuleExt};
+
+    use super::*;
+
+    mod imp {
+        use super::*;
+
+        #[derive(Default)]
+        pub struct SimpleModule;
+
+        #[crate::object_subclass]
+        impl ObjectSubclass for SimpleModule {
+            const NAME: &'static str = "SimpleModule";
+            type Type = super::SimpleModule;
+            type ParentType = TypeModule;
+            type Interfaces = (crate::TypePlugin,);
+        }
+
+        impl ObjectImpl for SimpleModule {}
+
+        impl TypePluginImpl for SimpleModule {}
+
+        impl TypeModuleImpl for SimpleModule {
+            fn load(&self) -> bool {
+                // register types on implementation load
+                SimpleModuleType::on_implementation_load(self.obj().upcast_ref::<TypeModule>())
+            }
+
+            fn unload(&self) {
+                // unregister types on implementation unload
+                SimpleModuleType::on_implementation_unload(self.obj().upcast_ref::<TypeModule>());
+            }
+        }
+
+        #[derive(Default)]
+        pub struct SimpleModuleType;
+
+        #[crate::dynamic_object_subclass]
+        impl ObjectSubclass for SimpleModuleType {
+            const NAME: &'static str = "SimpleModuleType";
+            type Type = super::SimpleModuleType;
+        }
+
+        impl ObjectImpl for SimpleModuleType {}
+    }
+
+    crate::wrapper! {
+        pub struct SimpleModule(ObjectSubclass<imp::SimpleModule>)
+        @extends TypeModule, @implements crate::TypePlugin;
+    }
+
+    crate::wrapper! {
+        pub struct SimpleModuleType(ObjectSubclass<imp::SimpleModuleType>);
+    }
+
+    #[test]
+    fn test_module() {
+        assert!(!imp::SimpleModuleType::type_().is_valid());
+        let simple_module = glib::Object::new::<SimpleModule>();
+        // simulates the glib type system to load the module.
+        assert!(simple_module.use_());
+        assert!(imp::SimpleModuleType::type_().is_valid());
+        simple_module.unuse();
+    }
+}

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -1,0 +1,301 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::translate::IntoGlib;
+use crate::translate::{FromGlib, ToGlibPtr};
+use crate::TypeFlags;
+use crate::{
+    subclass::prelude::*, Cast, Interface, InterfaceInfo, Type, TypeInfo, TypePlugin,
+    TypeValueTable,
+};
+
+pub trait TypePluginImpl: ObjectImpl + TypePluginImplExt {
+    fn use_plugin(&self) {
+        self.parent_use_plugin();
+    }
+
+    fn unuse_plugin(&self) {
+        self.parent_unuse_plugin();
+    }
+
+    fn complete_type_info(&self, type_: Type) -> (TypeInfo, TypeValueTable) {
+        self.parent_complete_type_info(type_)
+    }
+
+    fn complete_interface_info(&self, instance_type: Type, interface_type: Type) -> InterfaceInfo {
+        self.parent_complete_interface_info(instance_type, interface_type)
+    }
+}
+
+pub trait TypePluginImplExt: ObjectSubclass {
+    fn parent_use_plugin(&self);
+    fn parent_unuse_plugin(&self);
+    fn parent_complete_type_info(&self, type_: Type) -> (TypeInfo, TypeValueTable);
+    fn parent_complete_interface_info(
+        &self,
+        instance_type: Type,
+        interface_type: Type,
+    ) -> InterfaceInfo;
+}
+
+impl<T: TypePluginImpl> TypePluginImplExt for T {
+    fn parent_use_plugin(&self) {
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface = type_data.as_ref().parent_interface::<TypePlugin>()
+                as *const gobject_ffi::GTypePluginClass;
+
+            let f = (*parent_iface)
+                .use_plugin
+                .expect("no parent \"use_plugin\" implementation");
+
+            f(self.obj().unsafe_cast_ref::<TypePlugin>().to_glib_none().0)
+        }
+    }
+
+    fn parent_unuse_plugin(&self) {
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface = type_data.as_ref().parent_interface::<TypePlugin>()
+                as *const gobject_ffi::GTypePluginClass;
+
+            let f = (*parent_iface)
+                .unuse_plugin
+                .expect("no parent \"unuse_plugin\" implementation");
+
+            f(self.obj().unsafe_cast_ref::<TypePlugin>().to_glib_none().0)
+        }
+    }
+
+    fn parent_complete_type_info(&self, type_: Type) -> (TypeInfo, TypeValueTable) {
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface = type_data.as_ref().parent_interface::<TypePlugin>()
+                as *const gobject_ffi::GTypePluginClass;
+
+            let f = (*parent_iface)
+                .complete_type_info
+                .expect("no parent \"complete_type_info\" implementation");
+
+            let info = TypeInfo::default();
+            let value_table = TypeValueTable::default();
+            f(
+                self.obj().unsafe_cast_ref::<TypePlugin>().to_glib_none().0,
+                type_.into_glib(),
+                info.as_ptr(),
+                value_table.as_ptr(),
+            );
+
+            (info, value_table)
+        }
+    }
+
+    fn parent_complete_interface_info(
+        &self,
+        instance_type: Type,
+        interface_type: Type,
+    ) -> InterfaceInfo {
+        let info = InterfaceInfo::default();
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface = type_data.as_ref().parent_interface::<TypePlugin>()
+                as *const gobject_ffi::GTypePluginClass;
+
+            let f = (*parent_iface)
+                .complete_interface_info
+                .expect("no parent \"complete_interface_info\" implementation");
+
+            f(
+                self.obj().unsafe_cast_ref::<TypePlugin>().to_glib_none().0,
+                instance_type.into_glib(),
+                interface_type.into_glib(),
+                info.as_ptr(),
+            )
+        }
+        info
+    }
+}
+
+unsafe impl<T: TypePluginImpl> IsImplementable<T> for TypePlugin {
+    fn interface_init(iface: &mut Interface<Self>) {
+        let iface = iface.as_mut();
+
+        iface.use_plugin = Some(use_plugin::<T>);
+        iface.unuse_plugin = Some(unuse_plugin::<T>);
+        iface.complete_type_info = Some(complete_type_info::<T>);
+        iface.complete_interface_info = Some(complete_interface_info::<T>);
+    }
+}
+
+unsafe extern "C" fn use_plugin<T: TypePluginImpl>(type_plugin: *mut gobject_ffi::GTypePlugin) {
+    let instance = &*(type_plugin as *mut T::Instance);
+    let imp = instance.imp();
+
+    imp.use_plugin();
+}
+
+unsafe extern "C" fn unuse_plugin<T: TypePluginImpl>(type_plugin: *mut gobject_ffi::GTypePlugin) {
+    let instance = &*(type_plugin as *mut T::Instance);
+    let imp = instance.imp();
+
+    imp.unuse_plugin();
+}
+
+unsafe extern "C" fn complete_type_info<T: TypePluginImpl>(
+    type_plugin: *mut gobject_ffi::GTypePlugin,
+    gtype: ffi::GType,
+    info_ptr: *mut gobject_ffi::GTypeInfo,
+    value_table_ptr: *mut gobject_ffi::GTypeValueTable,
+) {
+    assert!(!info_ptr.is_null());
+    assert!(!value_table_ptr.is_null());
+    let instance = &*(type_plugin as *mut T::Instance);
+    let imp = instance.imp();
+    let type_ = Type::from_glib(gtype);
+    let info = TypeInfo::from_glib_ptr_borrow_mut(info_ptr);
+    let value_table = TypeValueTable::from_glib_ptr_borrow_mut(value_table_ptr);
+
+    let (info_, value_table_) = imp.complete_type_info(type_);
+
+    *info = info_;
+    *value_table = value_table_;
+}
+
+unsafe extern "C" fn complete_interface_info<T: TypePluginImpl>(
+    type_plugin: *mut gobject_ffi::GTypePlugin,
+    instance_gtype: ffi::GType,
+    interface_gtype: ffi::GType,
+    info_ptr: *mut gobject_ffi::GInterfaceInfo,
+) {
+    assert!(!info_ptr.is_null());
+    let instance = &*(type_plugin as *mut T::Instance);
+    let imp = instance.imp();
+    let instance_type = Type::from_glib(instance_gtype);
+    let interface_type = Type::from_glib(interface_gtype);
+    let info = InterfaceInfo::from_glib_ptr_borrow_mut(info_ptr);
+
+    let info_ = imp.complete_interface_info(instance_type, interface_type);
+    *info = info_;
+}
+
+pub trait TypePluginRegisterImpl: ObjectImpl + TypePluginImpl {
+    fn add_dynamic_interface(
+        &self,
+        _instance_type: Type,
+        _interface_type: Type,
+        _interface_info: &InterfaceInfo,
+    );
+
+    fn register_dynamic_type(
+        &self,
+        _parent_type: Type,
+        _type_name: &str,
+        _type_info: &TypeInfo,
+        _flags: TypeFlags,
+    ) -> Type;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{self as glib, prelude::TypePluginExt};
+
+    use super::*;
+
+    mod imp {
+        use super::*;
+
+        #[derive(Default)]
+        pub struct SimplePlugin {
+            type_info: std::cell::Cell<Option<TypeInfo>>,
+        }
+
+        #[crate::object_subclass]
+        impl ObjectSubclass for SimplePlugin {
+            const NAME: &'static str = "SimplePlugin";
+            type Type = super::SimplePlugin;
+            type Interfaces = (TypePlugin,);
+        }
+
+        impl ObjectImpl for SimplePlugin {}
+
+        impl TypePluginImpl for SimplePlugin {
+            fn use_plugin(&self) {
+                // registers types on implementation load
+                SimplePluginType::on_implementation_load(self.obj().as_ref());
+            }
+
+            fn unuse_plugin(&self) {
+                // unregisters types on implementation unload
+                SimplePluginType::on_implementation_unload(self.obj().as_ref());
+            }
+
+            fn complete_type_info(&self, _type_: Type) -> (TypeInfo, TypeValueTable) {
+                assert!(self.type_info.get().is_some());
+                // returns type info
+                (self.type_info.get().unwrap(), TypeValueTable::default())
+            }
+        }
+
+        impl TypePluginRegisterImpl for SimplePlugin {
+            fn add_dynamic_interface(
+                &self,
+                _instance_type: Type,
+                _interface_type: Type,
+                _interface_info: &InterfaceInfo,
+            ) {
+                unimplemented!()
+            }
+
+            fn register_dynamic_type(
+                &self,
+                parent_type: Type,
+                type_name: &str,
+                type_info: &TypeInfo,
+                flags: TypeFlags,
+            ) -> Type {
+                let type_ = Type::from_name(type_name).unwrap_or_else(|| {
+                    Type::register_dynamic(
+                        parent_type,
+                        type_name,
+                        self.obj().upcast_ref::<TypePlugin>(),
+                        flags,
+                    )
+                });
+                if type_.is_valid() {
+                    // save type info
+                    self.type_info.set(Some(*type_info));
+                }
+                type_
+            }
+        }
+
+        #[derive(Default)]
+        pub struct SimplePluginType;
+
+        #[crate::dynamic_object_subclass(plugin_type = super::SimplePlugin)]
+        impl ObjectSubclass for SimplePluginType {
+            const NAME: &'static str = "SimplePluginType";
+            type Type = super::SimplePluginType;
+        }
+
+        impl ObjectImpl for SimplePluginType {}
+    }
+
+    crate::wrapper! {
+        pub struct SimplePlugin(ObjectSubclass<imp::SimplePlugin>)
+        @implements TypePlugin;
+    }
+
+    crate::wrapper! {
+        pub struct SimplePluginType(ObjectSubclass<imp::SimplePluginType>);
+    }
+
+    #[test]
+    fn test_plugin() {
+        assert!(!imp::SimplePluginType::type_().is_valid());
+        let simple_plugin = crate::Object::new::<SimplePlugin>();
+        // simulates the glib type system to use the plugin.
+        TypePluginExt::use_(&simple_plugin);
+        assert!(imp::SimplePluginType::type_().is_valid());
+        TypePluginExt::unuse(&simple_plugin);
+    }
+}


### PR DESCRIPTION
This PR aims to add support of module types and interfaces. See https://docs.gtk.org/gobject/class.TypeModule.html
The new macros `module_object_subclass` and `module_object_interface` allow to register types and interfaces that are part of a module (e.g. a shared library on linux). The macros mimic `object_subclass` and `object_interface` but generate code that support registration when the module (`TypeModule`) is loaded, following the behavior defined in Glib doc. However it is possible to postpone the registration at first use of the type (like for `object_subclass`) by explicitly setting the macro attribute `lazy_registration = true`.
Some examples in `glib-macros/tests/test.rs`, `glib/src/subclass/mod.rs` and `glib/src/subclass/type_module.rs`
