### PR TITLE
gio: fix UnixSocketAddress constructor with a path

### DIFF
--- a/gio/src/unix_socket_address.rs
+++ b/gio/src/unix_socket_address.rs
@@ -46,20 +46,21 @@ impl UnixSocketAddress {
         use self::UnixSocketAddressPath::*;
 
         let type_ = address_type.to_type();
-        let (path, len) = match address_type {
-            Path(path) => (path.to_glib_none().0, path.as_os_str().len()),
-            Abstract(path) | AbstractPadded(path) => {
-                (path.to_glib_none().0 as *mut libc::c_char, path.len())
-            }
-            Anonymous => (ptr::null_mut(), 0),
-        };
-        unsafe {
+        let new = |ptr, len| unsafe {
             SocketAddress::from_glib_full(ffi::g_unix_socket_address_new_with_type(
-                path,
-                len as i32,
+                ptr,
+                len,
                 type_.into_glib(),
             ))
             .unsafe_cast()
+        };
+        match address_type {
+            Path(path) => new(path.to_glib_none().0, -1),
+            Abstract(path) | AbstractPadded(path) => new(
+                path.to_glib_none().0 as *mut libc::c_char,
+                path.len() as i32,
+            ),
+            Anonymous => new(ptr::null_mut(), 0),
         }
     }
 }
@@ -97,3 +98,24 @@ pub trait UnixSocketAddressExtManual: sealed::Sealed + IsA<UnixSocketAddress> + 
 }
 
 impl<O: IsA<UnixSocketAddress>> UnixSocketAddressExtManual for O {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Check the actual path and len are correct and are not the underlying OsString
+    #[test]
+    fn check_path() {
+        let mut os_string = std::ffi::OsString::with_capacity(100);
+        os_string.push("/tmp/foo");
+        let path = os_string.as_ref();
+
+        let addr = UnixSocketAddress::new(path);
+        assert_eq!(addr.path_len(), 8);
+        assert_eq!(addr.path_as_array().unwrap().as_ref(), b"/tmp/foo");
+
+        let addr = UnixSocketAddress::with_type(UnixSocketAddressPath::Path(path));
+        assert_eq!(addr.path_len(), 8);
+        assert_eq!(addr.path_as_array().unwrap().as_ref(), b"/tmp/foo");
+    }
+}


### PR DESCRIPTION
as_os_str().len() does not return the number of bytes in the string, but the full allocation size. Just pass -1 and let glib calculate the len.