### PR TITLE
macros: generate GlibPtrDefault when deriving Boxed and SharedBoxed

### DIFF
--- a/glib-macros/src/boxed_derive.rs
+++ b/glib-macros/src/boxed_derive.rs
@@ -197,6 +197,10 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> TokenStream {
 
         #impl_from_value
 
+        impl #crate_ident::translate::GlibPtrDefault for #name {
+            type GlibType = *mut #name;
+        }
+
         impl #crate_ident::translate::FromGlibPtrBorrow<*const #name> for #name {
             #[inline]
             unsafe fn from_glib_borrow(ptr: *const #name) -> #crate_ident::translate::Borrowed<Self> {

--- a/glib-macros/src/shared_boxed_derive.rs
+++ b/glib-macros/src/shared_boxed_derive.rs
@@ -218,6 +218,10 @@ pub fn impl_shared_boxed(input: &syn::DeriveInput) -> proc_macro2::TokenStream {
 
         #impl_from_value
 
+        impl #crate_ident::translate::GlibPtrDefault for #name {
+            type GlibType = *mut #refcounted_type_prefix::InnerType;
+        }
+
         impl #crate_ident::translate::FromGlibPtrBorrow<*const #refcounted_type_prefix::InnerType> for #name {
             #[inline]
             unsafe fn from_glib_borrow(ptr: *const #refcounted_type_prefix::InnerType) -> #crate_ident::translate::Borrowed<Self> {


### PR DESCRIPTION
As far as I understand this is needed to make To/FromGlibContainer traits work