### PR TITLE
glib-macros: Mark property getters as #[must_use]

### DIFF
--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -566,9 +566,11 @@ fn expand_impl_getset_properties(props: &[PropDesc]) -> Vec<syn::ImplItemFn> {
 
         let getter = p.get.is_some().then(|| {
             let span = p.attrs_span;
-            parse_quote_spanned!(span=> pub fn #ident(&self) -> <#ty as #crate_ident::Property>::Value {
-                 self.property::<<#ty as #crate_ident::Property>::Value>(#stripped_name)
-            })
+            parse_quote_spanned!(span=>
+                #[must_use]
+                pub fn #ident(&self) -> <#ty as #crate_ident::Property>::Value {
+                    self.property::<<#ty as #crate_ident::Property>::Value>(#stripped_name)
+                })
         });
 
         let setter = (p.set.is_some() && !p.is_construct_only).then(|| {


### PR DESCRIPTION
This PR should fix #1186 

I'm still not convinced that `quote_spanned` is correctly used (because there are obviously a lot of tokens which have nothing to do with the span of the attribute), but I don't know the reasoning behind the code, so adding `#[must_use]` to the codegen is the easiest fix and actually a useful addition even if you don't use `clippy::must_use_candidate`.