### PR TITLE
Add _full and _local_full methods for idle and timeout callbacks that take priority

### DIFF
--- a/glib/src/source.rs
+++ b/glib/src/source.rs
@@ -281,6 +281,29 @@ where
 // rustdoc-stripper-ignore-next
 /// Adds a closure to be called by the default main loop when it's idle.
 ///
+/// `func` will be called repeatedly with `priority` until it returns
+/// `ControlFlow::Break`.
+///
+/// The default main loop almost always is the main loop of the main thread.
+/// Thus, the closure is called on the main thread.
+#[doc(alias = "g_idle_add_full")]
+pub fn idle_add_full<F>(priority: Priority, func: F) -> SourceId
+where
+    F: FnMut() -> ControlFlow + Send + 'static,
+{
+    unsafe {
+        from_glib(ffi::g_idle_add_full(
+            priority.into_glib(),
+            Some(trampoline::<F>),
+            into_raw(func),
+            Some(destroy_closure::<F>),
+        ))
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// Adds a closure to be called by the default main loop when it's idle.
+///
 /// `func` will be called repeatedly until it returns `ControlFlow::Break`.
 ///
 /// The default main loop almost always is the main loop of the main thread.
@@ -322,6 +345,39 @@ where
             .expect("default main context already acquired by another thread");
         from_glib(ffi::g_idle_add_full(
             ffi::G_PRIORITY_DEFAULT_IDLE,
+            Some(trampoline_local::<F>),
+            into_raw_local(func),
+            Some(destroy_closure_local::<F>),
+        ))
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// Adds a closure to be called by the default main loop when it's idle.
+///
+/// `func` will be called repeatedly with `priority` until it returns
+/// `ControlFlow::Break`.
+///
+/// The default main loop almost always is the main loop of the main thread.
+/// Thus, the closure is called on the main thread.
+///
+/// Different to `idle_add()`, this does not require `func` to be
+/// `Send` but can only be called from the thread that owns the main context.
+///
+/// This function panics if called from a different thread than the one that
+/// owns the default main context.
+#[doc(alias = "g_idle_add_full")]
+pub fn idle_add_local_full<F>(priority: Priority, func: F) -> SourceId
+where
+    F: FnMut() -> ControlFlow + 'static,
+{
+    unsafe {
+        let context = MainContext::default();
+        let _acquire = context
+            .acquire()
+            .expect("default main context already acquired by another thread");
+        from_glib(ffi::g_idle_add_full(
+            priority.into_glib(),
             Some(trampoline_local::<F>),
             into_raw_local(func),
             Some(destroy_closure_local::<F>),
@@ -384,6 +440,33 @@ where
 /// Adds a closure to be called by the default main loop at regular intervals
 /// with millisecond granularity.
 ///
+/// `func` will be called repeatedly every `interval` milliseconds with `priority`
+/// until it returns `ControlFlow::Break`. Precise timing is not guaranteed, the
+/// timeout may be delayed by other events. Prefer `timeout_add_seconds` when
+/// millisecond precision is not necessary.
+///
+/// The default main loop almost always is the main loop of the main thread.
+/// Thus, the closure is called on the main thread.
+#[doc(alias = "g_timeout_add_full")]
+pub fn timeout_add_full<F>(interval: Duration, priority: Priority, func: F) -> SourceId
+where
+    F: FnMut() -> ControlFlow + Send + 'static,
+{
+    unsafe {
+        from_glib(ffi::g_timeout_add_full(
+            priority.into_glib(),
+            interval.as_millis() as _,
+            Some(trampoline::<F>),
+            into_raw(func),
+            Some(destroy_closure::<F>),
+        ))
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// Adds a closure to be called by the default main loop at regular intervals
+/// with millisecond granularity.
+///
 /// `func` will be called repeatedly every `interval` milliseconds until it
 /// returns `ControlFlow::Break`. Precise timing is not guaranteed, the timeout may
 /// be delayed by other events. Prefer `timeout_add_seconds` when millisecond
@@ -432,6 +515,43 @@ where
             .expect("default main context already acquired by another thread");
         from_glib(ffi::g_timeout_add_full(
             ffi::G_PRIORITY_DEFAULT,
+            interval.as_millis() as _,
+            Some(trampoline_local::<F>),
+            into_raw_local(func),
+            Some(destroy_closure_local::<F>),
+        ))
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// Adds a closure to be called by the default main loop at regular intervals
+/// with millisecond granularity.
+///
+/// `func` will be called repeatedly every `interval` milliseconds with `priority`
+/// until it returns `ControlFlow::Break`. Precise timing is not guaranteed, the
+/// timeout may be delayed by other events. Prefer `timeout_add_seconds` when
+/// millisecond precision is not necessary.
+///
+/// The default main loop almost always is the main loop of the main thread.
+/// Thus, the closure is called on the main thread.
+///
+/// Different to `timeout_add()`, this does not require `func` to be
+/// `Send` but can only be called from the thread that owns the main context.
+///
+/// This function panics if called from a different thread than the one that
+/// owns the main context.
+#[doc(alias = "g_timeout_add_full")]
+pub fn timeout_add_local_full<F>(interval: Duration, priority: Priority, func: F) -> SourceId
+where
+    F: FnMut() -> ControlFlow + 'static,
+{
+    unsafe {
+        let context = MainContext::default();
+        let _acquire = context
+            .acquire()
+            .expect("default main context already acquired by another thread");
+        from_glib(ffi::g_timeout_add_full(
+            priority.into_glib(),
             interval.as_millis() as _,
             Some(trampoline_local::<F>),
             into_raw_local(func),


### PR DESCRIPTION
Just copying and pasting with minimal changes.

Closes #1148 