### PR TITLE
Remove explicit linking in param_spec.rs

### DIFF
--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -296,7 +296,6 @@ pub unsafe trait ParamSpecType:
 {
 }
 
-#[link(name = "gobject-2.0")]
 extern "C" {
     pub static g_param_spec_types: *const ffi::GType;
 }


### PR DESCRIPTION
See the issue in librsvg here: https://gitlab.gnome.org/GNOME/librsvg/-/issues/896

I think this line can be removed, which fixes the ability to statically link the stack on e.g. Windows.