### PR TITLE
Pin the Fedora version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:38
 
 RUN dnf update -y && \
     dnf install wget git meson cmake gcc gcc-c++ \


### PR DESCRIPTION
Pin the `fedora` base image version to `38` in the Dockerfile, to ensure that CI builds which use the `gtk-rs` Docker images are reproducible.