### PR TITLE
glib: Remove `#[doc(hidden)]` from `once_cell` and `bitflags` re-export

### DIFF
--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::missing_safety_doc)]
 #![doc = include_str!("../README.md")]
 
-#[doc(hidden)]
 pub use bitflags;
 pub use ffi;
 #[doc(hidden)]
@@ -14,7 +13,6 @@ pub use glib_macros::{
     Boxed, Downgrade, Enum, ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
 };
 pub use gobject_ffi;
-#[doc(hidden)]
 pub use once_cell;
 
 pub use self::{


### PR DESCRIPTION
The blogpost[1] mentions that these are re-exported, so to avoid causing confusion, make it so these appear in documentation.

[1]: https://gtk-rs.org/blog/2023/08/28/new-release.html#switch-to-bitflags-20

---

Alternatives:
- do nothing
- remove the note about the two crates being re-exported from the blogpost