### PR TITLE
glib-macros: Remove unused imports from Properties doc test

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -935,8 +935,6 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 /// # Example
 /// ```
 /// use std::cell::RefCell;
-/// use std::marker::PhantomData;
-/// use std::sync::Mutex;
 /// use glib::prelude::*;
 /// use glib::subclass::prelude::*;
 /// use glib_macros::Properties;


### PR DESCRIPTION
I copied the example in a playground to understand why my properties are not working in the project I'm working on, and found out those two imports can be removed.