### PR TITLE
gio: return NULL from spawn_blocking's underlying gtask

### DIFF
--- a/gio/src/task.rs
+++ b/gio/src/task.rs
@@ -433,9 +433,10 @@ where
     // use Cancellable::NONE as source obj to fulfill `Send` requirement
     let task = unsafe { Task::<bool>::new(Cancellable::NONE, Cancellable::NONE, |_, _| {}) };
     let (join, tx) = JoinHandle::new();
-    task.run_in_thread(move |_, _: Option<&Cancellable>, _| {
+    task.run_in_thread(move |task, _: Option<&Cancellable>, _| {
         let res = panic::catch_unwind(panic::AssertUnwindSafe(func));
         let _ = tx.send(res);
+        unsafe { ffi::g_task_return_pointer(task.to_glib_none().0, ptr::null_mut(), None) }
     });
 
     join


### PR DESCRIPTION
This tells GIO that the task did in fact complete, and avoids a log message when the task is finalised