### PR TITLE
Add support of enums as dynamic types

### DIFF
--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -328,6 +328,7 @@ pub fn impl_enum_(
 
             #[inline]
             fn into_glib(self) -> i32 {
+                assert!(#name::static_type().is_valid());
                 self as i32
             }
         }
@@ -337,6 +338,7 @@ pub fn impl_enum_(
 
             #[inline]
             unsafe fn try_from_glib(value: i32) -> ::core::result::Result<Self, i32> {
+                assert!(#name::static_type().is_valid());
                 let from_glib = || {
                     #from_glib
                 };

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -3,24 +3,31 @@
 use heck::{ToKebabCase, ToUpperCamelCase};
 use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
-use quote::{quote, quote_spanned};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{punctuated::Punctuated, spanned::Spanned, token::Comma, Data, Ident, Variant};
 
 use crate::utils::{crate_ident_new, gen_enum_from_glib, parse_nested_meta_items, NestedMetaItem};
 
-// Generate glib::gobject_ffi::GEnumValue structs mapping the enum such as:
+// If `wrap` is `false`, generates glib::gobject_ffi::GEnumValue structs mapping the enum such as:
 //     glib::gobject_ffi::GEnumValue {
 //         value: Animal::Goat as i32,
 //         value_name: "Goat\0" as *const _ as *const _,
 //         value_nick: "goat\0" as *const _ as *const _,
 //     },
+// If `wrap` is `true`, generates glib::EnumValue structs mapping the enum such as:
+//     glib::EnumValue::new(glib::gobject_ffi::GEnumValue {
+//         value: Animal::Goat as i32,
+//         value_name: "Goat\0" as *const _ as *const _,
+//         value_nick: "goat\0" as *const _ as *const _,
+//     }),
 fn gen_enum_values(
+    wrap: bool,
     enum_name: &Ident,
     enum_variants: &Punctuated<Variant, Comma>,
 ) -> (TokenStream, usize) {
     let crate_ident = crate_ident_new();
 
-    // start at one as GEnumValue array is null-terminated
+    // starts at one as GEnumValue array is null-terminated.
     let mut n = 1;
     let recurse = enum_variants.iter().map(|v| {
         let name = &v.ident;
@@ -43,12 +50,24 @@ fn gen_enum_values(
         let value_nick = format!("{value_nick}\0");
 
         n += 1;
-        quote_spanned! {v.span()=>
-            #crate_ident::gobject_ffi::GEnumValue {
-                value: #enum_name::#name as i32,
-                value_name: #value_name as *const _ as *const _,
-                value_nick: #value_nick as *const _ as *const _,
-            },
+        if wrap {
+            // generates a glib::EnumValue.
+            quote_spanned! {v.span()=>
+                #crate_ident::EnumValue::new(#crate_ident::gobject_ffi::GEnumValue {
+                    value: #enum_name::#name as i32,
+                    value_name: #value_name as *const _ as *const _,
+                    value_nick: #value_nick as *const _ as *const _,
+                }),
+            }
+        } else {
+            // generates a glib::gobject_ffi::GEnumValue.
+            quote_spanned! {v.span()=>
+                #crate_ident::gobject_ffi::GEnumValue {
+                    value: #enum_name::#name as i32,
+                    value_name: #value_name as *const _ as *const _,
+                    value_nick: #value_nick as *const _ as *const _,
+                },
+            }
         }
     });
     (
@@ -81,8 +100,226 @@ pub fn impl_enum(input: &syn::DeriveInput) -> TokenStream {
     };
     let gtype_name = gtype_name.value.unwrap();
     let from_glib = gen_enum_from_glib(name, enum_variants);
-    let (enum_values, nb_enum_values) = gen_enum_values(name, enum_variants);
+    let (enum_values, nb_enum_values) = gen_enum_values(false, name, enum_variants);
 
+    let crate_ident = crate_ident_new();
+
+    // registers the enum on first use (lazy registration).
+    let register_enum = quote! {
+        impl #name {
+            /// Registers the enum only once.
+            #[inline]
+            fn register_enum() -> #crate_ident::Type {
+                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
+                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
+
+                ONCE.call_once(|| {
+                    static mut VALUES: [#crate_ident::gobject_ffi::GEnumValue; #nb_enum_values] = [
+                        #enum_values
+                        #crate_ident::gobject_ffi::GEnumValue {
+                            value: 0,
+                            value_name: ::std::ptr::null(),
+                            value_nick: ::std::ptr::null(),
+                        },
+                    ];
+                    let name = ::std::ffi::CString::new(#gtype_name).expect("CString::new failed");
+                    unsafe {
+                        let type_ = #crate_ident::gobject_ffi::g_enum_register_static(name.as_ptr(), VALUES.as_ptr());
+                        let type_: #crate_ident::Type = #crate_ident::translate::from_glib(type_);
+                        assert!(type_.is_valid());
+                        TYPE = type_;
+                    }
+                });
+
+                unsafe {
+                    TYPE
+                }
+            }
+        }
+    };
+
+    impl_enum_(name, from_glib, register_enum)
+}
+
+pub fn impl_dynamic_enum(input: &syn::DeriveInput) -> TokenStream {
+    let name = &input.ident;
+
+    let enum_variants = match input.data {
+        Data::Enum(ref e) => &e.variants,
+        _ => abort_call_site!("#[derive(glib::Enum)] only supports enums"),
+    };
+
+    let mut gtype_name = NestedMetaItem::<syn::LitStr>::new("name")
+        .required()
+        .value_required();
+    let mut plugin_type = NestedMetaItem::<syn::Path>::new("plugin_type").value_required();
+    let mut lazy_registration =
+        NestedMetaItem::<syn::LitBool>::new("lazy_registration").value_required();
+    let found = parse_nested_meta_items(
+        &input.attrs,
+        "enum_type",
+        &mut [&mut gtype_name, &mut plugin_type, &mut lazy_registration],
+    );
+
+    match found {
+        Ok(None) => {
+            abort_call_site!("#[derive(glib::DynamicEnum)] requires #[enum_type(name = \"EnumTypeName\"[, plugin_type =  <subclass_of_glib::TypePlugin>][, lazy_registration = true|false])]")
+        }
+        Err(e) => return e.to_compile_error(),
+        Ok(attr) => attr,
+    };
+
+    let crate_ident = crate_ident_new();
+
+    let gtype_name = gtype_name.value.unwrap();
+    let plugin_ty = plugin_type
+        .value
+        .map(|p| p.into_token_stream())
+        .unwrap_or(quote!(#crate_ident::TypeModule));
+    let lazy_registration = lazy_registration.value.map(|b| b.value).unwrap_or_default();
+
+    let from_glib = gen_enum_from_glib(name, enum_variants);
+    let (enum_values, nb_enum_values) = gen_enum_values(true, name, enum_variants);
+
+    let enum_values_expr = quote! {
+        [#crate_ident::EnumValue; #nb_enum_values] = [
+            #enum_values
+            #crate_ident::EnumValue::new(#crate_ident::gobject_ffi::GEnumValue {
+                value: 0,
+                value_name: ::std::ptr::null(),
+                value_nick: ::std::ptr::null(),
+            }),
+        ]
+    };
+
+    // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt`] and [`TypeModuleExt`]).
+    // An enum can be reregistered as a dynamic type.
+    let register_enum_impl = if lazy_registration {
+        // registers the enum as a dynamic type on the first use (lazy registration).
+        // a weak reference on the plugin is stored and will be used later on the first use of the enum.
+        // this implementation relies on a static storage of a weak reference on the plugin and of the glib type to know if the enum has been registered.
+        quote! {
+            impl #name {
+                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the glib type.
+                /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the data.
+                #[inline]
+                fn get_registration_status_ref_mut() -> &'static mut Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)> {
+                    static mut REGISTRATION_STATUS: ::std::sync::Mutex<Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)>> = ::std::sync::Mutex::new(None);
+                    unsafe { REGISTRATION_STATUS.get_mut().unwrap() }
+                }
+
+                /// Registers the enum as a dynamic type within the plugin only once.
+                /// Plugin must have been used at least once.
+                /// Do nothing if plugin has never been used or if the enum is already registered as a dynamic type.
+                #[inline]
+                fn register_enum() -> #crate_ident::Type {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used, so the enum cannot be registered as a dynamic type.
+                        None => #crate_ident::Type::INVALID,
+                        // plugin has been used and the enum has not been registered yet, so registers it as a dynamic type.
+                        Some((type_plugin, type_)) if !type_.is_valid() => {
+                            static mut VALUES: #enum_values_expr;
+                            *type_ = <#plugin_ty as glib::prelude::DynamicObjectRegisterExt>::register_dynamic_enum(type_plugin.upgrade().unwrap().as_ref(), #gtype_name, unsafe { &VALUES } );
+                            *type_
+                        },
+                        // plugin has been used and the enum has already been registered as a dynamic type.
+                        Some((_, type_)) => *type_
+                    }
+                }
+
+                /// Depending on the plugin lifecycle state and on the registration status of the enum:
+                /// If plugin is used (and has loaded the implementation) for the first time, postpones the registration and stores a weak reference on the plugin.
+                /// If plugin is reused (and has reloaded the implementation) and the enum has been already registered as a dynamic type, reregisters it.
+                /// An enum can be reregistered several times as a dynamic type.
+                /// If plugin is reused (and has reloaded the implementation) and the enum has not been registered yet as a dynamic type, do nothing.
+                #[inline]
+                pub fn on_implementation_load(type_plugin: &#plugin_ty) -> bool {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used (this is the first time), so postpones registration of the enum as a dynamic type on the first use.
+                        None => {
+                            *registration_status_ref_mut = Some((#crate_ident::clone::Downgrade::downgrade(type_plugin), #crate_ident::Type::INVALID));
+                            true
+                        },
+                        // plugin has been used at least one time and the enum has been registered as a dynamic type at least one time, so re-registers it.
+                        Some((_, type_)) if type_.is_valid() => {
+                            static mut VALUES: #enum_values_expr;
+                            *type_ = <#plugin_ty as glib::prelude::DynamicObjectRegisterExt>::register_dynamic_enum(type_plugin, #gtype_name, unsafe { &VALUES } );
+                            type_.is_valid()
+                        },
+                        // plugin has been used at least one time but the enum has not been registered yet as a dynamic type, so keeps postponed registration.
+                        Some(_) => {
+                            true
+                        }
+                    }
+                }
+
+                /// Depending on the plugin lifecycle state and on the registration status of the enum:
+                /// If plugin has been used (or reused) but the enum has not been registered yet as a dynamic type, cancels the postponed registration by deleting the weak reference on the plugin.
+                /// Else do nothing.
+                #[inline]
+                pub fn on_implementation_unload(type_plugin_: &#plugin_ty) -> bool {
+                    let registration_status_ref_mut = Self::get_registration_status_ref_mut();
+                    match registration_status_ref_mut {
+                        // plugin has never been used, so unload implementation is unexpected.
+                        None => false,
+                        // plugin has been used at least one time and the enum has been registered as a dynamic type at least one time.
+                        Some((_, type_)) if type_.is_valid() => true,
+                        // plugin has been used at least one time but the enum has not been registered yet as a dynamic type, so cancels the postponed registration.
+                        Some(_) => {
+                            *registration_status_ref_mut = None;
+                            true
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        // registers immediately the enum as a dynamic type.
+        quote! {
+            impl #name {
+                /// Returns a mutable reference to the glib type.
+                /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the atomic data.
+                #[inline]
+                fn get_type_mut() -> &'static mut #crate_ident::ffi::GType {
+                    static mut TYPE: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(#crate_ident::gobject_ffi::G_TYPE_INVALID);
+                    unsafe { TYPE.get_mut() }
+                }
+
+                /// Do nothing as the enum has been registered on implementation load.
+                #[inline]
+                fn register_enum() -> #crate_ident::Type {
+                    unsafe { <#crate_ident::Type as #crate_ident::translate::FromGlib<#crate_ident::ffi::GType>>::from_glib(*Self::get_type_mut()) }
+                }
+
+                /// Registers the enum as a dynamic type within the plugin.
+                /// The enum can be registered several times as a dynamic type.
+                #[inline]
+                pub fn on_implementation_load(type_plugin: &#plugin_ty) -> bool {
+                    let type_mut = Self::get_type_mut();
+                    static mut VALUES: #enum_values_expr;
+                    *type_mut = #crate_ident::translate::IntoGlib::into_glib(<#plugin_ty as glib::prelude::DynamicObjectRegisterExt>::register_dynamic_enum(type_plugin, #gtype_name, unsafe { &VALUES } ));
+                    *type_mut != #crate_ident::gobject_ffi::G_TYPE_INVALID
+                }
+
+                /// Do nothing as enums registered as dynamic types are never unregistered.
+                #[inline]
+                pub fn on_implementation_unload(type_plugin_: &#plugin_ty) -> bool {
+                    true
+                }
+            }
+        }
+    };
+
+    impl_enum_(name, from_glib, register_enum_impl)
+}
+
+pub fn impl_enum_(
+    name: &syn::Ident,
+    from_glib: TokenStream,
+    register_enum: TokenStream,
+) -> TokenStream {
     let crate_ident = crate_ident_new();
 
     quote! {
@@ -161,33 +398,11 @@ pub fn impl_enum(input: &syn::DeriveInput) -> TokenStream {
         impl #crate_ident::StaticType for #name {
             #[inline]
             fn static_type() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
-
-                ONCE.call_once(|| {
-                    static mut VALUES: [#crate_ident::gobject_ffi::GEnumValue; #nb_enum_values] = [
-                        #enum_values
-                        #crate_ident::gobject_ffi::GEnumValue {
-                            value: 0,
-                            value_name: ::std::ptr::null(),
-                            value_nick: ::std::ptr::null(),
-                        },
-                    ];
-
-                    let name = ::std::ffi::CString::new(#gtype_name).expect("CString::new failed");
-                    unsafe {
-                        let type_ = #crate_ident::gobject_ffi::g_enum_register_static(name.as_ptr(), VALUES.as_ptr());
-                        let type_: #crate_ident::Type = #crate_ident::translate::from_glib(type_);
-                        assert!(type_.is_valid());
-                        TYPE = type_;
-                    }
-                });
-
-                unsafe {
-                    TYPE
-                }
+                Self::register_enum()
             }
         }
+
+        #register_enum
 
         impl #crate_ident::HasParamSpec for #name {
             type ParamSpec = #crate_ident::ParamSpecEnum;

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -170,19 +170,19 @@ pub fn impl_dynamic_enum(input: &syn::DeriveInput) -> TokenStream {
     let g_enum_values_expr: ExprArray = parse_quote! { [#g_enum_values] };
     let enum_values_iter = g_enum_values_expr.elems.iter().map(|v| {
         quote_spanned! {v.span()=>
-            #crate_ident::EnumValue::new(#v),
+            #crate_ident::EnumValue::unsafe_from(#v),
         }
     });
 
     let enum_values = quote! {
-        [#crate_ident::EnumValue; #nb_enum_values] = [
+        [#crate_ident::EnumValue; #nb_enum_values] = unsafe {[
             #(#enum_values_iter)*
-            #crate_ident::EnumValue::new(#crate_ident::gobject_ffi::GEnumValue {
+            #crate_ident::EnumValue::unsafe_from(#crate_ident::gobject_ffi::GEnumValue {
                 value: 0,
                 value_name: ::std::ptr::null(),
                 value_nick: ::std::ptr::null(),
             }),
-        ]
+        ]}
     };
 
     // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt`] and [`TypeModuleExt`]).

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -175,8 +175,8 @@ pub fn impl_dynamic_enum(input: &syn::DeriveInput) -> TokenStream {
     });
 
     let enum_values = quote! {
-        #crate_ident::EnumValuesStorage<#nb_enum_values> = unsafe {
-            #crate_ident::EnumValuesStorage::<#nb_enum_values>::new::<{#nb_enum_values - 1}>([
+        #crate_ident::enums::EnumValuesStorage<#nb_enum_values> = unsafe {
+            #crate_ident::enums::EnumValuesStorage::<#nb_enum_values>::new::<{#nb_enum_values - 1}>([
                 #(#enum_values_iter)*
             ])
         }

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -328,7 +328,6 @@ pub fn impl_enum_(
 
             #[inline]
             fn into_glib(self) -> i32 {
-                assert!(#name::static_type().is_valid());
                 self as i32
             }
         }
@@ -338,7 +337,6 @@ pub fn impl_enum_(
 
             #[inline]
             unsafe fn try_from_glib(value: i32) -> ::core::result::Result<Self, i32> {
-                assert!(#name::static_type().is_valid());
                 let from_glib = || {
                     #from_glib
                 };

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -190,13 +190,13 @@ pub fn impl_dynamic_enum(input: &syn::DeriveInput) -> TokenStream {
     let register_enum_impl = if lazy_registration {
         // registers the enum as a dynamic type on the first use (lazy registration).
         // a weak reference on the plugin is stored and will be used later on the first use of the enum.
-        // this implementation relies on a static storage of a weak reference on the plugin and of the glib type to know if the enum has been registered.
+        // this implementation relies on a static storage of a weak reference on the plugin and of the GLib type to know if the enum has been registered.
         quote! {
             struct RegistrationStatus(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type);
             unsafe impl Send for RegistrationStatus {}
 
             impl #name {
-                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the glib type.
+                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the GLib type.
                 /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the data.
                 #[inline]
                 fn get_registration_status_ref() -> &'static ::std::sync::Mutex<Option<RegistrationStatus>> {
@@ -278,7 +278,7 @@ pub fn impl_dynamic_enum(input: &syn::DeriveInput) -> TokenStream {
         // registers immediately the enum as a dynamic type.
         quote! {
             impl #name {
-                /// Returns a reference to the glib type which can be safely shared between threads.
+                /// Returns a reference to the GLib type which can be safely shared between threads.
                 #[inline]
                 fn get_gtype_ref() -> &'static ::std::sync::atomic::AtomicUsize {
                     static TYPE: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(#crate_ident::gobject_ffi::G_TYPE_INVALID);

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -513,14 +513,47 @@ pub fn enum_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// By default an enum is considered to be registered as a dynamic type within
-/// a [`TypeModule`] subclass. Optionally setting the macro attribute
-/// `plugin_type` allows to register an enum as a dynamic type within a given
-/// [`TypePlugin`] subclass:
+/// An enum is usually registered as a dynamic type within a [`TypeModule`]
+/// subclass:
 /// ```ignore
 /// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::DynamicEnum)]
-/// #[enum_type(name = "MyEnum", plugin_type = MyPlugin)]
-/// enum MyEnum {
+/// #[enum_type(name = "MyModuleEnum")]
+/// enum MyModuleEnum {
+///     ...
+/// }
+/// ...
+/// #[derive(Default)]
+/// pub struct MyModule;
+/// ...
+/// impl TypeModuleImpl for MyModule {
+///     fn load(&self) -> bool {
+///         // registers enums as dynamic types.
+///         let my_module = self.obj();
+///         let type_module: &glib::TypeModule = my_module.upcast_ref();
+///         MyModuleEnum::on_implementation_load(type_module)
+///     }
+///     ...
+/// }
+/// ```
+///
+/// Optionally setting the macro attribute `plugin_type` allows to register an
+/// enum as a dynamic type within a given [`TypePlugin`] subclass:
+/// ```ignore
+/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::DynamicEnum)]
+/// #[enum_type(name = "MyPluginEnum", plugin_type = MyPlugin)]
+/// enum MyPluginEnum {
+///     ...
+/// }
+/// ...
+/// #[derive(Default)]
+/// pub struct MyPlugin;
+/// ...
+/// impl TypePluginImpl for MyPlugin {
+///     fn use_plugin(&self) {
+///         // register enums as dynamic types.
+///         let my_plugin = self.obj();
+///         MyPluginEnum::on_implementation_load(my_plugin.as_ref());
+///     }
 ///     ...
 /// }
 /// ```

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -439,7 +439,7 @@ pub fn closure_local(item: TokenStream) -> TokenStream {
     closure::closure_inner(item, "new_local")
 }
 
-/// Derive macro for register a rust enum in the glib type system and derive the
+/// Derive macro for register a Rust enum in the GLib type system and derive the
 /// the [`glib::Value`] traits.
 ///
 /// # Example
@@ -468,7 +468,7 @@ pub fn enum_derive(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
-/// Derive macro for register a rust enum in the glib type system as a dynamic
+/// Derive macro for register a Rust enum in the GLib type system as a dynamic
 /// type and derive the [`glib::Value`] traits.
 ///
 /// An enum must be explicitly registered as a dynamic type when the system

--- a/glib-macros/src/object_interface_attribute.rs
+++ b/glib-macros/src/object_interface_attribute.rs
@@ -91,10 +91,10 @@ pub fn impl_dynamic_object_interface(
     let register_interface = if lazy_registration {
         // registers the object interface as a dynamic type on the first use (lazy registration).
         // a weak reference on the plugin is stored and will be used later on the first use of the object interface.
-        // this implementation relies on a static storage of a weak reference on the plugin and of the glib type to know if the object interface has been registered.
+        // this implementation relies on a static storage of a weak reference on the plugin and of the GLib type to know if the object interface has been registered.
         quote! {
             impl #self_ty {
-                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the glib type.
+                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the GLib type.
                 /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the data.
                 #[inline]
                 fn get_registration_status_ref_mut() -> &'static mut Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)> {
@@ -171,7 +171,7 @@ pub fn impl_dynamic_object_interface(
         // registers immediately the object interface as a dynamic type.
         quote! {
             impl #self_ty {
-                /// Returns a mutable reference to the glib type.
+                /// Returns a mutable reference to the GLib type.
                 /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the atomic data.
                 #[inline]
                 fn get_type_mut() -> &'static mut #crate_ident::ffi::GType {

--- a/glib-macros/src/object_interface_attribute.rs
+++ b/glib-macros/src/object_interface_attribute.rs
@@ -86,8 +86,8 @@ pub fn impl_dynamic_object_interface(
         ),
     };
 
-    // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt::unuse`]).
-    // An object interface can be reregistered as a dynamic type (see [`TypePluginExt::register_type`]).
+    // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt`] and [`TypeModuleExt`]).
+    // An object interface can be reregistered as a dynamic type.
     let register_interface = if lazy_registration {
         // registers the object interface as a dynamic type on the first use (lazy registration).
         // a weak reference on the plugin is stored and will be used later on the first use of the object interface.

--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -81,8 +81,8 @@ pub fn impl_dynamic_object_subclass(
         ),
     };
 
-    // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt::unuse`]).
-    // An object subclass can be reregistered as a dynamic type (see [`TypePluginExt::register_type`]).
+    // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt`] and [`TypeModuleExt`]).
+    // An object subclass can be reregistered as a dynamic type.
     let register_type = if lazy_registration {
         // registers the object subclass as a dynamic type on the first use (lazy registration).
         // a weak reference on the plugin is stored and will be used later on the first use of the object subclass.

--- a/glib-macros/src/object_subclass_attribute.rs
+++ b/glib-macros/src/object_subclass_attribute.rs
@@ -86,10 +86,10 @@ pub fn impl_dynamic_object_subclass(
     let register_type = if lazy_registration {
         // registers the object subclass as a dynamic type on the first use (lazy registration).
         // a weak reference on the plugin is stored and will be used later on the first use of the object subclass.
-        // this implementation relies on a static storage of a weak reference on the plugin and of the glib type to know if the object subclass has been registered.
+        // this implementation relies on a static storage of a weak reference on the plugin and of the GLib type to know if the object subclass has been registered.
         quote! {
             impl #self_ty {
-                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the glib type.
+                /// Returns a mutable reference to the registration status: a tuple of the weak reference on the plugin and of the GLib type.
                 /// This is safe because the mutable reference guarantees that no other threads are concurrently accessing the data.
                 #[inline]
                 fn get_registration_status_ref_mut() -> &'static mut Option<(<#plugin_ty as #crate_ident::clone::Downgrade>::Weak, #crate_ident::Type)> {

--- a/glib-macros/tests/dynamic_enums.rs
+++ b/glib-macros/tests/dynamic_enums.rs
@@ -85,7 +85,7 @@ mod module {
         assert!(!MyModuleEnum::static_type().is_valid());
         assert!(!MyModuleEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to load/unload the module.
+        // simulates the GLib type system to load/unload the module.
         TypeModuleExt::use_(module);
         TypeModuleExt::unuse(module);
 
@@ -94,7 +94,7 @@ mod module {
         // checks types of enums that are lazy registered as dynamic types are valid (module is unloaded).
         assert!(!MyModuleEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to load the module.
+        // simulates the GLib type system to load the module.
         TypeModuleExt::use_(module);
 
         // checks types of enums registered as dynamic types are valid (module is loaded).
@@ -113,21 +113,21 @@ mod module {
             Some(module.upcast_ref::<glib::TypePlugin>())
         );
 
-        // simulates the glib type system to unload the module.
+        // simulates the GLib type system to unload the module.
         TypeModuleExt::unuse(module);
 
-        // checks types of enums registered as dynamic types are still valid (should have been marked as unloaded by the glib type system but this cannot be checked).
+        // checks types of enums registered as dynamic types are still valid (should have been marked as unloaded by the GLib type system but this cannot be checked).
         assert!(MyModuleEnum::static_type().is_valid());
         assert!(MyModuleEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to reload the module.
+        // simulates the GLib type system to reload the module.
         TypeModuleExt::use_(module);
 
-        // checks types of enums registered as dynamic types are still valid (should have been marked as loaded by the glib type system but this cannot be checked).
+        // checks types of enums registered as dynamic types are still valid (should have been marked as loaded by the GLib type system but this cannot be checked).
         assert!(MyModuleEnum::static_type().is_valid());
         assert!(MyModuleEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to unload the module.
+        // simulates the GLib type system to unload the module.
         TypeModuleExt::unuse(module);
     }
 
@@ -136,7 +136,7 @@ mod module {
         use glib::prelude::*;
         use glib::translate::{FromGlib, IntoGlib};
 
-        // simulates the glib type system to load the module.
+        // simulates the GLib type system to load the module.
         TypeModuleExt::use_(module);
 
         assert_eq!(MyModuleEnum::Foo.into_glib(), 0);
@@ -205,7 +205,7 @@ mod module {
             Ok(MyModuleEnumLazy::Bar)
         );
 
-        // simulates the glib type system to unload the module.
+        // simulates the GLib type system to unload the module.
         TypeModuleExt::unuse(module);
     }
 }
@@ -368,7 +368,7 @@ pub mod plugin {
         assert!(!MyPluginEnum::static_type().is_valid());
         assert!(!MyPluginEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to use/unuse the plugin.
+        // simulates the GLib type system to use/unuse the plugin.
         TypePluginExt::use_(plugin);
         TypePluginExt::unuse(plugin);
 
@@ -377,7 +377,7 @@ pub mod plugin {
         // checks types of enums that are lazy registered as dynamic types are still invalid (plugin is unused).
         assert!(!MyPluginEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to use the plugin.
+        // simulates the GLib type system to use the plugin.
         TypePluginExt::use_(plugin);
 
         // checks types of enums registered as dynamic types are valid (plugin is used).
@@ -396,21 +396,21 @@ pub mod plugin {
             Some(plugin.upcast_ref::<glib::TypePlugin>())
         );
 
-        // simulates the glib type system to unuse the plugin.
+        // simulates the GLib type system to unuse the plugin.
         TypePluginExt::unuse(plugin);
 
         // checks types of enums registered as dynamic types are still valid.
         assert!(MyPluginEnum::static_type().is_valid());
         assert!(MyPluginEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to reuse the plugin.
+        // simulates the GLib type system to reuse the plugin.
         TypePluginExt::use_(plugin);
 
         // checks types of enums registered as dynamic types are still valid.
         assert!(MyPluginEnum::static_type().is_valid());
         assert!(MyPluginEnumLazy::static_type().is_valid());
 
-        // simulates the glib type system to unuse the plugin.
+        // simulates the GLib type system to unuse the plugin.
         TypePluginExt::unuse(plugin);
     }
 
@@ -419,7 +419,7 @@ pub mod plugin {
         use glib::prelude::*;
         use glib::translate::{FromGlib, IntoGlib};
 
-        // simulates the glib type system to use the plugin.
+        // simulates the GLib type system to use the plugin.
         TypePluginExt::use_(plugin);
 
         assert_eq!(MyPluginEnum::Foo.into_glib(), 0);
@@ -488,7 +488,7 @@ pub mod plugin {
             Ok(MyPluginEnumLazy::Bar)
         );
 
-        // simulates the glib type system to unuse the plugin.
+        // simulates the GLib type system to unuse the plugin.
         TypePluginExt::unuse(plugin);
     }
 }

--- a/glib-macros/tests/dynamic_enums.rs
+++ b/glib-macros/tests/dynamic_enums.rs
@@ -264,8 +264,8 @@ pub mod plugin {
                     _ => panic!("unexpected type"),
                 }
                 .expect("enum type values");
-                let type_info = EnumClass::type_info(type_, enum_type_values)
-                    .expect("EnumClass::type_info failed");
+                let type_info = EnumClass::complete_type_info(type_, enum_type_values)
+                    .expect("EnumClass::complete_type_info failed");
                 (type_info, glib::TypeValueTable::default())
             }
 

--- a/glib-macros/tests/dynamic_enums.rs
+++ b/glib-macros/tests/dynamic_enums.rs
@@ -1,0 +1,494 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::{prelude::*, subclass::prelude::*, Cast};
+
+mod module {
+    use super::*;
+
+    mod imp {
+        use super::*;
+
+        // impl for a type module (must extend `glib::TypeModule` and must implement `glib::TypePlugin`).
+        #[derive(Default)]
+        pub struct MyModule;
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for MyModule {
+            const NAME: &'static str = "MyModule";
+            type Type = super::MyModule;
+            type ParentType = glib::TypeModule;
+            type Interfaces = (glib::TypePlugin,);
+        }
+
+        impl ObjectImpl for MyModule {}
+
+        impl TypePluginImpl for MyModule {}
+
+        impl TypeModuleImpl for MyModule {
+            fn load(&self) -> bool {
+                // registers enums as dynamic types.
+                let my_module = self.obj();
+                let type_module: &glib::TypeModule = my_module.upcast_ref();
+                super::MyModuleEnum::on_implementation_load(type_module)
+                    && super::MyModuleEnumLazy::on_implementation_load(type_module)
+            }
+
+            fn unload(&self) {
+                // marks the enums as unregistered.
+                let my_module = self.obj();
+                let type_module: &glib::TypeModule = my_module.upcast_ref();
+                super::MyModuleEnumLazy::on_implementation_unload(type_module);
+                super::MyModuleEnum::on_implementation_unload(type_module);
+            }
+        }
+    }
+
+    // an enum to register as a dynamic type.
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[repr(u32)]
+    #[enum_type(name = "MyModuleEnum")]
+    pub enum MyModuleEnum {
+        #[enum_value(name = "Foo")]
+        Foo,
+        Bar,
+    }
+
+    // an enum to lazy register as a dynamic type.
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[repr(u32)]
+    #[enum_type(name = "MyModuleEnumLazy", lazy_registration = true)]
+    pub enum MyModuleEnumLazy {
+        #[enum_value(name = "Foo")]
+        Foo,
+        Bar,
+    }
+
+    // a module (must extend `glib::TypeModule` and must implement `glib::TypePlugin`).
+    glib::wrapper! {
+        pub struct MyModule(ObjectSubclass<imp::MyModule>)
+        @extends glib::TypeModule, @implements glib::TypePlugin;
+    }
+
+    #[test]
+    fn dynamic_types() {
+        // 1st: creates a single module to test with.
+        let module = glib::Object::new::<MyModule>();
+        // 1st: uses it to test lifecycle of enums registered as dynamic types.
+        enum_lifecycle(&module);
+        // 2nd: uses it to test behavior of enums registered as dynamic types.
+        enum_behavior(&module);
+    }
+
+    // tests lifecycle of enums registered as dynamic types within a module.
+    fn enum_lifecycle(module: &MyModule) {
+        // checks types of enums to register as dynamic types are invalid (module is not loaded yet).
+        assert!(!MyModuleEnum::static_type().is_valid());
+        assert!(!MyModuleEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to load/unload the module.
+        TypeModuleExt::use_(module);
+        TypeModuleExt::unuse(module);
+
+        // checks types of enums registered as dynamic types are valid (module is unloaded).
+        assert!(MyModuleEnum::static_type().is_valid());
+        // checks types of enums that are lazy registered as dynamic types are valid (module is unloaded).
+        assert!(!MyModuleEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to load the module.
+        TypeModuleExt::use_(module);
+
+        // checks types of enums registered as dynamic types are valid (module is loaded).
+        let enum_type = MyModuleEnum::static_type();
+        assert!(enum_type.is_valid());
+        let enum_lazy_type = MyModuleEnumLazy::static_type();
+        assert!(enum_lazy_type.is_valid());
+
+        // checks plugin of enums registered as dynamic types is `MyModule`.
+        assert_eq!(
+            enum_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            enum_lazy_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+
+        // simulates the glib type system to unload the module.
+        TypeModuleExt::unuse(module);
+
+        // checks types of enums registered as dynamic types are still valid (should have been marked as unloaded by the glib type system but this cannot be checked).
+        assert!(MyModuleEnum::static_type().is_valid());
+        assert!(MyModuleEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to reload the module.
+        TypeModuleExt::use_(module);
+
+        // checks types of enums registered as dynamic types are still valid (should have been marked as loaded by the glib type system but this cannot be checked).
+        assert!(MyModuleEnum::static_type().is_valid());
+        assert!(MyModuleEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to unload the module.
+        TypeModuleExt::unuse(module);
+    }
+
+    // tests behavior of enums registered as dynamic types within a module.
+    fn enum_behavior(module: &MyModule) {
+        use glib::prelude::*;
+        use glib::translate::{FromGlib, IntoGlib};
+
+        // simulates the glib type system to load the module.
+        TypeModuleExt::use_(module);
+
+        assert_eq!(MyModuleEnum::Foo.into_glib(), 0);
+        assert_eq!(MyModuleEnum::Bar.into_glib(), 1);
+
+        assert_eq!(unsafe { MyModuleEnum::from_glib(0) }, MyModuleEnum::Foo);
+        assert_eq!(unsafe { MyModuleEnum::from_glib(1) }, MyModuleEnum::Bar);
+
+        let t = MyModuleEnum::static_type();
+        assert!(t.is_a(glib::Type::ENUM));
+        assert_eq!(t.name(), "MyModuleEnum");
+
+        let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+        let v = e.value(0).expect("EnumClass::get_value(0) failed");
+        assert_eq!(v.name(), "Foo");
+        assert_eq!(v.nick(), "foo");
+        let v = e.value(1).expect("EnumClass::get_value(1) failed");
+        assert_eq!(v.name(), "Bar");
+        assert_eq!(v.nick(), "bar");
+        assert_eq!(e.value(2), None);
+
+        // within enums registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::EnumClass`).
+        assert_eq!(
+            MyModuleEnum::Foo.to_value().get::<MyModuleEnum>(),
+            Ok(MyModuleEnum::Foo)
+        );
+        assert_eq!(
+            MyModuleEnum::Bar.to_value().get::<MyModuleEnum>(),
+            Ok(MyModuleEnum::Bar)
+        );
+
+        assert_eq!(MyModuleEnumLazy::Foo.into_glib(), 0);
+        assert_eq!(MyModuleEnumLazy::Bar.into_glib(), 1);
+
+        assert_eq!(
+            unsafe { MyModuleEnumLazy::from_glib(0) },
+            MyModuleEnumLazy::Foo
+        );
+        assert_eq!(
+            unsafe { MyModuleEnumLazy::from_glib(1) },
+            MyModuleEnumLazy::Bar
+        );
+
+        let t = MyModuleEnumLazy::static_type();
+        assert!(t.is_a(glib::Type::ENUM));
+        assert_eq!(t.name(), "MyModuleEnumLazy");
+
+        let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+        let v = e.value(0).expect("EnumClass::get_value(0) failed");
+        assert_eq!(v.name(), "Foo");
+        assert_eq!(v.nick(), "foo");
+        let v = e.value(1).expect("EnumClass::get_value(1) failed");
+        assert_eq!(v.name(), "Bar");
+        assert_eq!(v.nick(), "bar");
+        assert_eq!(e.value(2), None);
+
+        // within enums registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::EnumClass`).
+        assert_eq!(
+            MyModuleEnumLazy::Foo.to_value().get::<MyModuleEnumLazy>(),
+            Ok(MyModuleEnumLazy::Foo)
+        );
+        assert_eq!(
+            MyModuleEnumLazy::Bar.to_value().get::<MyModuleEnumLazy>(),
+            Ok(MyModuleEnumLazy::Bar)
+        );
+
+        // simulates the glib type system to unload the module.
+        TypeModuleExt::unuse(module);
+    }
+}
+
+pub mod plugin {
+    use super::*;
+
+    pub mod imp {
+        use glib::EnumClass;
+
+        use super::*;
+        use std::cell::Cell;
+
+        // impl for a type plugin (must implement `glib::TypePlugin`).
+        #[derive(Default)]
+        pub struct MyPlugin {
+            my_enum_type_values: Cell<Option<&'static [glib::EnumValue]>>,
+            my_enum_lazy_type_values: Cell<Option<&'static [glib::EnumValue]>>,
+        }
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for MyPlugin {
+            const NAME: &'static str = "MyPlugin";
+            type Type = super::MyPlugin;
+            type Interfaces = (glib::TypePlugin,);
+        }
+
+        impl ObjectImpl for MyPlugin {}
+
+        impl TypePluginImpl for MyPlugin {
+            fn use_plugin(&self) {
+                // register enums as dynamic types.
+                let my_plugin = self.obj();
+                super::MyPluginEnum::on_implementation_load(my_plugin.as_ref());
+                super::MyPluginEnumLazy::on_implementation_load(my_plugin.as_ref());
+            }
+
+            fn unuse_plugin(&self) {
+                // marks enums as unregistered.
+                let my_plugin = self.obj();
+                super::MyPluginEnumLazy::on_implementation_unload(my_plugin.as_ref());
+                super::MyPluginEnum::on_implementation_unload(my_plugin.as_ref());
+            }
+
+            fn complete_type_info(
+                &self,
+                type_: glib::Type,
+            ) -> (glib::TypeInfo, glib::TypeValueTable) {
+                let enum_type_values = match type_ {
+                    type_ if type_ == super::MyPluginEnum::static_type() => {
+                        self.my_enum_type_values.get()
+                    }
+                    type_ if type_ == super::MyPluginEnumLazy::static_type() => {
+                        self.my_enum_lazy_type_values.get()
+                    }
+                    _ => panic!("unexpected type"),
+                }
+                .expect("enum type values");
+                let type_info = EnumClass::type_info(type_, enum_type_values)
+                    .expect("EnumClass::type_info failed");
+                (type_info, glib::TypeValueTable::default())
+            }
+
+            fn complete_interface_info(
+                &self,
+                _instance_type: glib::Type,
+                _interface_type: glib::Type,
+            ) -> glib::InterfaceInfo {
+                unimplemented!()
+            }
+        }
+
+        impl TypePluginRegisterImpl for MyPlugin {
+            fn add_dynamic_interface(
+                &self,
+                _instance_type: glib::Type,
+                _interface_type: glib::Type,
+                _interface_info: &glib::InterfaceInfo,
+            ) {
+                unimplemented!()
+            }
+
+            fn register_dynamic_enum(
+                &self,
+                type_name: &str,
+                const_static_values: &'static [glib::EnumValue],
+            ) -> glib::Type {
+                let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
+                    glib::Type::register_dynamic(
+                        glib::Type::ENUM,
+                        type_name,
+                        self.obj().upcast_ref::<glib::TypePlugin>(),
+                        glib::TypeFlags::NONE,
+                    )
+                });
+                if type_.is_valid() {
+                    match type_name {
+                        "MyPluginEnum" => self.my_enum_type_values.set(Some(const_static_values)),
+                        "MyPluginEnumLazy" => {
+                            self.my_enum_lazy_type_values.set(Some(const_static_values))
+                        }
+                        _ => panic!("unexpected"),
+                    };
+                }
+                type_
+            }
+
+            fn register_dynamic_type(
+                &self,
+                _parent_type: glib::Type,
+                _type_name: &str,
+                _type_info: &glib::TypeInfo,
+                _flags: glib::TypeFlags,
+            ) -> glib::Type {
+                unimplemented!()
+            }
+        }
+    }
+
+    // an enum to register as a dynamic type.
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[repr(u32)]
+    #[enum_type(name = "MyPluginEnum", plugin_type = MyPlugin)]
+    pub enum MyPluginEnum {
+        #[enum_value(name = "Foo")]
+        Foo,
+        Bar,
+    }
+
+    // an enum to lazy register as a dynamic type.
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[repr(u32)]
+    #[enum_type(name = "MyPluginEnumLazy", plugin_type = MyPlugin, lazy_registration = true)]
+    pub enum MyPluginEnumLazy {
+        #[enum_value(name = "Foo")]
+        Foo,
+        Bar,
+    }
+
+    // a plugin (must implement `glib::TypePlugin`).
+    glib::wrapper! {
+        pub struct MyPlugin(ObjectSubclass<imp::MyPlugin>) @implements glib::TypePlugin;
+    }
+
+    #[test]
+    fn dynamic_types() {
+        // 1st: creates a single plugin to test with.
+        let plugin = glib::Object::new::<MyPlugin>();
+        // 1st: uses it to test lifecycle of enums registered as dynamic types.
+        enum_lifecycle(&plugin);
+        // 2nd: uses it to test behavior of enums registered as dynamic types.
+        enum_behavior(&plugin);
+    }
+
+    // tests lifecycle of enums registered as dynamic types within a plugin.
+    fn enum_lifecycle(plugin: &MyPlugin) {
+        use glib::prelude::*;
+
+        // checks types of enums to register as dynamic types are invalid (plugin is not used yet).
+        assert!(!MyPluginEnum::static_type().is_valid());
+        assert!(!MyPluginEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to use/unuse the plugin.
+        TypePluginExt::use_(plugin);
+        TypePluginExt::unuse(plugin);
+
+        // checks types of enums registered as dynamic types are valid (plugin is unused).
+        assert!(MyPluginEnum::static_type().is_valid());
+        // checks types of enums that are lazy registered as dynamic types are still invalid (plugin is unused).
+        assert!(!MyPluginEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to use the plugin.
+        TypePluginExt::use_(plugin);
+
+        // checks types of enums registered as dynamic types are valid (plugin is used).
+        let enum_type = MyPluginEnum::static_type();
+        assert!(enum_type.is_valid());
+        let enum_lazy_type = MyPluginEnumLazy::static_type();
+        assert!(enum_lazy_type.is_valid());
+
+        // checks plugin of enums registered as dynamic types is `MyPlugin`.
+        assert_eq!(
+            enum_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            enum_lazy_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+
+        // simulates the glib type system to unuse the plugin.
+        TypePluginExt::unuse(plugin);
+
+        // checks types of enums registered as dynamic types are still valid.
+        assert!(MyPluginEnum::static_type().is_valid());
+        assert!(MyPluginEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to reuse the plugin.
+        TypePluginExt::use_(plugin);
+
+        // checks types of enums registered as dynamic types are still valid.
+        assert!(MyPluginEnum::static_type().is_valid());
+        assert!(MyPluginEnumLazy::static_type().is_valid());
+
+        // simulates the glib type system to unuse the plugin.
+        TypePluginExt::unuse(plugin);
+    }
+
+    // tests behavior of enums registered as dynamic types within a plugin.
+    fn enum_behavior(plugin: &MyPlugin) {
+        use glib::prelude::*;
+        use glib::translate::{FromGlib, IntoGlib};
+
+        // simulates the glib type system to use the plugin.
+        TypePluginExt::use_(plugin);
+
+        assert_eq!(MyPluginEnum::Foo.into_glib(), 0);
+        assert_eq!(MyPluginEnum::Bar.into_glib(), 1);
+
+        assert_eq!(unsafe { MyPluginEnum::from_glib(0) }, MyPluginEnum::Foo);
+        assert_eq!(unsafe { MyPluginEnum::from_glib(1) }, MyPluginEnum::Bar);
+
+        let t = MyPluginEnum::static_type();
+        assert!(t.is_a(glib::Type::ENUM));
+        assert_eq!(t.name(), "MyPluginEnum");
+
+        let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+        let v = e.value(0).expect("EnumClass::get_value(0) failed");
+        assert_eq!(v.name(), "Foo");
+        assert_eq!(v.nick(), "foo");
+        let v = e.value(1).expect("EnumClass::get_value(1) failed");
+        assert_eq!(v.name(), "Bar");
+        assert_eq!(v.nick(), "bar");
+        assert_eq!(e.value(2), None);
+
+        // within enums registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::EnumClass`).
+        assert_eq!(
+            MyPluginEnum::Foo.to_value().get::<MyPluginEnum>(),
+            Ok(MyPluginEnum::Foo)
+        );
+        assert_eq!(
+            MyPluginEnum::Bar.to_value().get::<MyPluginEnum>(),
+            Ok(MyPluginEnum::Bar)
+        );
+
+        assert_eq!(MyPluginEnumLazy::Foo.into_glib(), 0);
+        assert_eq!(MyPluginEnumLazy::Bar.into_glib(), 1);
+
+        assert_eq!(
+            unsafe { MyPluginEnumLazy::from_glib(0) },
+            MyPluginEnumLazy::Foo
+        );
+        assert_eq!(
+            unsafe { MyPluginEnumLazy::from_glib(1) },
+            MyPluginEnumLazy::Bar
+        );
+
+        let t = MyPluginEnumLazy::static_type();
+        assert!(t.is_a(glib::Type::ENUM));
+        assert_eq!(t.name(), "MyPluginEnumLazy");
+
+        let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+        let v = e.value(0).expect("EnumClass::get_value(0) failed");
+        assert_eq!(v.name(), "Foo");
+        assert_eq!(v.nick(), "foo");
+        let v = e.value(1).expect("EnumClass::get_value(1) failed");
+        assert_eq!(v.name(), "Bar");
+        assert_eq!(v.nick(), "bar");
+        assert_eq!(e.value(2), None);
+
+        // within enums registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::EnumClass`).
+        assert_eq!(
+            MyPluginEnumLazy::Foo.to_value().get::<MyPluginEnumLazy>(),
+            Ok(MyPluginEnumLazy::Foo)
+        );
+        assert_eq!(
+            MyPluginEnumLazy::Bar.to_value().get::<MyPluginEnumLazy>(),
+            Ok(MyPluginEnumLazy::Bar)
+        );
+
+        // simulates the glib type system to unuse the plugin.
+        TypePluginExt::unuse(plugin);
+    }
+}

--- a/glib-macros/tests/dynamic_enums.rs
+++ b/glib-macros/tests/dynamic_enums.rs
@@ -238,8 +238,8 @@ pub mod plugin {
         // impl for a type plugin (must implement `glib::TypePlugin`).
         #[derive(Default)]
         pub struct MyPlugin {
-            my_enum_type_values: Cell<Option<&'static glib::EnumValues>>,
-            my_enum_lazy_type_values: Cell<Option<&'static glib::EnumValues>>,
+            my_enum_type_values: Cell<Option<&'static glib::enums::EnumValues>>,
+            my_enum_lazy_type_values: Cell<Option<&'static glib::enums::EnumValues>>,
         }
 
         #[glib::object_subclass]
@@ -290,7 +290,7 @@ pub mod plugin {
             fn register_dynamic_enum(
                 &self,
                 type_name: &str,
-                const_static_values: &'static glib::EnumValues,
+                const_static_values: &'static glib::enums::EnumValues,
             ) -> glib::Type {
                 let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
                     glib::Type::register_dynamic(

--- a/glib-macros/tests/dynamic_enums.rs
+++ b/glib-macros/tests/dynamic_enums.rs
@@ -238,8 +238,8 @@ pub mod plugin {
         // impl for a type plugin (must implement `glib::TypePlugin`).
         #[derive(Default)]
         pub struct MyPlugin {
-            my_enum_type_values: Cell<Option<&'static [glib::EnumValue]>>,
-            my_enum_lazy_type_values: Cell<Option<&'static [glib::EnumValue]>>,
+            my_enum_type_values: Cell<Option<&'static glib::EnumValues>>,
+            my_enum_lazy_type_values: Cell<Option<&'static glib::EnumValues>>,
         }
 
         #[glib::object_subclass]
@@ -290,7 +290,7 @@ pub mod plugin {
             fn register_dynamic_enum(
                 &self,
                 type_name: &str,
-                const_static_values: &'static [glib::EnumValue],
+                const_static_values: &'static glib::EnumValues,
             ) -> glib::Type {
                 let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
                     glib::Type::register_dynamic(

--- a/glib-macros/tests/dynamic_enums.rs
+++ b/glib-macros/tests/dynamic_enums.rs
@@ -268,26 +268,9 @@ pub mod plugin {
                     .expect("EnumClass::complete_type_info failed");
                 (type_info, glib::TypeValueTable::default())
             }
-
-            fn complete_interface_info(
-                &self,
-                _instance_type: glib::Type,
-                _interface_type: glib::Type,
-            ) -> glib::InterfaceInfo {
-                unimplemented!()
-            }
         }
 
         impl TypePluginRegisterImpl for MyPlugin {
-            fn add_dynamic_interface(
-                &self,
-                _instance_type: glib::Type,
-                _interface_type: glib::Type,
-                _interface_info: &glib::InterfaceInfo,
-            ) {
-                unimplemented!()
-            }
-
             fn register_dynamic_enum(
                 &self,
                 type_name: &str,
@@ -311,16 +294,6 @@ pub mod plugin {
                     };
                 }
                 type_
-            }
-
-            fn register_dynamic_type(
-                &self,
-                _parent_type: glib::Type,
-                _type_name: &str,
-                _type_info: &glib::TypeInfo,
-                _flags: glib::TypeFlags,
-            ) -> glib::Type {
-                unimplemented!()
             }
         }
     }

--- a/glib-macros/tests/dynamic_enums.rs
+++ b/glib-macros/tests/dynamic_enums.rs
@@ -150,6 +150,14 @@ mod module {
         assert_eq!(t.name(), "MyModuleEnum");
 
         let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+
+        let values = e.values();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].name(), "Foo");
+        assert_eq!(values[0].nick(), "foo");
+        assert_eq!(values[1].name(), "Bar");
+        assert_eq!(values[1].nick(), "bar");
+
         let v = e.value(0).expect("EnumClass::get_value(0) failed");
         assert_eq!(v.name(), "Foo");
         assert_eq!(v.nick(), "foo");
@@ -186,6 +194,14 @@ mod module {
         assert_eq!(t.name(), "MyModuleEnumLazy");
 
         let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+
+        let values = e.values();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].name(), "Foo");
+        assert_eq!(values[0].nick(), "foo");
+        assert_eq!(values[1].name(), "Bar");
+        assert_eq!(values[1].nick(), "bar");
+
         let v = e.value(0).expect("EnumClass::get_value(0) failed");
         assert_eq!(v.name(), "Foo");
         assert_eq!(v.nick(), "foo");
@@ -406,6 +422,14 @@ pub mod plugin {
         assert_eq!(t.name(), "MyPluginEnum");
 
         let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+
+        let values = e.values();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].name(), "Foo");
+        assert_eq!(values[0].nick(), "foo");
+        assert_eq!(values[1].name(), "Bar");
+        assert_eq!(values[1].nick(), "bar");
+
         let v = e.value(0).expect("EnumClass::get_value(0) failed");
         assert_eq!(v.name(), "Foo");
         assert_eq!(v.nick(), "foo");
@@ -442,6 +466,14 @@ pub mod plugin {
         assert_eq!(t.name(), "MyPluginEnumLazy");
 
         let e = glib::EnumClass::with_type(t).expect("EnumClass::new failed");
+
+        let values = e.values();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].name(), "Foo");
+        assert_eq!(values[0].nick(), "foo");
+        assert_eq!(values[1].name(), "Bar");
+        assert_eq!(values[1].nick(), "bar");
+
         let v = e.value(0).expect("EnumClass::get_value(0) failed");
         assert_eq!(v.name(), "Foo");
         assert_eq!(v.nick(), "foo");

--- a/glib-macros/tests/dynamic_objects.rs
+++ b/glib-macros/tests/dynamic_objects.rs
@@ -465,14 +465,6 @@ pub mod plugin {
                 };
             }
 
-            fn register_dynamic_enum(
-                &self,
-                _name: &str,
-                _const_static_values: &'static [glib::EnumValue],
-            ) -> glib::Type {
-                unimplemented!()
-            }
-
             fn register_dynamic_type(
                 &self,
                 parent_type: glib::Type,

--- a/glib-macros/tests/dynamic_objects.rs
+++ b/glib-macros/tests/dynamic_objects.rs
@@ -465,6 +465,14 @@ pub mod plugin {
                 };
             }
 
+            fn register_dynamic_enum(
+                &self,
+                _name: &str,
+                _const_static_values: &'static [glib::EnumValue],
+            ) -> glib::Type {
+                unimplemented!()
+            }
+
             fn register_dynamic_type(
                 &self,
                 parent_type: glib::Type,

--- a/glib-macros/tests/dynamic_objects.rs
+++ b/glib-macros/tests/dynamic_objects.rs
@@ -215,7 +215,7 @@ mod module {
         assert!(!imp::MyModuleInterfaceLazy::type_().is_valid());
         assert!(!imp::MyModuleTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to load/unload the module.
+        // simulates the GLib type system to load/unload the module.
         let module = glib::Object::new::<MyModule>();
         TypeModuleExt::use_(&module);
         TypeModuleExt::unuse(&module);
@@ -227,7 +227,7 @@ mod module {
         assert!(!imp::MyModuleInterfaceLazy::type_().is_valid());
         assert!(!imp::MyModuleTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to load the module.
+        // simulates the GLib type system to load the module.
         TypeModuleExt::use_(&module);
 
         // checks types of object subclasses and of object interfaces registered as dynamic types are valid (module is loaded).
@@ -258,25 +258,25 @@ mod module {
             Some(module.upcast_ref::<glib::TypePlugin>())
         );
 
-        // simulates the glib type system to unload the module.
+        // simulates the GLib type system to unload the module.
         TypeModuleExt::unuse(&module);
 
-        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid (should have been marked as unloaded by the glib type system but this cannot be checked).
+        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid (should have been marked as unloaded by the GLib type system but this cannot be checked).
         assert!(imp::MyModuleInterface::type_().is_valid());
         assert!(imp::MyModuleType::type_().is_valid());
         assert!(imp::MyModuleInterfaceLazy::type_().is_valid());
         assert!(imp::MyModuleTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to reload the module.
+        // simulates the GLib type system to reload the module.
         TypeModuleExt::use_(&module);
 
-        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid (should have been marked as unloaded by the glib type system but this cannot be checked).
+        // checks types of object subclasses and of object interfaces registered as dynamic types are still valid (should have been marked as unloaded by the GLib type system but this cannot be checked).
         assert!(imp::MyModuleInterface::type_().is_valid());
         assert!(imp::MyModuleType::type_().is_valid());
         assert!(imp::MyModuleInterfaceLazy::type_().is_valid());
         assert!(imp::MyModuleTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to unload the module.
+        // simulates the GLib type system to unload the module.
         TypeModuleExt::unuse(&module);
     }
 }
@@ -547,7 +547,7 @@ pub mod plugin {
         assert!(!imp::MyPluginInterfaceLazy::type_().is_valid());
         assert!(!imp::MyPluginTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to use/unuse the plugin.
+        // simulates the GLib type system to use/unuse the plugin.
         let plugin = glib::Object::new::<MyPlugin>();
         TypePluginExt::use_(&plugin);
         TypePluginExt::unuse(&plugin);
@@ -559,7 +559,7 @@ pub mod plugin {
         assert!(!imp::MyPluginInterfaceLazy::type_().is_valid());
         assert!(!imp::MyPluginTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to use the plugin.
+        // simulates the GLib type system to use the plugin.
         TypePluginExt::use_(&plugin);
 
         // checks types of object subclasses and of object interfaces registered as dynamic types are valid (plugin is used).
@@ -590,7 +590,7 @@ pub mod plugin {
             Some(plugin.upcast_ref::<glib::TypePlugin>())
         );
 
-        // simulates the glib type system to unuse the plugin.
+        // simulates the GLib type system to unuse the plugin.
         TypePluginExt::unuse(&plugin);
 
         // checks types of object subclasses and of object interfaces registered as dynamic types are still valid.
@@ -599,7 +599,7 @@ pub mod plugin {
         assert!(imp::MyPluginInterfaceLazy::type_().is_valid());
         assert!(imp::MyPluginTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to reuse the plugin.
+        // simulates the GLib type system to reuse the plugin.
         TypePluginExt::use_(&plugin);
 
         // checks types of object subclasses and of object interfaces registered as dynamic types are still valid.
@@ -608,7 +608,7 @@ pub mod plugin {
         assert!(imp::MyPluginInterfaceLazy::type_().is_valid());
         assert!(imp::MyPluginTypeLazy::type_().is_valid());
 
-        // simulates the glib type system to unuse the plugin.
+        // simulates the GLib type system to unuse the plugin.
         TypePluginExt::unuse(&plugin);
     }
 }

--- a/glib/Gir_GObject.toml
+++ b/glib/Gir_GObject.toml
@@ -24,6 +24,7 @@ manual = [
     "GLib.Quark",
     "GObject.Object",
     "GObject.Value",
+    "GObject.EnumValue",
     "GObject.TypeValueTable",
     "GObject.ParamFlags",
     "GObject.ParamSpec",

--- a/glib/src/enums.rs
+++ b/glib/src/enums.rs
@@ -194,11 +194,25 @@ impl EnumClass {
     /// callers should first create an `EnumClass` instance by calling `EnumClass::with_type()` which indirectly
     /// calls `TypePluginRegisterImpl::register_dynamic_enum()` and `TypePluginImpl::complete_type_info()`
     /// and one of them should call `EnumClass::with_type()` before calling this method.
+    /// `const_static_values` is an array of `EnumValue` for the possible enumeration values. The array must be
+    /// static to ensure enumeration values are never dropped, and must be terminated by an `EnumValue` with
+    /// all members being 0, as expected by GLib.
     #[doc(alias = "g_enum_complete_type_info")]
     pub fn complete_type_info(
         type_: Type,
         const_static_values: &'static [EnumValue],
     ) -> Option<TypeInfo> {
+        assert!(
+            !const_static_values.is_empty()
+                && const_static_values[const_static_values.len() - 1]
+                    == unsafe {
+                        EnumValue::unsafe_from(gobject_ffi::GEnumValue {
+                            value: 0,
+                            value_name: ::std::ptr::null(),
+                            value_nick: ::std::ptr::null(),
+                        })
+                    }
+        );
         unsafe {
             let is_enum: bool = from_glib(gobject_ffi::g_type_is_a(
                 type_.into_glib(),

--- a/glib/src/enums.rs
+++ b/glib/src/enums.rs
@@ -258,9 +258,12 @@ impl fmt::Debug for EnumValue {
 
 impl EnumValue {
     // rustdoc-stripper-ignore-next
-    /// Creates a new `EnumValue` containing `value`.
-    pub const fn new(value: gobject_ffi::GEnumValue) -> Self {
-        Self(value)
+    /// # Safety
+    ///
+    /// It is the responsibility of the caller to ensure `GEnumValue` is
+    /// valid.
+    pub const unsafe fn unsafe_from(g_value: gobject_ffi::GEnumValue) -> Self {
+        Self(g_value)
     }
 
     // rustdoc-stripper-ignore-next
@@ -323,6 +326,12 @@ impl PartialOrd for EnumValue {
 impl Ord for EnumValue {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         self.value().cmp(&other.value())
+    }
+}
+
+impl UnsafeFrom<gobject_ffi::GEnumValue> for EnumValue {
+    unsafe fn unsafe_from(g_value: gobject_ffi::GEnumValue) -> Self {
+        Self::unsafe_from(g_value)
     }
 }
 

--- a/glib/src/enums.rs
+++ b/glib/src/enums.rs
@@ -195,7 +195,10 @@ impl EnumClass {
     /// calls `TypePluginRegisterImpl::register_dynamic_enum()` and `TypePluginImpl::complete_type_info()`
     /// and one of them should call `EnumClass::with_type()` before calling this method.
     #[doc(alias = "g_enum_complete_type_info")]
-    pub fn type_info(type_: Type, const_static_values: &'static [EnumValue]) -> Option<TypeInfo> {
+    pub fn complete_type_info(
+        type_: Type,
+        const_static_values: &'static [EnumValue],
+    ) -> Option<TypeInfo> {
         unsafe {
             let is_enum: bool = from_glib(gobject_ffi::g_type_is_a(
                 type_.into_glib(),

--- a/glib/src/gobject/dynamic_object.rs
+++ b/glib/src/gobject/dynamic_object.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::{
-    prelude::*, subclass::prelude::*, EnumValue, InterfaceInfo, IsA, TypeFlags, TypeInfo,
+    enums::EnumValues, prelude::*, subclass::prelude::*, InterfaceInfo, IsA, TypeFlags, TypeInfo,
     TypeModule, TypePlugin,
 };
 
@@ -21,7 +21,7 @@ pub trait DynamicObjectRegisterExt: AsRef<TypePlugin> + sealed::Sealed + 'static
     fn register_dynamic_enum(
         &self,
         name: &str,
-        const_static_values: &'static [EnumValue],
+        const_static_values: &'static EnumValues,
     ) -> crate::types::Type;
 
     fn register_dynamic_type(
@@ -50,7 +50,7 @@ where
     fn register_dynamic_enum(
         &self,
         name: &str,
-        const_static_values: &'static [EnumValue],
+        const_static_values: &'static EnumValues,
     ) -> crate::types::Type {
         self.imp().register_dynamic_enum(name, const_static_values)
     }
@@ -80,7 +80,7 @@ impl DynamicObjectRegisterExt for TypeModule {
     fn register_dynamic_enum(
         &self,
         name: &str,
-        const_static_values: &'static [EnumValue],
+        const_static_values: &'static EnumValues,
     ) -> crate::types::Type {
         <Self as TypeModuleExt>::register_enum(self, name, const_static_values)
     }

--- a/glib/src/gobject/dynamic_object.rs
+++ b/glib/src/gobject/dynamic_object.rs
@@ -1,8 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::{
-    prelude::*, subclass::prelude::*, InterfaceInfo, IsA, TypeFlags, TypeInfo, TypeModule,
-    TypePlugin,
+    prelude::*, subclass::prelude::*, EnumValue, InterfaceInfo, IsA, TypeFlags, TypeInfo,
+    TypeModule, TypePlugin,
 };
 
 mod sealed {
@@ -17,6 +17,12 @@ pub trait DynamicObjectRegisterExt: AsRef<TypePlugin> + sealed::Sealed + 'static
         interface_type: crate::types::Type,
         interface_info: &InterfaceInfo,
     );
+
+    fn register_dynamic_enum(
+        &self,
+        name: &str,
+        const_static_values: &'static [EnumValue],
+    ) -> crate::types::Type;
 
     fn register_dynamic_type(
         &self,
@@ -41,6 +47,14 @@ where
             .add_dynamic_interface(instance_type, interface_type, interface_info);
     }
 
+    fn register_dynamic_enum(
+        &self,
+        name: &str,
+        const_static_values: &'static [EnumValue],
+    ) -> crate::types::Type {
+        self.imp().register_dynamic_enum(name, const_static_values)
+    }
+
     fn register_dynamic_type(
         &self,
         parent_type: crate::types::Type,
@@ -61,6 +75,14 @@ impl DynamicObjectRegisterExt for TypeModule {
         interface_info: &InterfaceInfo,
     ) {
         <Self as TypeModuleExt>::add_interface(self, instance_type, interface_type, interface_info);
+    }
+
+    fn register_dynamic_enum(
+        &self,
+        name: &str,
+        const_static_values: &'static [EnumValue],
+    ) -> crate::types::Type {
+        <Self as TypeModuleExt>::register_enum(self, name, const_static_values)
     }
 
     fn register_dynamic_type(

--- a/glib/src/gobject/type_module.rs
+++ b/glib/src/gobject/type_module.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{prelude::*, translate::*, InterfaceInfo, TypeFlags, TypeInfo, TypePlugin};
+use crate::{prelude::*, translate::*, EnumValue, InterfaceInfo, TypeFlags, TypeInfo, TypePlugin};
 
 crate::wrapper! {
     #[doc(alias = "GTypeModule")]
@@ -35,6 +35,21 @@ pub trait TypeModuleExt: IsA<TypeModule> + sealed::Sealed + 'static {
                 interface_type.into_glib(),
                 interface_info.as_ptr(),
             );
+        }
+    }
+
+    #[doc(alias = "g_type_module_register_enum")]
+    fn register_enum(
+        &self,
+        name: &str,
+        const_static_values: &'static [EnumValue],
+    ) -> crate::types::Type {
+        unsafe {
+            from_glib(gobject_ffi::g_type_module_register_enum(
+                self.as_ref().to_glib_none().0,
+                name.to_glib_none().0,
+                const_static_values.to_glib_none().0,
+            ))
         }
     }
 

--- a/glib/src/gobject/type_module.rs
+++ b/glib/src/gobject/type_module.rs
@@ -1,6 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::{prelude::*, translate::*, EnumValue, InterfaceInfo, TypeFlags, TypeInfo, TypePlugin};
+use crate::{
+    enums::EnumValues, prelude::*, translate::*, InterfaceInfo, TypeFlags, TypeInfo, TypePlugin,
+};
 
 crate::wrapper! {
     #[doc(alias = "GTypeModule")]
@@ -42,19 +44,8 @@ pub trait TypeModuleExt: IsA<TypeModule> + sealed::Sealed + 'static {
     fn register_enum(
         &self,
         name: &str,
-        const_static_values: &'static [EnumValue],
+        const_static_values: &'static EnumValues,
     ) -> crate::types::Type {
-        assert!(
-            !const_static_values.is_empty()
-                && const_static_values[const_static_values.len() - 1]
-                    == unsafe {
-                        EnumValue::unsafe_from(gobject_ffi::GEnumValue {
-                            value: 0,
-                            value_name: ::std::ptr::null(),
-                            value_nick: ::std::ptr::null(),
-                        })
-                    }
-        );
         unsafe {
             from_glib(gobject_ffi::g_type_module_register_enum(
                 self.as_ref().to_glib_none().0,

--- a/glib/src/gobject/type_module.rs
+++ b/glib/src/gobject/type_module.rs
@@ -44,6 +44,17 @@ pub trait TypeModuleExt: IsA<TypeModule> + sealed::Sealed + 'static {
         name: &str,
         const_static_values: &'static [EnumValue],
     ) -> crate::types::Type {
+        assert!(
+            !const_static_values.is_empty()
+                && const_static_values[const_static_values.len() - 1]
+                    == unsafe {
+                        EnumValue::unsafe_from(gobject_ffi::GEnumValue {
+                            value: 0,
+                            value_name: ::std::ptr::null(),
+                            value_nick: ::std::ptr::null(),
+                        })
+                    }
+        );
         unsafe {
             from_glib(gobject_ffi::g_type_module_register_enum(
                 self.as_ref().to_glib_none().0,

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -20,10 +20,7 @@ pub use self::{
     byte_array::ByteArray,
     bytes::Bytes,
     closure::{Closure, RustClosure},
-    enums::{
-        EnumClass, EnumValue, EnumValues, EnumValuesStorage, FlagsBuilder, FlagsClass, FlagsValue,
-        UserDirectory,
-    },
+    enums::{EnumClass, EnumValue, FlagsBuilder, FlagsClass, FlagsValue, UserDirectory},
     error::{BoolError, Error},
     object::{
         BorrowedObject, Cast, CastNone, Class, InitiallyUnowned, Interface, IsA, Object,
@@ -142,7 +139,7 @@ mod checksum;
 pub mod closure;
 mod convert;
 pub use self::convert::*;
-mod enums;
+pub mod enums;
 mod functions;
 pub use self::functions::*;
 mod key_file;

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -20,7 +20,10 @@ pub use self::{
     byte_array::ByteArray,
     bytes::Bytes,
     closure::{Closure, RustClosure},
-    enums::{EnumClass, EnumValue, FlagsBuilder, FlagsClass, FlagsValue, UserDirectory},
+    enums::{
+        EnumClass, EnumValue, EnumValues, EnumValuesStorage, FlagsBuilder, FlagsClass, FlagsValue,
+        UserDirectory,
+    },
     error::{BoolError, Error},
     object::{
         BorrowedObject, Cast, CastNone, Class, InitiallyUnowned, Interface, IsA, Object,

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -10,8 +10,8 @@ pub use ffi;
 pub use glib_macros::cstr_bytes;
 pub use glib_macros::{
     clone, closure, closure_local, derived_properties, dynamic_object_interface,
-    dynamic_object_subclass, flags, object_interface, object_subclass, Boxed, Downgrade, Enum,
-    ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
+    dynamic_object_subclass, flags, object_interface, object_subclass, Boxed, Downgrade,
+    DynamicEnum, Enum, ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
 };
 pub use gobject_ffi;
 pub use once_cell;

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -347,6 +347,10 @@
 //!             unimplemented!()
 //!         }
 //!
+//!         fn register_dynamic_enum(&self, _: &str, _: &'static [glib::EnumValue]) -> glib::Type {
+//!             unimplemented!()
+//!         }
+//!
 //!         fn register_dynamic_type(&self, parent_type: glib::Type, type_name: &str, type_info: &glib::TypeInfo, flags: glib::TypeFlags) -> glib::Type {
 //!             let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
 //!                 glib::Type::register_dynamic(parent_type, type_name, self.obj().upcast_ref::<glib::TypePlugin>(), flags)

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -343,14 +343,6 @@
 //!     }
 //!
 //!     impl TypePluginRegisterImpl for SimpleTypePlugin {
-//!         fn add_dynamic_interface(&self, _: glib::Type, _: glib::Type, _: &glib::InterfaceInfo) {
-//!             unimplemented!()
-//!         }
-//!
-//!         fn register_dynamic_enum(&self, _: &str, _: &'static [glib::EnumValue]) -> glib::Type {
-//!             unimplemented!()
-//!         }
-//!
 //!         fn register_dynamic_type(&self, parent_type: glib::Type, type_name: &str, type_info: &glib::TypeInfo, flags: glib::TypeFlags) -> glib::Type {
 //!             let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
 //!                 glib::Type::register_dynamic(parent_type, type_name, self.obj().upcast_ref::<glib::TypePlugin>(), flags)

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -275,7 +275,7 @@
 //!     let simple_module_object_type = imp::SimpleModuleObject::type_();
 //!     assert!(!simple_module_object_type.is_valid());
 //!
-//!     // simulates the glib type system to load the module.
+//!     // simulates the GLib type system to load the module.
 //!     TypeModuleExt::use_(&simple_type_module);
 //!
 //!     // at this step, SimpleModuleObject must have been registered.
@@ -389,7 +389,7 @@
 //!     let simple_plugin_object_type = imp::SimplePluginObject::type_();
 //!     assert!(!simple_plugin_object_type.is_valid());
 //!
-//!     // simulates the glib type system to use the plugin.
+//!     // simulates the GLib type system to use the plugin.
 //!     TypePluginExt::use_(&simple_type_plugin);
 //!
 //!     // at this step, SimplePluginObject must have been registered.

--- a/glib/src/subclass/type_module.rs
+++ b/glib/src/subclass/type_module.rs
@@ -156,7 +156,7 @@ mod tests {
     fn test_module() {
         assert!(!imp::SimpleModuleType::type_().is_valid());
         let simple_module = glib::Object::new::<SimpleModule>();
-        // simulates the glib type system to load the module.
+        // simulates the GLib type system to load the module.
         assert!(simple_module.use_());
         assert!(imp::SimpleModuleType::type_().is_valid());
         simple_module.unuse();

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -1,12 +1,12 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use crate::enums::EnumValues;
 use crate::translate::IntoGlib;
 use crate::translate::{FromGlib, ToGlibPtr};
 use crate::{
-    subclass::prelude::*, Cast, Interface, InterfaceInfo, Type, TypeInfo, TypePlugin,
+    subclass::prelude::*, Cast, Interface, InterfaceInfo, Type, TypeFlags, TypeInfo, TypePlugin,
     TypeValueTable,
 };
-use crate::{EnumValue, TypeFlags};
 
 pub trait TypePluginImpl: ObjectImpl + TypePluginImplExt {
     fn use_plugin(&self) {
@@ -189,7 +189,7 @@ pub trait TypePluginRegisterImpl: ObjectImpl + TypePluginImpl {
     fn register_dynamic_enum(
         &self,
         _name: &str,
-        _const_static_values: &'static [EnumValue],
+        _const_static_values: &'static EnumValues,
     ) -> Type {
         unimplemented!()
     }

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -2,11 +2,11 @@
 
 use crate::translate::IntoGlib;
 use crate::translate::{FromGlib, ToGlibPtr};
-use crate::TypeFlags;
 use crate::{
     subclass::prelude::*, Cast, Interface, InterfaceInfo, Type, TypeInfo, TypePlugin,
     TypeValueTable,
 };
+use crate::{EnumValue, TypeFlags};
 
 pub trait TypePluginImpl: ObjectImpl + TypePluginImplExt {
     fn use_plugin(&self) {
@@ -184,7 +184,11 @@ pub trait TypePluginRegisterImpl: ObjectImpl + TypePluginImpl {
         _interface_type: Type,
         _interface_info: &InterfaceInfo,
     );
-
+    fn register_dynamic_enum(
+        &self,
+        _name: &str,
+        _const_static_values: &'static [EnumValue],
+    ) -> Type;
     fn register_dynamic_type(
         &self,
         _parent_type: Type,
@@ -242,6 +246,14 @@ mod tests {
                 _interface_type: Type,
                 _interface_info: &InterfaceInfo,
             ) {
+                unimplemented!()
+            }
+
+            fn register_dynamic_enum(
+                &self,
+                _name: &str,
+                _const_static_values: &'static [EnumValue],
+            ) -> Type {
                 unimplemented!()
             }
 

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -305,7 +305,7 @@ mod tests {
     fn test_plugin() {
         assert!(!imp::SimplePluginType::type_().is_valid());
         let simple_plugin = crate::Object::new::<SimplePlugin>();
-        // simulates the glib type system to use the plugin.
+        // simulates the GLib type system to use the plugin.
         TypePluginExt::use_(&simple_plugin);
         assert!(imp::SimplePluginType::type_().is_valid());
         TypePluginExt::unuse(&simple_plugin);

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -183,19 +183,25 @@ pub trait TypePluginRegisterImpl: ObjectImpl + TypePluginImpl {
         _instance_type: Type,
         _interface_type: Type,
         _interface_info: &InterfaceInfo,
-    );
+    ) {
+        unimplemented!()
+    }
     fn register_dynamic_enum(
         &self,
         _name: &str,
         _const_static_values: &'static [EnumValue],
-    ) -> Type;
+    ) -> Type {
+        unimplemented!()
+    }
     fn register_dynamic_type(
         &self,
         _parent_type: Type,
         _type_name: &str,
         _type_info: &TypeInfo,
         _flags: TypeFlags,
-    ) -> Type;
+    ) -> Type {
+        unimplemented!()
+    }
 }
 
 #[cfg(test)]
@@ -240,23 +246,6 @@ mod tests {
         }
 
         impl TypePluginRegisterImpl for SimplePlugin {
-            fn add_dynamic_interface(
-                &self,
-                _instance_type: Type,
-                _interface_type: Type,
-                _interface_info: &InterfaceInfo,
-            ) {
-                unimplemented!()
-            }
-
-            fn register_dynamic_enum(
-                &self,
-                _name: &str,
-                _const_static_values: &'static [EnumValue],
-            ) -> Type {
-                unimplemented!()
-            }
-
             fn register_dynamic_type(
                 &self,
                 parent_type: Type,


### PR DESCRIPTION
This PR aims to add support of enums registered as dynamic types. See [https://docs.gtk.org/gobject/class.TypeModule.html](https://docs.gtk.org/gobject/class.TypeModule.html)  and [https://docs.gtk.org/gobject/iface.TypePlugin.html](https://docs.gtk.org/gobject/iface.TypePlugin.html).
The new macro `dynamic_enum_derive` allows to register enums that are part of a module or of a plugin (e.g. a shared library on linux). The macro mimic `enum_derive` but generates code that support registration when the plugin (`TypePlugin`) is used, following the behavior defined in Glib doc. However it is possible to postpone the registration at first use of the enum (like within `enum_derive`) by explicitly setting the macro attribute `lazy_registration = true`.
Some examples in [glib-macros/tests/dynamic_enums.rs](https://github.com/fbrouille/gtk-rs-core/blob/68da73d2a5a1292ac9f0c1ebfc9a11e61feb0330/glib-macros/tests/dynamic_enums.rs)