### PR TITLE
Move from unmaintained winapi crate to windows-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,18 +162,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -281,9 +281,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.21"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
- "winapi",
+ "windows-sys 0.52.0",
  "x11",
 ]
 
@@ -286,7 +286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -478,7 +478,7 @@ dependencies = [
  "shell-words",
  "system-deps",
  "tempfile",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -639,7 +639,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -989,7 +989,7 @@ dependencies = [
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1002,7 +1002,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1473,7 +1473,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1482,13 +1491,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -1498,10 +1522,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1510,10 +1546,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1522,16 +1570,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/cairo/src/win32_surface.rs
+++ b/cairo/src/win32_surface.rs
@@ -2,7 +2,7 @@
 
 use std::{convert::TryFrom, ops::Deref};
 
-pub use ffi::winapi;
+pub use ffi::windows;
 #[cfg(feature = "use_glib")]
 use glib::translate::*;
 
@@ -12,12 +12,12 @@ declare_surface!(Win32Surface, SurfaceType::Win32);
 
 impl Win32Surface {
     #[doc(alias = "cairo_win32_surface_create")]
-    pub fn create(hdc: winapi::HDC) -> Result<Win32Surface, Error> {
+    pub fn create(hdc: windows::HDC) -> Result<Win32Surface, Error> {
         unsafe { Self::from_raw_full(ffi::cairo_win32_surface_create(hdc)) }
     }
 
     #[doc(alias = "cairo_win32_surface_create_with_format")]
-    pub fn create_with_format(hdc: winapi::HDC, format: Format) -> Result<Win32Surface, Error> {
+    pub fn create_with_format(hdc: windows::HDC, format: Format) -> Result<Win32Surface, Error> {
         unsafe {
             Self::from_raw_full(ffi::cairo_win32_surface_create_with_format(
                 hdc,
@@ -39,7 +39,7 @@ impl Win32Surface {
 
     #[doc(alias = "cairo_win32_surface_create_with_ddb")]
     pub fn create_with_ddb(
-        hdc: winapi::HDC,
+        hdc: windows::HDC,
         format: Format,
         width: i32,
         height: i32,
@@ -55,7 +55,7 @@ impl Win32Surface {
     }
 
     #[doc(alias = "cairo_win32_printing_surface_create")]
-    pub fn printing_surface_create(hdc: winapi::HDC) -> Result<Win32Surface, Error> {
+    pub fn printing_surface_create(hdc: windows::HDC) -> Result<Win32Surface, Error> {
         unsafe { Self::from_raw_full(ffi::cairo_win32_printing_surface_create(hdc)) }
     }
 }

--- a/cairo/sys/Cargo.toml
+++ b/cairo/sys/Cargo.toml
@@ -47,7 +47,7 @@ freetype = []
 script = []
 xcb = []
 use_glib = ["glib"]
-win32-surface = ["winapi"]
+win32-surface = ["windows-sys"]
 
 [dependencies]
 libc = "0.2"
@@ -63,7 +63,7 @@ version = "2.16"
 features = ["xlib"]
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.2", features = ["windef"], optional = true }
+windows-sys = { version = "0.52", features = ["Win32_Graphics_Gdi"], optional = true }
 
 [build-dependencies]
 system-deps = "6"

--- a/cairo/sys/src/lib.rs
+++ b/cairo/sys/src/lib.rs
@@ -6,18 +6,10 @@
 #![allow(clippy::upper_case_acronyms)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-extern crate libc;
-
-#[cfg(feature = "xlib")]
-extern crate x11;
-
-#[cfg(all(windows, feature = "win32-surface"))]
-extern crate winapi as winapi_orig;
-
 #[cfg(all(windows, feature = "win32-surface"))]
 #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
-pub mod winapi {
-    pub use winapi_orig::shared::windef::HDC;
+pub mod windows {
+    pub use windows_sys::Win32::Graphics::Gdi::HDC;
 }
 
 #[cfg(all(docsrs, not(all(windows, feature = "win32-surface"))))]
@@ -25,7 +17,7 @@ pub mod winapi {
     docsrs,
     doc(cfg(all(docsrs, not(all(windows, feature = "win32-surface")))))
 )]
-pub mod winapi {
+pub mod windows {
     use libc::c_void;
 
     #[repr(C)]
@@ -1472,11 +1464,11 @@ extern "C" {
     // CAIRO WINDOWS SURFACE
     #[cfg(all(windows, feature = "win32-surface"))]
     #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
-    pub fn cairo_win32_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
+    pub fn cairo_win32_surface_create(hdc: windows::HDC) -> *mut cairo_surface_t;
     #[cfg(all(windows, feature = "win32-surface"))]
     #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
     pub fn cairo_win32_surface_create_with_format(
-        hdc: winapi::HDC,
+        hdc: windows::HDC,
         format: cairo_format_t,
     ) -> *mut cairo_surface_t;
     #[cfg(all(windows, feature = "win32-surface"))]
@@ -1489,17 +1481,17 @@ extern "C" {
     #[cfg(all(windows, feature = "win32-surface"))]
     #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
     pub fn cairo_win32_surface_create_with_ddb(
-        hdc: winapi::HDC,
+        hdc: windows::HDC,
         format: cairo_format_t,
         width: c_int,
         height: c_int,
     ) -> *mut cairo_surface_t;
     #[cfg(all(windows, feature = "win32-surface"))]
     #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
-    pub fn cairo_win32_printing_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
+    pub fn cairo_win32_printing_surface_create(hdc: windows::HDC) -> *mut cairo_surface_t;
     #[cfg(all(windows, feature = "win32-surface"))]
     #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
-    pub fn cairo_win32_surface_get_dc(surface: *mut cairo_surface_t) -> winapi::HDC;
+    pub fn cairo_win32_surface_get_dc(surface: *mut cairo_surface_t) -> windows::HDC;
     #[cfg(all(windows, feature = "win32-surface"))]
     #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
     pub fn cairo_win32_surface_get_image(surface: *mut cairo_surface_t) -> *mut cairo_surface_t;

--- a/gio/sys/Cargo.toml
+++ b/gio/sys/Cargo.toml
@@ -12,9 +12,9 @@ path = "../../glib/sys"
 package = "gobject-sys"
 path = "../../glib/gobject-sys"
 
-[target."cfg(windows)".dependencies.winapi]
-version = "0.3.9"
-features = ["ws2def", "winsock2"]
+[target."cfg(windows)".dependencies.windows-sys]
+version = "0.52"
+features = ["Win32_Networking_WinSock"]
 
 [dev-dependencies]
 shell-words = "1.0.0"

--- a/gio/sys/src/manual.rs
+++ b/gio/sys/src/manual.rs
@@ -10,15 +10,22 @@ pub type GSocketMsgFlags = libc::c_int;
 
 #[cfg(target_family = "windows")]
 mod windows_constants {
-    pub const G_SOCKET_FAMILY_INVALID: super::GSocketFamily = winapi::shared::ws2def::AF_UNSPEC;
-    pub const G_SOCKET_FAMILY_UNIX: super::GSocketFamily = winapi::shared::ws2def::AF_UNIX;
-    pub const G_SOCKET_FAMILY_IPV4: super::GSocketFamily = winapi::shared::ws2def::AF_INET;
-    pub const G_SOCKET_FAMILY_IPV6: super::GSocketFamily = winapi::shared::ws2def::AF_INET6;
+    pub const G_SOCKET_FAMILY_INVALID: super::GSocketFamily =
+        windows_sys::Win32::Networking::WinSock::AF_UNSPEC as super::GSocketFamily;
+    pub const G_SOCKET_FAMILY_UNIX: super::GSocketFamily =
+        windows_sys::Win32::Networking::WinSock::AF_UNIX as super::GSocketFamily;
+    pub const G_SOCKET_FAMILY_IPV4: super::GSocketFamily =
+        windows_sys::Win32::Networking::WinSock::AF_INET as super::GSocketFamily;
+    pub const G_SOCKET_FAMILY_IPV6: super::GSocketFamily =
+        windows_sys::Win32::Networking::WinSock::AF_INET6 as super::GSocketFamily;
 
     pub const G_SOCKET_MSG_NONE: super::GSocketMsgFlags = 0;
-    pub const G_SOCKET_MSG_OOB: super::GSocketMsgFlags = winapi::um::winsock2::MSG_OOB;
-    pub const G_SOCKET_MSG_PEEK: super::GSocketMsgFlags = winapi::um::winsock2::MSG_PEEK;
-    pub const G_SOCKET_MSG_DONTROUTE: super::GSocketMsgFlags = winapi::um::winsock2::MSG_DONTROUTE;
+    pub const G_SOCKET_MSG_OOB: super::GSocketMsgFlags =
+        windows_sys::Win32::Networking::WinSock::MSG_OOB;
+    pub const G_SOCKET_MSG_PEEK: super::GSocketMsgFlags =
+        windows_sys::Win32::Networking::WinSock::MSG_PEEK;
+    pub const G_SOCKET_MSG_DONTROUTE: super::GSocketMsgFlags =
+        windows_sys::Win32::Networking::WinSock::MSG_DONTROUTE;
 }
 
 #[cfg(not(target_family = "windows"))]


### PR DESCRIPTION
windows-sys / windows is also used by the gdk4-win32 crate.