### PR TITLE
glib/GStringPtr: Add `as_str()` and `Deref<Target=&str>`

### DIFF
--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -409,7 +409,7 @@ impl Clone for StrV {
         unsafe {
             let mut s = Self::with_capacity(self.len());
             for (i, item) in self.iter().enumerate() {
-                *s.ptr.as_ptr().add(i) = GString::from(item.to_str()).into_glib_ptr();
+                *s.ptr.as_ptr().add(i) = GString::from(item.as_str()).into_glib_ptr();
             }
             s.len = self.len();
             *s.ptr.as_ptr().add(s.len) = ptr::null_mut();

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -694,8 +694,16 @@ impl GStringPtr {
     // rustdoc-stripper-ignore-next
     /// Returns the corresponding [`&str`].
     #[inline]
-    pub fn to_str(&self) -> &str {
+    pub fn as_str(&self) -> &str {
         self.to_gstr().as_str()
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// This is just an alias for [`as_str`].
+    #[inline]
+    #[deprecated = "Use as_str instead"]
+    pub fn to_str(&self) -> &str {
+        self
     }
 
     // rustdoc-stripper-ignore-next
@@ -724,6 +732,15 @@ impl Clone for GStringPtr {
     }
 }
 
+impl Deref for GStringPtr {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl IntoGlibPtr<*mut c_char> for GStringPtr {
     #[inline]
     unsafe fn into_glib_ptr(self) -> *mut c_char {
@@ -749,7 +766,7 @@ impl fmt::Debug for GStringPtr {
 impl fmt::Display for GStringPtr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.to_str())
+        f.write_str(self.as_str())
     }
 }
 
@@ -863,7 +880,7 @@ impl Ord for GStringPtr {
 impl PartialOrd<GStringPtr> for String {
     #[inline]
     fn partial_cmp(&self, other: &GStringPtr) -> Option<std::cmp::Ordering> {
-        Some(self.as_str().cmp(other.to_str()))
+        Some(self.as_str().cmp(other))
     }
 }
 
@@ -877,7 +894,7 @@ impl PartialOrd<GStringPtr> for GString {
 impl PartialOrd<String> for GStringPtr {
     #[inline]
     fn partial_cmp(&self, other: &String) -> Option<std::cmp::Ordering> {
-        Some(self.to_str().cmp(other))
+        Some(self.as_str().cmp(other))
     }
 }
 
@@ -891,7 +908,7 @@ impl PartialOrd<GString> for GStringPtr {
 impl PartialOrd<GStringPtr> for str {
     #[inline]
     fn partial_cmp(&self, other: &GStringPtr) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other.to_str()))
+        Some(self.cmp(other.as_str()))
     }
 }
 
@@ -905,14 +922,14 @@ impl PartialOrd<GStringPtr> for GStr {
 impl PartialOrd<str> for GStringPtr {
     #[inline]
     fn partial_cmp(&self, other: &str) -> Option<std::cmp::Ordering> {
-        Some(self.to_str().cmp(other))
+        Some(self.as_str().cmp(other))
     }
 }
 
 impl PartialOrd<&str> for GStringPtr {
     #[inline]
     fn partial_cmp(&self, other: &&str) -> Option<std::cmp::Ordering> {
-        Some(self.to_str().cmp(other))
+        Some(self.as_str().cmp(other))
     }
 }
 
@@ -933,7 +950,7 @@ impl PartialOrd<&GStr> for GStringPtr {
 impl PartialOrd<GStringPtr> for &str {
     #[inline]
     fn partial_cmp(&self, other: &GStringPtr) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other.to_str()))
+        Some(self.cmp(&other.as_str()))
     }
 }
 
@@ -954,7 +971,7 @@ impl AsRef<GStringPtr> for GStringPtr {
 impl std::hash::Hash for GStringPtr {
     #[inline]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.to_str().hash(state);
+        self.as_str().hash(state);
     }
 }
 


### PR DESCRIPTION
I was updating some code to glib 0.18 and we were previously using `as_str()` - which is what the default Rust nomenclature for an *infallible* reference-to-reference conversion uses.

The `to_str()` is used for fallible conversions
(e.g. https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_str) which this is not.