### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: (GTK binaries) output cache key
         id: output
-        run: echo "::set-output name=cachekey::gvsbuild-${{ env.gvsbuildupdate }}-${{ env.gvsbuildref }}"
+        run: echo "cachekey=gvsbuild-${{ env.gvsbuildupdate }}-${{ env.gvsbuildref }}" >> $GITHUB_OUTPUT
 
   build:
     name: build gtk-rs on Windows

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: (GTK binaries) output cache key
         id: output
-        run: echo "cachekey=gvsbuild-${{ env.gvsbuildupdate }}-${{ env.gvsbuildref }}" >> $GITHUB_OUTPUT
+        run: echo "cachekey=gvsbuild-${{ env.gvsbuildupdate }}-${{ env.gvsbuildref }}" >> "$GITHUB_OUTPUT"
 
   build:
     name: build gtk-rs on Windows


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


