### PR TITLE
gio: Use weak reference to ActionMap when adding action entries

### DIFF
--- a/gio/src/action_map.rs
+++ b/gio/src/action_map.rs
@@ -20,13 +20,13 @@ pub trait ActionMapExtManual: sealed::Sealed + IsA<ActionMap> {
             };
             let action_map = self.as_ref();
             if let Some(callback) = entry.activate {
-                action.connect_activate(clone!(@strong action_map =>  move |action, state| {
+                action.connect_activate(clone!(@weak action_map =>  move |action, state| {
                     // safe to unwrap as O: IsA<ActionMap>
                     callback(action_map.downcast_ref::<Self>().unwrap(), action, state);
                 }));
             }
             if let Some(callback) = entry.change_state {
-                action.connect_change_state(clone!(@strong action_map => move |action, state| {
+                action.connect_change_state(clone!(@weak action_map => move |action, state| {
                     // safe to unwrap as O: IsA<ActionMap>
                     callback(action_map.downcast_ref::<Self>().unwrap(), action, state);
                 }));


### PR DESCRIPTION
Otherwise it is not possible to drop the ActionMap without dropping the actions first.

See https://github.com/gtk-rs/gtk4-rs/issues/1516.