### PR TITLE
Refactor macros to register dynamic types

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -459,65 +459,54 @@ pub fn closure_local(item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// [`glib::Value`]: ../glib/value/struct.Value.html
-#[proc_macro_derive(Enum, attributes(enum_type, enum_value))]
-#[proc_macro_error]
-pub fn enum_derive(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    let gen = enum_derive::impl_enum(&input);
-    gen.into()
-}
-
-/// Derive macro for register a Rust enum in the GLib type system as a dynamic
-/// type and derive the [`glib::Value`] traits.
-///
-/// An enum must be explicitly registered as a dynamic type when the system
-/// loads its implementation (see [`TypePlugin`] and [`TypeModule`].
-/// Therefore, whereas an enum can be registered only once as a static type,
-/// it can be registered several times as a dynamic type.
-///
-/// An enum registered as a dynamic type is never unregistered. The system
-/// calls [`TypePluginExt::unuse`] to unload its implementation. If the
-/// [`TypePlugin`] subclass is a [`TypeModule`], the enum registered as a
-/// dynamic type is marked as unloaded and must be registered again when the
-/// module is reloaded.
-///
-/// This macro provides two behaviors when registering an enum as a dynamic
-/// type:
-///
-/// By default an enum is registered as a dynamic type when the system loads
-/// its implementation (e.g. when the module is loaded):
+/// An enum can be registered as a dynamic type by setting the derive macro
+/// helper attribute `enum_dynamic`:
 /// ```ignore
 /// use glib::prelude::*;
 /// use glib::subclass::prelude::*;
 ///
-/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::DynamicEnum)]
+/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::Enum)]
 /// #[enum_type(name = "MyEnum")]
-/// enum MyEnum {
-///     Val,
-///     #[enum_value(name = "My Val")]
-///     ValWithCustomName,
-///     #[enum_value(name = "My Other Val", nick = "other")]
-///     ValWithCustomNameAndNick,
-/// }
-/// ```
-///
-/// Optionally setting the macro attribute `lazy_registration` to `true`
-/// postpones registration on the first use (when `static_type()` is called for
-/// the first time), similarly to the [`macro@enum_derive`] macro:
-/// ```ignore
-/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::DynamicEnum)]
-/// #[enum_type(name = "MyEnum", lazy_registration = true)]
+/// #[enum_dynamic]
 /// enum MyEnum {
 ///     ...
 /// }
 /// ```
 ///
-/// An enum is usually registered as a dynamic type within a [`TypeModule`]
-/// subclass:
+/// As a dynamic type, an enum must be explicitly registered when the system
+/// loads the implementation (see [`TypePlugin`] and [`TypeModule`].
+/// Therefore, whereas an enum can be registered only once as a static type,
+/// it can be registered several times as a dynamic type.
+///
+/// An enum registered as a dynamic type is never unregistered. The system
+/// calls [`TypePluginExt::unuse`] to unload the implementation. If the
+/// [`TypePlugin`] subclass is a [`TypeModule`], the enum registered as a
+/// dynamic type is marked as unloaded and must be registered again when the
+/// module is reloaded.
+///
+/// The derive macro helper attribute `enum_dynamic` provides two behaviors
+/// when registering an enum as a dynamic type:
+///
+/// - lazy registration: by default an enum is registered as a dynamic type
+/// when the system loads the implementation (e.g. when the module is loaded).
+/// Optionally setting `lazy_registration` to `true` postpones registration on
+/// the first use (when `static_type()` is called for the first time):
 /// ```ignore
-/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::DynamicEnum)]
+/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::Enum)]
+/// #[enum_type(name = "MyEnum")]
+/// #[enum_dynamic(lazy_registration = true)]
+/// enum MyEnum {
+///     ...
+/// }
+/// ```
+///
+/// - registration within [`TypeModule`] subclass or within [`TypePlugin`]
+/// subclass: an enum is usually registered as a dynamic type within a
+/// [`TypeModule`] subclass:
+/// ```ignore
+/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::Enum)]
 /// #[enum_type(name = "MyModuleEnum")]
+/// #[enum_dynamic]
 /// enum MyModuleEnum {
 ///     ...
 /// }
@@ -536,11 +525,12 @@ pub fn enum_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Optionally setting the macro attribute `plugin_type` allows to register an
-/// enum as a dynamic type within a given [`TypePlugin`] subclass:
+/// Optionally setting `plugin_type` allows to register an enum as a dynamic
+/// type within a [`TypePlugin`] subclass that is not a [`TypeModule`]:
 /// ```ignore
-/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::DynamicEnum)]
-/// #[enum_type(name = "MyPluginEnum", plugin_type = MyPlugin)]
+/// #[derive(Debug, Copy, Clone, PartialEq, Eq, glib::Enum)]
+/// #[enum_type(name = "MyPluginEnum")]
+/// #[enum_dynamic(plugin_type = MyPlugin)]
 /// enum MyPluginEnum {
 ///     ...
 /// }
@@ -561,12 +551,12 @@ pub fn enum_derive(input: TokenStream) -> TokenStream {
 /// [`glib::Value`]: ../glib/value/struct.Value.html
 /// [`TypePlugin`]: ../glib/gobject/type_plugin/struct.TypePlugin.html
 /// [`TypeModule`]: ../glib/gobject/type_module/struct.TypeModule.html
-/// [`TypePluginExt::unuse`]: ../glib/gobject/type_plugin/trait.TypePluginExt.html#method.unuse
-#[proc_macro_derive(DynamicEnum, attributes(enum_type, enum_value))]
+/// [`TypePluginExt::unuse`]: ../glib/gobject/type_plugin/trait.TypePluginExt.
+#[proc_macro_derive(Enum, attributes(enum_type, enum_dynamic, enum_value))]
 #[proc_macro_error]
-pub fn dynamic_enum_derive(input: TokenStream) -> TokenStream {
+pub fn enum_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let gen = enum_derive::impl_dynamic_enum(&input);
+    let gen = enum_derive::impl_enum(&input);
     gen.into()
 }
 

--- a/glib-macros/src/object_interface_attribute.rs
+++ b/glib-macros/src/object_interface_attribute.rs
@@ -4,21 +4,101 @@ use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
 use quote::{quote, ToTokens};
 
-pub const WRONG_EXPRESSION_MSG: &str =
-    "This macro's attributes should be a sequence of assign expressions punctuated by comma";
-
-pub const UNSUPPORTED_EXPRESSION_MSG: &str =
-    "This macro's supported attributes are: `plugin_type = <subclass_of_glib::TypePlugin>, lazy_registration = true|false`";
+use crate::utils::{parse_optional_nested_meta_items, NestedMetaItem};
 
 pub const WRONG_PLACE_MSG: &str =
     "This macro should be used on `impl` block for `glib::ObjectInterface` trait";
 
-pub fn impl_object_interface(input: &syn::ItemImpl) -> TokenStream {
+pub fn impl_object_interface(input: &mut syn::ItemImpl) -> TokenStream {
     let crate_ident = crate::utils::crate_ident_new();
-    let syn::ItemImpl { self_ty, .. } = &input;
+    let syn::ItemImpl {
+        attrs,
+        generics,
+        trait_,
+        self_ty,
+        unsafety,
+        items,
+        ..
+    } = input;
 
+    let mut plugin_type = NestedMetaItem::<syn::Path>::new("plugin_type").value_required();
+    let mut lazy_registration =
+        NestedMetaItem::<syn::LitBool>::new("lazy_registration").value_required();
+
+    let found = parse_optional_nested_meta_items(
+        &*attrs,
+        "object_interface_dynamic",
+        &mut [&mut plugin_type, &mut lazy_registration],
+    );
+
+    let register_object_interface = match found {
+        Err(e) => return e.to_compile_error(),
+        Ok(None) => register_object_interface_as_static(&crate_ident, self_ty),
+        Ok(Some(_)) => {
+            // remove attribute 'object_interface_dynamic' from the attribute list because it is not a real proc_macro_attribute
+            attrs.retain(|attr| !attr.path().is_ident("object_interface_dynamic"));
+            let plugin_ty = plugin_type
+                .value
+                .map(|p| p.into_token_stream())
+                .unwrap_or(quote!(#crate_ident::TypeModule));
+            let lazy_registration = lazy_registration.value.map(|b| b.value).unwrap_or_default();
+            register_object_interface_as_dynamic(
+                &crate_ident,
+                self_ty,
+                plugin_ty,
+                lazy_registration,
+            )
+        }
+    };
+
+    let mut has_prerequisites = false;
+    for item in items.iter() {
+        if let syn::ImplItem::Type(type_) = item {
+            let name = type_.ident.to_string();
+            if name == "Prerequisites" {
+                has_prerequisites = true;
+            }
+        }
+    }
+
+    let prerequisites_opt = if has_prerequisites {
+        None
+    } else {
+        Some(quote!(
+            type Prerequisites = ();
+        ))
+    };
+
+    let trait_path = match &trait_ {
+        Some(path) => &path.1,
+        None => abort_call_site!(WRONG_PLACE_MSG),
+    };
+
+    quote! {
+        #(#attrs)*
+        #unsafety impl #generics #trait_path for #self_ty {
+            #prerequisites_opt
+            #(#items)*
+        }
+
+        unsafe impl #crate_ident::subclass::interface::ObjectInterfaceType for #self_ty {
+            #[inline]
+            fn type_() -> #crate_ident::Type {
+                Self::register_interface()
+            }
+        }
+
+        #register_object_interface
+    }
+}
+
+// Registers the object interface as a static type.
+fn register_object_interface_as_static(
+    crate_ident: &TokenStream,
+    self_ty: &syn::Type,
+) -> TokenStream {
     // registers the interface on first use (lazy registration).
-    let register_interface = quote! {
+    quote! {
         impl #self_ty {
             /// Registers the interface only once.
             #[inline]
@@ -35,60 +115,20 @@ pub fn impl_object_interface(input: &syn::ItemImpl) -> TokenStream {
                 }
             }
         }
-    };
-
-    impl_object_interface_(register_interface, input)
+    }
 }
 
-pub fn impl_dynamic_object_interface(
-    attrs: &syn::punctuated::Punctuated<syn::Expr, syn::Token![,]>,
-    input: &syn::ItemImpl,
+// The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt`] and [`TypeModuleExt`]).
+// An object interface can be reregistered as a dynamic type.
+fn register_object_interface_as_dynamic(
+    crate_ident: &TokenStream,
+    self_ty: &syn::Type,
+    plugin_ty: TokenStream,
+    lazy_registration: bool,
 ) -> TokenStream {
-    let crate_ident = crate::utils::crate_ident_new();
-    let syn::ItemImpl { self_ty, .. } = &input;
-
-    let mut plugin_type_opt: Option<syn::Path> = None;
-    let mut lazy_registration_opt: Option<bool> = None;
-
-    for attr in attrs {
-        match attr {
-            // attribute must be one of supported assign expressions.
-            syn::Expr::Assign(syn::ExprAssign { left, right, .. }) => {
-                match (*left.to_owned(), *right.to_owned()) {
-                    // `plugin_type = <subclass_of_TypePlugin>`
-                    (
-                        syn::Expr::Path(syn::ExprPath { path: path1, .. }),
-                        syn::Expr::Path(syn::ExprPath { path: path2, .. }),
-                    ) if path1.is_ident(&"plugin_type") => plugin_type_opt = Some(path2),
-                    // `lazy_registration = true|false`
-                    (
-                        syn::Expr::Path(syn::ExprPath { path, .. }),
-                        syn::Expr::Lit(syn::ExprLit {
-                            lit: syn::Lit::Bool(syn::LitBool { value, .. }),
-                            ..
-                        }),
-                    ) if path.is_ident(&"lazy_registration") => lazy_registration_opt = Some(value),
-                    _ => abort_call_site!(UNSUPPORTED_EXPRESSION_MSG),
-                };
-            }
-            _ => abort_call_site!(WRONG_EXPRESSION_MSG),
-        };
-    }
-
-    let (plugin_ty, lazy_registration) = match (plugin_type_opt, lazy_registration_opt) {
-        (Some(type_plugin), lazy_registration_opt) => (
-            type_plugin.into_token_stream(),
-            lazy_registration_opt.unwrap_or_default(),
-        ),
-        (None, lazy_registration_opt) => (
-            quote!(#crate_ident::TypeModule),
-            lazy_registration_opt.unwrap_or_default(),
-        ),
-    };
-
     // The following implementations follows the lifecycle of plugins and of dynamic types (see [`TypePluginExt`] and [`TypeModuleExt`]).
     // An object interface can be reregistered as a dynamic type.
-    let register_interface = if lazy_registration {
+    if lazy_registration {
         // registers the object interface as a dynamic type on the first use (lazy registration).
         // a weak reference on the plugin is stored and will be used later on the first use of the object interface.
         // this implementation relies on a static storage of a weak reference on the plugin and of the GLib type to know if the object interface has been registered.
@@ -201,64 +241,5 @@ pub fn impl_dynamic_object_interface(
                 }
             }
         }
-    };
-
-    impl_object_interface_(register_interface, input)
-}
-
-pub fn impl_object_interface_(
-    register_interface: TokenStream,
-    input: &syn::ItemImpl,
-) -> TokenStream {
-    let mut has_prerequisites = false;
-    for item in &input.items {
-        if let syn::ImplItem::Type(type_) = item {
-            let name = type_.ident.to_string();
-            if name == "Prerequisites" {
-                has_prerequisites = true;
-            }
-        }
-    }
-
-    let syn::ItemImpl {
-        attrs,
-        generics,
-        trait_,
-        self_ty,
-        unsafety,
-        items,
-        ..
-    } = &input;
-
-    let prerequisites_opt = if has_prerequisites {
-        None
-    } else {
-        Some(quote!(
-            type Prerequisites = ();
-        ))
-    };
-
-    let crate_ident = crate::utils::crate_ident_new();
-
-    let trait_path = match &trait_ {
-        Some(path) => &path.1,
-        None => abort_call_site!(WRONG_PLACE_MSG),
-    };
-
-    quote! {
-        #(#attrs)*
-        #unsafety impl #generics #trait_path for #self_ty {
-            #prerequisites_opt
-            #(#items)*
-        }
-
-        unsafe impl #crate_ident::subclass::interface::ObjectInterfaceType for #self_ty {
-            #[inline]
-            fn type_() -> #crate_ident::Type {
-                Self::register_interface()
-            }
-        }
-
-        #register_interface
     }
 }

--- a/glib-macros/src/utils.rs
+++ b/glib-macros/src/utils.rs
@@ -164,6 +164,27 @@ pub fn parse_nested_meta_items<'a>(
     }
 }
 
+pub fn parse_optional_nested_meta_items<'a>(
+    attrs: impl IntoIterator<Item = &'a syn::Attribute>,
+    attr_name: &str,
+    items: &mut [&mut dyn ParseNestedMetaItem],
+) -> syn::Result<Option<&'a syn::Attribute>> {
+    let attr = attrs
+        .into_iter()
+        .find(|attr| attr.path().is_ident(attr_name));
+    if let Some(attr) = attr {
+        if let syn::Meta::Path(_) = attr.meta {
+            Ok(Some(attr))
+        } else {
+            parse_nested_meta_items_from_fn(|x| attr.parse_nested_meta(x), items)?;
+            check_meta_items(attr.span(), items)?;
+            Ok(Some(attr))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
 pub fn crate_ident_new() -> TokenStream {
     use proc_macro_crate::FoundCrate;
 

--- a/glib-macros/tests/enum_dynamic.rs
+++ b/glib-macros/tests/enum_dynamic.rs
@@ -44,9 +44,10 @@ mod module {
     }
 
     // an enum to register as a dynamic type.
-    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::Enum)]
     #[repr(u32)]
     #[enum_type(name = "MyModuleEnum")]
+    #[enum_dynamic]
     pub enum MyModuleEnum {
         #[enum_value(name = "Foo")]
         Foo,
@@ -54,9 +55,10 @@ mod module {
     }
 
     // an enum to lazy register as a dynamic type.
-    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::Enum)]
     #[repr(u32)]
-    #[enum_type(name = "MyModuleEnumLazy", lazy_registration = true)]
+    #[enum_type(name = "MyModuleEnumLazy")]
+    #[enum_dynamic(lazy_registration = true)]
     pub enum MyModuleEnumLazy {
         #[enum_value(name = "Foo")]
         Foo,
@@ -70,17 +72,17 @@ mod module {
     }
 
     #[test]
-    fn dynamic_types() {
+    fn dynamic_enums() {
         // 1st: creates a single module to test with.
         let module = glib::Object::new::<MyModule>();
         // 1st: uses it to test lifecycle of enums registered as dynamic types.
-        enum_lifecycle(&module);
+        dynamic_enums_lifecycle(&module);
         // 2nd: uses it to test behavior of enums registered as dynamic types.
-        enum_behavior(&module);
+        dynamic_enums_behavior(&module);
     }
 
     // tests lifecycle of enums registered as dynamic types within a module.
-    fn enum_lifecycle(module: &MyModule) {
+    fn dynamic_enums_lifecycle(module: &MyModule) {
         // checks types of enums to register as dynamic types are invalid (module is not loaded yet).
         assert!(!MyModuleEnum::static_type().is_valid());
         assert!(!MyModuleEnumLazy::static_type().is_valid());
@@ -132,7 +134,7 @@ mod module {
     }
 
     // tests behavior of enums registered as dynamic types within a module.
-    fn enum_behavior(module: &MyModule) {
+    fn dynamic_enums_behavior(module: &MyModule) {
         use glib::prelude::*;
         use glib::translate::{FromGlib, IntoGlib};
 
@@ -315,9 +317,10 @@ pub mod plugin {
     }
 
     // an enum to register as a dynamic type.
-    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::Enum)]
     #[repr(u32)]
-    #[enum_type(name = "MyPluginEnum", plugin_type = MyPlugin)]
+    #[enum_type(name = "MyPluginEnum")]
+    #[enum_dynamic(plugin_type = MyPlugin)]
     pub enum MyPluginEnum {
         #[enum_value(name = "Foo")]
         Foo,
@@ -325,9 +328,10 @@ pub mod plugin {
     }
 
     // an enum to lazy register as a dynamic type.
-    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::DynamicEnum)]
+    #[derive(Debug, Eq, PartialEq, Clone, Copy, glib::Enum)]
     #[repr(u32)]
-    #[enum_type(name = "MyPluginEnumLazy", plugin_type = MyPlugin, lazy_registration = true)]
+    #[enum_type(name = "MyPluginEnumLazy")]
+    #[enum_dynamic(plugin_type = MyPlugin, lazy_registration = true)]
     pub enum MyPluginEnumLazy {
         #[enum_value(name = "Foo")]
         Foo,
@@ -340,17 +344,17 @@ pub mod plugin {
     }
 
     #[test]
-    fn dynamic_types() {
+    fn dynamic_enums() {
         // 1st: creates a single plugin to test with.
         let plugin = glib::Object::new::<MyPlugin>();
         // 1st: uses it to test lifecycle of enums registered as dynamic types.
-        enum_lifecycle(&plugin);
+        dynamic_enums_lifecycle(&plugin);
         // 2nd: uses it to test behavior of enums registered as dynamic types.
-        enum_behavior(&plugin);
+        dynamic_enums_behavior(&plugin);
     }
 
     // tests lifecycle of enums registered as dynamic types within a plugin.
-    fn enum_lifecycle(plugin: &MyPlugin) {
+    fn dynamic_enums_lifecycle(plugin: &MyPlugin) {
         use glib::prelude::*;
 
         // checks types of enums to register as dynamic types are invalid (plugin is not used yet).
@@ -404,7 +408,7 @@ pub mod plugin {
     }
 
     // tests behavior of enums registered as dynamic types within a plugin.
-    fn enum_behavior(plugin: &MyPlugin) {
+    fn dynamic_enums_behavior(plugin: &MyPlugin) {
         use glib::prelude::*;
         use glib::translate::{FromGlib, IntoGlib};
 

--- a/glib-macros/tests/object_subclass_dynamic.rs
+++ b/glib-macros/tests/object_subclass_dynamic.rs
@@ -85,7 +85,8 @@ mod module {
         #[derive(Default)]
         pub struct MyModuleType;
 
-        #[glib::dynamic_object_subclass]
+        #[glib::object_subclass]
+        #[object_subclass_dynamic]
         impl ObjectSubclass for MyModuleType {
             const NAME: &'static str = "MyModuleType";
             type Type = super::MyModuleType;
@@ -120,7 +121,8 @@ mod module {
         #[derive(Default)]
         pub struct MyModuleTypeLazy;
 
-        #[glib::dynamic_object_subclass(lazy_registration = true)]
+        #[glib::object_subclass]
+        #[object_subclass_dynamic(lazy_registration = true)]
         impl ObjectSubclass for MyModuleTypeLazy {
             const NAME: &'static str = "MyModuleTypeLazy";
             type Type = super::MyModuleTypeLazy;
@@ -206,7 +208,7 @@ mod module {
     }
 
     #[test]
-    fn dynamic_types() {
+    fn dynamic_object_subclasses() {
         use glib::prelude::TypeModuleExt;
 
         // checks types of object subclasses and of object interfaces to register as dynamic types are invalid (module is not loaded yet).
@@ -307,7 +309,8 @@ pub mod plugin {
         #[derive(Default)]
         pub struct MyPluginType;
 
-        #[glib::dynamic_object_subclass(plugin_type = super::MyPlugin)]
+        #[glib::object_subclass]
+        #[object_subclass_dynamic(plugin_type = super::MyPlugin)]
         impl ObjectSubclass for MyPluginType {
             const NAME: &'static str = "MyPluginType";
             type Type = super::MyPluginType;
@@ -342,7 +345,8 @@ pub mod plugin {
         #[derive(Default)]
         pub struct MyPluginTypeLazy;
 
-        #[glib::dynamic_object_subclass(plugin_type = super::MyPlugin, lazy_registration = true)]
+        #[glib::object_subclass]
+        #[object_subclass_dynamic(plugin_type = super::MyPlugin, lazy_registration = true)]
         impl ObjectSubclass for MyPluginTypeLazy {
             const NAME: &'static str = "MyPluginTypeLazy";
             type Type = super::MyPluginTypeLazy;
@@ -530,7 +534,7 @@ pub mod plugin {
     }
 
     #[test]
-    fn dynamic_types() {
+    fn dynamic_object_subclasses() {
         use glib::prelude::TypePluginExt;
 
         // checks types of object subclasses and of object interfaces to register as dynamic types are invalid (plugin is not used yet).

--- a/glib-macros/tests/object_subclass_dynamic.rs
+++ b/glib-macros/tests/object_subclass_dynamic.rs
@@ -73,7 +73,8 @@ mod module {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
-        #[glib::dynamic_object_interface]
+        #[glib::object_interface]
+        #[object_interface_dynamic]
         unsafe impl ObjectInterface for MyModuleInterface {
             const NAME: &'static str = "MyModuleInterface";
             type Prerequisites = (MyStaticInterface,);
@@ -109,7 +110,8 @@ mod module {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
-        #[glib::dynamic_object_interface(lazy_registration = true)]
+        #[glib::object_interface]
+        #[object_interface_dynamic(lazy_registration = true)]
         unsafe impl ObjectInterface for MyModuleInterfaceLazy {
             const NAME: &'static str = "MyModuleInterfaceLazy";
             type Prerequisites = (MyStaticInterface,);
@@ -297,7 +299,8 @@ pub mod plugin {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
-        #[glib::dynamic_object_interface(plugin_type = super::MyPlugin)]
+        #[glib::object_interface]
+        #[object_interface_dynamic(plugin_type = super::MyPlugin)]
         unsafe impl ObjectInterface for MyPluginInterface {
             const NAME: &'static str = "MyPluginInterface";
             type Prerequisites = (MyStaticInterface,);
@@ -333,7 +336,8 @@ pub mod plugin {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
-        #[glib::dynamic_object_interface(plugin_type = super::MyPlugin, lazy_registration = true)]
+        #[glib::object_interface]
+        #[object_interface_dynamic(plugin_type = super::MyPlugin, lazy_registration = true)]
         unsafe impl ObjectInterface for MyPluginInterfaceLazy {
             const NAME: &'static str = "MyPluginInterfaceLazy";
             type Prerequisites = (MyStaticInterface,);

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -10,9 +10,8 @@ pub use ffi;
 #[doc(hidden)]
 pub use glib_macros::cstr_bytes;
 pub use glib_macros::{
-    clone, closure, closure_local, derived_properties, dynamic_object_interface, flags,
-    object_interface, object_subclass, Boxed, Downgrade, Enum, ErrorDomain, Properties,
-    SharedBoxed, ValueDelegate, Variant,
+    clone, closure, closure_local, derived_properties, flags, object_interface, object_subclass,
+    Boxed, Downgrade, Enum, ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
 };
 pub use gobject_ffi;
 pub use once_cell;

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -10,9 +10,9 @@ pub use ffi;
 #[doc(hidden)]
 pub use glib_macros::cstr_bytes;
 pub use glib_macros::{
-    clone, closure, closure_local, derived_properties, dynamic_object_interface,
-    dynamic_object_subclass, flags, object_interface, object_subclass, Boxed, Downgrade, Enum,
-    ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
+    clone, closure, closure_local, derived_properties, dynamic_object_interface, flags,
+    object_interface, object_subclass, Boxed, Downgrade, Enum, ErrorDomain, Properties,
+    SharedBoxed, ValueDelegate, Variant,
 };
 pub use gobject_ffi;
 pub use once_cell;

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -11,8 +11,8 @@ pub use ffi;
 pub use glib_macros::cstr_bytes;
 pub use glib_macros::{
     clone, closure, closure_local, derived_properties, dynamic_object_interface,
-    dynamic_object_subclass, flags, object_interface, object_subclass, Boxed, Downgrade,
-    DynamicEnum, Enum, ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
+    dynamic_object_subclass, flags, object_interface, object_subclass, Boxed, Downgrade, Enum,
+    ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
 };
 pub use gobject_ffi;
 pub use once_cell;

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -224,11 +224,11 @@ pub fn register_interface<T: ObjectInterface>() -> Type {
 /// interfaces registered as static types, object interfaces registered as
 /// dynamic types can be registered several times.
 ///
-/// The [`dynamic_object_interface!`] macro will create `register_interface()`
-/// and `on_implementation_load()` functions around this, which will ensure
-/// that the function is called when necessary.
+/// The [`object_interface_dynamic!`] macro helper attribute will create
+/// `register_interface()` and `on_implementation_load()` functions around this,
+/// which will ensure that the function is called when necessary.
 ///
-/// [`dynamic_object_interface!`]: ../../../glib_macros/attr.dynamic_object_interface.html
+/// [`object_interface_dynamic!`]: ../../../glib_macros/attr.object_interface.html
 /// [`TypePluginImpl::use_`]: ../type_plugin/trait.TypePluginImpl.html#method.use_
 /// [`TypeModuleImpl::load`]: ../type_module/trait.TypeModuleImpl.html#method.load
 pub fn register_dynamic_interface<P: DynamicObjectRegisterExt, T: ObjectInterface>(

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -213,7 +213,8 @@
 //!     #[derive(Default)]
 //!     pub struct SimpleModuleObject;
 //!
-//!     #[glib::dynamic_object_subclass]
+//!     #[glib::object_subclass]
+//!     #[object_subclass_dynamic]
 //!     impl ObjectSubclass for SimpleModuleObject {
 //!         const NAME: &'static str = "SimpleModuleObject";
 //!         type Type = super::SimpleModuleObject;
@@ -300,7 +301,8 @@
 //!     #[derive(Default)]
 //!     pub struct SimplePluginObject;
 //!
-//!     #[glib::dynamic_object_subclass(plugin_type = super::SimpleTypePlugin)]
+//!     #[glib::object_subclass]
+//!     #[object_subclass_dynamic(plugin_type = super::SimpleTypePlugin)]
 //!     impl ObjectSubclass for SimplePluginObject {
 //!         const NAME: &'static str = "SimplePluginObject";
 //!         type Type = super::SimplePluginObject;

--- a/glib/src/subclass/type_module.rs
+++ b/glib/src/subclass/type_module.rs
@@ -134,7 +134,8 @@ mod tests {
         #[derive(Default)]
         pub struct SimpleModuleType;
 
-        #[crate::dynamic_object_subclass]
+        #[crate::object_subclass]
+        #[object_subclass_dynamic]
         impl ObjectSubclass for SimpleModuleType {
             const NAME: &'static str = "SimpleModuleType";
             type Type = super::SimpleModuleType;

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -272,7 +272,8 @@ mod tests {
         #[derive(Default)]
         pub struct SimplePluginType;
 
-        #[crate::dynamic_object_subclass(plugin_type = super::SimplePlugin)]
+        #[crate::object_subclass]
+        #[object_subclass_dynamic(plugin_type = super::SimplePlugin)]
         impl ObjectSubclass for SimplePluginType {
             const NAME: &'static str = "SimplePluginType";
             type Type = super::SimplePluginType;

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -1056,17 +1056,17 @@ pub fn register_type<T: ObjectSubclass>() -> Type {
 // rustdoc-stripper-ignore-next
 /// Registers a `glib::Type` ID for `T` as a dynamic type.
 ///
-/// An object subclass must be explicitly registered as a  ynamic type when the
+/// An object subclass must be explicitly registered as a dynamic type when the
 /// system loads the implementation by calling [`TypePluginImpl::use_`] or more
 /// specifically [`TypeModuleImpl::load`]. Therefore, unlike for object
 /// subclasses registered as static types, object subclasses registered as
 /// dynamic types can be registered several times.
 ///
-/// The [`dynamic_object_subclass!`] macro will create `register_type()` and
-/// `on_implementation_load()` functions around this, which will ensure that
-/// the function is called when necessary.
+/// The [`object_subclass_dynamic!`] macro helper attribute will create
+/// `register_type()` and `on_implementation_load()` functions around this,
+/// which will ensure that the function is called when necessary.
 ///
-/// [`dynamic_object_subclass!`]: ../../../glib_macros/attr.dynamic_object_subclass.html
+/// [`object_subclass_dynamic!`]: ../../../glib_macros/attr.object_subclass.html
 /// [`TypePluginImpl::use_`]: ../type_plugin/trait.TypePluginImpl.html#method.use_
 /// [`TypeModuleImpl::load`]: ../type_module/trait.TypeModuleImpl.html#method.load
 pub fn register_dynamic_type<P: DynamicObjectRegisterExt, T: ObjectSubclass>(


### PR DESCRIPTION
This PR aims to refactor the macros to register dynamic types, by replacing a macro by a macro helper attribute for `object_subclass`, `object_interface` and `Enum`