### PR TITLE
glib: Deprecate main context channel

### DIFF
--- a/glib/src/main_context_channel.rs
+++ b/glib/src/main_context_channel.rs
@@ -539,6 +539,7 @@ impl MainContext {
     /// will fail.
     ///
     /// The returned `Sender` behaves the same as `std::sync::mpsc::Sender`.
+    #[deprecated = "Use an async channel on the main context instead"]
     pub fn channel<T>(priority: Priority) -> (Sender<T>, Receiver<T>) {
         let channel = Channel::new(None);
         let receiver = Receiver(Some(channel.clone()), priority);
@@ -562,6 +563,7 @@ impl MainContext {
     /// will fail.
     ///
     /// The returned `SyncSender` behaves the same as `std::sync::mpsc::SyncSender`.
+    #[deprecated = "Use an async channel on the main context instead"]
     pub fn sync_channel<T>(priority: Priority, bound: usize) -> (SyncSender<T>, Receiver<T>) {
         let channel = Channel::new(Some(bound));
         let receiver = Receiver(Some(channel.clone()), priority);
@@ -572,6 +574,7 @@ impl MainContext {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use std::{
         cell::RefCell,


### PR DESCRIPTION
It was already removed in git master and giving an advance warning seems useful so people already port now if possible.