### PR TITLE
add support of flags registered as dynamic types

### DIFF
--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -284,7 +284,7 @@ fn register_enum_as_dynamic(
 
     let enum_values = quote! {
         #crate_ident::enums::EnumValuesStorage<#nb_enum_values> = unsafe {
-            #crate_ident::enums::EnumValuesStorage::<#nb_enum_values>::new::<{#nb_enum_values - 1}>([
+            #crate_ident::enums::EnumValuesStorage::<#nb_enum_values>::new([
                 #(#enum_values_iter)*
             ])
         }

--- a/glib-macros/src/flags_attribute.rs
+++ b/glib-macros/src/flags_attribute.rs
@@ -2,14 +2,15 @@
 
 use heck::{ToKebabCase, ToUpperCamelCase};
 use proc_macro2::TokenStream;
-use proc_macro_error::abort_call_site;
 use quote::{quote, quote_spanned};
 use syn::{
-    punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Data, DeriveInput, Ident,
-    Variant, Visibility,
+    punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Ident, ItemEnum, Variant,
+    Visibility,
 };
 
 use crate::utils::{crate_ident_new, parse_nested_meta_items, NestedMetaItem};
+
+pub const WRONG_PLACE_MSG: &str = "#[glib::flags] only supports enums";
 
 pub struct AttrInput {
     pub enum_name: syn::LitStr,
@@ -114,15 +115,12 @@ fn gen_bitflags(
     }
 }
 
-pub fn impl_flags(attrs: AttrInput, input: &DeriveInput) -> TokenStream {
+pub fn impl_flags(attrs: AttrInput, input: &mut ItemEnum) -> TokenStream {
     let gtype_name = attrs.enum_name.value();
     let name = &input.ident;
     let visibility = &input.vis;
 
-    let enum_variants = match input.data {
-        Data::Enum(ref e) => &e.variants,
-        _ => abort_call_site!("#[glib::flags] only supports enums"),
-    };
+    let enum_variants = &input.variants;
 
     let crate_ident = crate_ident_new();
 

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -589,7 +589,95 @@ pub fn enum_derive(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
+/// The flags can be registered as a dynamic type by setting the macro helper
+/// attribute `flags_dynamic`:
+/// ```ignore
+/// use glib::prelude::*;
+/// use glib::subclass::prelude::*;
+///
+/// #[glib::flags(name = "MyFlags")]
+/// #[flags_dynamic]
+/// enum MyFlags {
+///     ...
+/// }
+/// ```
+///
+/// As a dynamic type, the flags must be explicitly registered when the system
+/// loads the implementation (see [`TypePlugin`] and [`TypeModule`].
+/// Therefore, whereas the flags can be registered only once as a static type,
+/// they can be registered several times as a dynamic type.
+///
+/// The flags registered as a dynamic type are never unregistered. The system
+/// calls [`TypePluginExt::unuse`] to unload the implementation. If the
+/// [`TypePlugin`] subclass is a [`TypeModule`], the flags registered as a
+/// dynamic type are marked as unloaded and must be registered again when the
+/// module is reloaded.
+///
+/// The macro helper attribute `flags_dynamic` provides two behaviors when
+/// registering the flags as a dynamic type:
+///
+/// - lazy registration: by default the flags are registered as a dynamic type
+/// when the system loads the implementation (e.g. when the module is loaded).
+/// Optionally setting `lazy_registration` to `true` postpones registration on
+/// the first use (when `static_type()` is called for the first time):
+/// ```ignore
+/// #[glib::flags(name = "MyFlags")]
+/// #[flags_dynamic(lazy_registration = true)]
+/// enum MyFlags {
+///     ...
+/// }
+/// ```
+///
+/// - registration within [`TypeModule`] subclass or within [`TypePlugin`]
+/// subclass: the flags are usually registered as a dynamic type within a
+/// [`TypeModule`] subclass:
+/// ```ignore
+/// #[glib::flags(name = "MyModuleFlags")]
+/// #[flags_dynamic]
+/// enum MyModuleFlags {
+///     ...
+/// }
+/// ...
+/// #[derive(Default)]
+/// pub struct MyModule;
+/// ...
+/// impl TypeModuleImpl for MyModule {
+///     fn load(&self) -> bool {
+///         // registers flags as dynamic types.
+///         let my_module = self.obj();
+///         let type_module: &glib::TypeModule = my_module.upcast_ref();
+///         MyModuleFlags::on_implementation_load(type_module)
+///     }
+///     ...
+/// }
+/// ```
+///
+/// Optionally setting `plugin_type` allows to register the flags as a dynamic
+/// type within a [`TypePlugin`] subclass that is not a [`TypeModule`]:
+/// ```ignore
+/// #[glib::flags(name = "MyModuleFlags")]
+/// #[flags_dynamic(plugin_type = MyPlugin)]
+/// enum MyModuleFlags {
+///     ...
+/// }
+/// ...
+/// #[derive(Default)]
+/// pub struct MyPlugin;
+/// ...
+/// impl TypePluginImpl for MyPlugin {
+///     fn use_plugin(&self) {
+///         // register flags as dynamic types.
+///         let my_plugin = self.obj();
+///         MyPluginFlags::on_implementation_load(my_plugin.as_ref());
+///     }
+///     ...
+/// }
+/// ```
+///
 /// [`glib::Value`]: ../glib/value/struct.Value.html
+/// [`TypePlugin`]: ../glib/gobject/type_plugin/struct.TypePlugin.html
+/// [`TypeModule`]: ../glib/gobject/type_module/struct.TypeModule.html
+/// [`TypePluginExt::unuse`]: ../glib/gobject/type_plugin/trait.TypePluginExt.
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn flags(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -604,9 +604,11 @@ pub fn flags(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr_meta = AttrInput {
         enum_name: name.value.unwrap(),
     };
-    let input = parse_macro_input!(item as DeriveInput);
-    let gen = flags_attribute::impl_flags(attr_meta, &input);
-    gen.into()
+    use proc_macro_error::abort_call_site;
+    match syn::parse::<syn::ItemEnum>(item) {
+        Ok(mut input) => flags_attribute::impl_flags(attr_meta, &mut input).into(),
+        Err(_) => abort_call_site!(flags_attribute::WRONG_PLACE_MSG),
+    }
 }
 
 /// Derive macro for defining a GLib error domain and its associated

--- a/glib-macros/tests/flags_dynamic.rs
+++ b/glib-macros/tests/flags_dynamic.rs
@@ -1,0 +1,653 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use glib::{prelude::*, subclass::prelude::*, Cast};
+
+mod module {
+    use super::*;
+
+    mod imp {
+        use super::*;
+
+        // impl for a type module (must extend `glib::TypeModule` and must implement `glib::TypePlugin`).
+        #[derive(Default)]
+        pub struct MyModule;
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for MyModule {
+            const NAME: &'static str = "MyModule";
+            type Type = super::MyModule;
+            type ParentType = glib::TypeModule;
+            type Interfaces = (glib::TypePlugin,);
+        }
+
+        impl ObjectImpl for MyModule {}
+
+        impl TypePluginImpl for MyModule {}
+
+        impl TypeModuleImpl for MyModule {
+            fn load(&self) -> bool {
+                // registers flags as dynamic types.
+                let my_module = self.obj();
+                let type_module: &glib::TypeModule = my_module.upcast_ref();
+                super::MyModuleFlags::on_implementation_load(type_module)
+                    && super::MyModuleFlagsLazy::on_implementation_load(type_module)
+            }
+
+            fn unload(&self) {
+                // marks the flags as unregistered.
+                let my_module = self.obj();
+                let type_module: &glib::TypeModule = my_module.upcast_ref();
+                super::MyModuleFlagsLazy::on_implementation_unload(type_module);
+                super::MyModuleFlags::on_implementation_unload(type_module);
+            }
+        }
+    }
+
+    // flags to register as a dynamic type.
+    #[glib::flags(name = "MyModuleFlags")]
+    #[flags_dynamic]
+    enum MyModuleFlags {
+        #[flags_value(name = "Flag A", nick = "nick-a")]
+        A = 0b00000001,
+        #[flags_value(name = "Flag B")]
+        B = 0b00000010,
+        #[flags_value(skip)]
+        AB = Self::A.bits() | Self::B.bits(),
+        C = 0b00000100,
+    }
+
+    // flags to lazy register as a dynamic type.
+    #[glib::flags(name = "MyModuleFlagsLazy")]
+    #[flags_dynamic(lazy_registration = true)]
+    enum MyModuleFlagsLazy {
+        #[flags_value(name = "Flag A", nick = "nick-a")]
+        A = 0b00000001,
+        #[flags_value(name = "Flag B")]
+        B = 0b00000010,
+        #[flags_value(skip)]
+        AB = Self::A.bits() | Self::B.bits(),
+        C = 0b00000100,
+    }
+
+    // a module (must extend `glib::TypeModule` and must implement `glib::TypePlugin`).
+    glib::wrapper! {
+        pub struct MyModule(ObjectSubclass<imp::MyModule>)
+        @extends glib::TypeModule, @implements glib::TypePlugin;
+    }
+
+    #[test]
+    fn dynamic_flags() {
+        // 1st: creates a single module to test with.
+        let module = glib::Object::new::<MyModule>();
+        // 1st: uses it to test lifecycle of flags registered as dynamic types.
+        dynamic_flags_lifecycle(&module);
+        // 2nd: uses it to test behavior of flags registered as dynamic types.
+        dynamic_flags_behavior(&module);
+    }
+
+    // tests lifecycle of flags registered as dynamic types within a module.
+    fn dynamic_flags_lifecycle(module: &MyModule) {
+        // checks types of flags to register as dynamic types are invalid (module is not loaded yet).
+        assert!(!MyModuleFlags::static_type().is_valid());
+        assert!(!MyModuleFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to load/unload the module.
+        TypeModuleExt::use_(module);
+        TypeModuleExt::unuse(module);
+
+        // checks types of flags registered as dynamic types are valid (module is unloaded).
+        assert!(MyModuleFlags::static_type().is_valid());
+        // checks types of flags that are lazy registered as dynamic types are valid (module is unloaded).
+        assert!(!MyModuleFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to load the module.
+        TypeModuleExt::use_(module);
+
+        // checks types of flags registered as dynamic types are valid (module is loaded).
+        let flags_type = MyModuleFlags::static_type();
+        assert!(flags_type.is_valid());
+        let flags_lazy_type = MyModuleFlagsLazy::static_type();
+        assert!(flags_lazy_type.is_valid());
+
+        // checks plugin of flags registered as dynamic types is `MyModule`.
+        assert_eq!(
+            flags_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            flags_lazy_type.plugin().as_ref(),
+            Some(module.upcast_ref::<glib::TypePlugin>())
+        );
+
+        // simulates the GLib type system to unload the module.
+        TypeModuleExt::unuse(module);
+
+        // checks types of flags registered as dynamic types are still valid (should have been marked as unloaded by the GLib type system but this cannot be checked).
+        assert!(MyModuleFlags::static_type().is_valid());
+        assert!(MyModuleFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to reload the module.
+        TypeModuleExt::use_(module);
+
+        // checks types of flags registered as dynamic types are still valid (should have been marked as loaded by the GLib type system but this cannot be checked).
+        assert!(MyModuleFlags::static_type().is_valid());
+        assert!(MyModuleFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to unload the module.
+        TypeModuleExt::unuse(module);
+    }
+
+    // tests behavior of flags registered as dynamic types within a module.
+    fn dynamic_flags_behavior(module: &MyModule) {
+        use glib::prelude::*;
+        use glib::translate::{FromGlib, IntoGlib};
+
+        // simulates the GLib type system to load the module.
+        TypeModuleExt::use_(module);
+
+        assert_eq!(MyModuleFlags::A.bits(), 1);
+        assert_eq!(MyModuleFlags::B.bits(), 2);
+        assert_eq!(MyModuleFlags::AB.bits(), 3);
+
+        assert_eq!(MyModuleFlags::empty().into_glib(), 0);
+        assert_eq!(MyModuleFlags::A.into_glib(), 1);
+        assert_eq!(MyModuleFlags::B.into_glib(), 2);
+        assert_eq!(MyModuleFlags::AB.into_glib(), 3);
+
+        assert_eq!(
+            unsafe { MyModuleFlags::from_glib(0) },
+            MyModuleFlags::empty()
+        );
+        assert_eq!(unsafe { MyModuleFlags::from_glib(1) }, MyModuleFlags::A);
+        assert_eq!(unsafe { MyModuleFlags::from_glib(2) }, MyModuleFlags::B);
+        assert_eq!(unsafe { MyModuleFlags::from_glib(3) }, MyModuleFlags::AB);
+
+        let t = MyModuleFlags::static_type();
+        assert!(t.is_a(glib::Type::FLAGS));
+        assert_eq!(t.name(), "MyModuleFlags");
+
+        let e = glib::FlagsClass::with_type(t).expect("FlagsClass::new failed");
+        let values = e.values();
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0].name(), "Flag A");
+        assert_eq!(values[0].nick(), "nick-a");
+        assert_eq!(values[1].name(), "Flag B");
+        assert_eq!(values[1].nick(), "b");
+        assert_eq!(values[2].name(), "C");
+        assert_eq!(values[2].nick(), "c");
+
+        let v = e.value(1).expect("FlagsClass::get_value(1) failed");
+        assert_eq!(v.name(), "Flag A");
+        assert_eq!(v.nick(), "nick-a");
+        let v = e.value(2).expect("FlagsClass::get_value(2) failed");
+        assert_eq!(v.name(), "Flag B");
+        assert_eq!(v.nick(), "b");
+        let v = e.value(4).expect("FlagsClass::get_value(4) failed");
+        assert_eq!(v.name(), "C");
+        assert_eq!(v.nick(), "c");
+
+        // within flags registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::FlagsClass`).
+        assert_eq!(
+            MyModuleFlags::empty().to_value().get::<MyModuleFlags>(),
+            Ok(MyModuleFlags::empty())
+        );
+
+        assert_eq!(
+            MyModuleFlags::A.to_value().get::<MyModuleFlags>(),
+            Ok(MyModuleFlags::A)
+        );
+        assert_eq!(
+            MyModuleFlags::B.to_value().get::<MyModuleFlags>(),
+            Ok(MyModuleFlags::B)
+        );
+        assert_eq!(
+            MyModuleFlags::AB.to_value().get::<MyModuleFlags>(),
+            Ok(MyModuleFlags::AB)
+        );
+
+        assert!(e.value_by_name("Flag A").is_some());
+        assert!(e.value_by_name("Flag B").is_some());
+        assert!(e.value_by_name("AB").is_none());
+        assert!(e.value_by_name("C").is_some());
+
+        assert!(e.value_by_nick("nick-a").is_some());
+        assert!(e.value_by_nick("b").is_some());
+        assert!(e.value_by_nick("ab").is_none());
+        assert!(e.value_by_nick("c").is_some());
+
+        assert_eq!(MyModuleFlagsLazy::A.bits(), 1);
+        assert_eq!(MyModuleFlagsLazy::B.bits(), 2);
+        assert_eq!(MyModuleFlagsLazy::AB.bits(), 3);
+
+        assert_eq!(MyModuleFlagsLazy::empty().into_glib(), 0);
+        assert_eq!(MyModuleFlagsLazy::A.into_glib(), 1);
+        assert_eq!(MyModuleFlagsLazy::B.into_glib(), 2);
+        assert_eq!(MyModuleFlagsLazy::AB.into_glib(), 3);
+
+        assert_eq!(
+            unsafe { MyModuleFlagsLazy::from_glib(0) },
+            MyModuleFlagsLazy::empty()
+        );
+        assert_eq!(
+            unsafe { MyModuleFlagsLazy::from_glib(1) },
+            MyModuleFlagsLazy::A
+        );
+        assert_eq!(
+            unsafe { MyModuleFlagsLazy::from_glib(2) },
+            MyModuleFlagsLazy::B
+        );
+        assert_eq!(
+            unsafe { MyModuleFlagsLazy::from_glib(3) },
+            MyModuleFlagsLazy::AB
+        );
+
+        let t = MyModuleFlagsLazy::static_type();
+        assert!(t.is_a(glib::Type::FLAGS));
+        assert_eq!(t.name(), "MyModuleFlagsLazy");
+
+        let e = glib::FlagsClass::with_type(t).expect("FlagsClass::new failed");
+        let values = e.values();
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0].name(), "Flag A");
+        assert_eq!(values[0].nick(), "nick-a");
+        assert_eq!(values[1].name(), "Flag B");
+        assert_eq!(values[1].nick(), "b");
+        assert_eq!(values[2].name(), "C");
+        assert_eq!(values[2].nick(), "c");
+
+        let v = e.value(1).expect("FlagsClass::get_value(1) failed");
+        assert_eq!(v.name(), "Flag A");
+        assert_eq!(v.nick(), "nick-a");
+        let v = e.value(2).expect("FlagsClass::get_value(2) failed");
+        assert_eq!(v.name(), "Flag B");
+        assert_eq!(v.nick(), "b");
+        let v = e.value(4).expect("FlagsClass::get_value(4) failed");
+        assert_eq!(v.name(), "C");
+        assert_eq!(v.nick(), "c");
+
+        // within flags registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::FlagsClass`).
+        assert_eq!(
+            MyModuleFlagsLazy::empty()
+                .to_value()
+                .get::<MyModuleFlagsLazy>(),
+            Ok(MyModuleFlagsLazy::empty())
+        );
+
+        assert_eq!(
+            MyModuleFlagsLazy::A.to_value().get::<MyModuleFlagsLazy>(),
+            Ok(MyModuleFlagsLazy::A)
+        );
+        assert_eq!(
+            MyModuleFlagsLazy::B.to_value().get::<MyModuleFlagsLazy>(),
+            Ok(MyModuleFlagsLazy::B)
+        );
+        assert_eq!(
+            MyModuleFlagsLazy::AB.to_value().get::<MyModuleFlagsLazy>(),
+            Ok(MyModuleFlagsLazy::AB)
+        );
+
+        assert!(e.value_by_name("Flag A").is_some());
+        assert!(e.value_by_name("Flag B").is_some());
+        assert!(e.value_by_name("AB").is_none());
+        assert!(e.value_by_name("C").is_some());
+
+        assert!(e.value_by_nick("nick-a").is_some());
+        assert!(e.value_by_nick("b").is_some());
+        assert!(e.value_by_nick("ab").is_none());
+        assert!(e.value_by_nick("c").is_some());
+
+        // simulates the GLib type system to unload the module.
+        TypeModuleExt::unuse(module);
+    }
+}
+
+pub mod plugin {
+    use super::*;
+
+    pub mod imp {
+        use glib::FlagsClass;
+
+        use super::*;
+        use std::cell::Cell;
+
+        // impl for a type plugin (must implement `glib::TypePlugin`).
+        #[derive(Default)]
+        pub struct MyPlugin {
+            my_flags_type_values: Cell<Option<&'static glib::enums::FlagsValues>>,
+            my_flags_lazy_type_values: Cell<Option<&'static glib::enums::FlagsValues>>,
+        }
+
+        #[glib::object_subclass]
+        impl ObjectSubclass for MyPlugin {
+            const NAME: &'static str = "MyPlugin";
+            type Type = super::MyPlugin;
+            type Interfaces = (glib::TypePlugin,);
+        }
+
+        impl ObjectImpl for MyPlugin {}
+
+        impl TypePluginImpl for MyPlugin {
+            fn use_plugin(&self) {
+                // register flags as dynamic types.
+                let my_plugin = self.obj();
+                super::MyPluginFlags::on_implementation_load(my_plugin.as_ref());
+                super::MyPluginFlagsLazy::on_implementation_load(my_plugin.as_ref());
+            }
+
+            fn unuse_plugin(&self) {
+                // marks flags as unregistered.
+                let my_plugin = self.obj();
+                super::MyPluginFlagsLazy::on_implementation_unload(my_plugin.as_ref());
+                super::MyPluginFlags::on_implementation_unload(my_plugin.as_ref());
+            }
+
+            fn complete_type_info(
+                &self,
+                type_: glib::Type,
+            ) -> (glib::TypeInfo, glib::TypeValueTable) {
+                let flags_type_values = match type_ {
+                    type_ if type_ == super::MyPluginFlags::static_type() => {
+                        self.my_flags_type_values.get()
+                    }
+                    type_ if type_ == super::MyPluginFlagsLazy::static_type() => {
+                        self.my_flags_lazy_type_values.get()
+                    }
+                    _ => panic!("unexpected type"),
+                }
+                .expect("flags type values");
+                let type_info = FlagsClass::complete_type_info(type_, flags_type_values)
+                    .expect("FlagsClass::type_info failed");
+                (type_info, glib::TypeValueTable::default())
+            }
+        }
+
+        impl TypePluginRegisterImpl for MyPlugin {
+            fn register_dynamic_flags(
+                &self,
+                type_name: &str,
+                const_static_values: &'static glib::enums::FlagsValues,
+            ) -> glib::Type {
+                let type_ = glib::Type::from_name(type_name).unwrap_or_else(|| {
+                    glib::Type::register_dynamic(
+                        glib::Type::FLAGS,
+                        type_name,
+                        self.obj().upcast_ref::<glib::TypePlugin>(),
+                        glib::TypeFlags::NONE,
+                    )
+                });
+                if type_.is_valid() {
+                    match type_name {
+                        "MyPluginFlags" => self.my_flags_type_values.set(Some(const_static_values)),
+                        "MyPluginFlagsLazy" => self
+                            .my_flags_lazy_type_values
+                            .set(Some(const_static_values)),
+                        _ => panic!("unexpected"),
+                    };
+                }
+                type_
+            }
+        }
+    }
+
+    // flags to register as a dynamic type.
+    #[glib::flags(name = "MyPluginFlags")]
+    #[flags_dynamic(plugin_type = MyPlugin)]
+    enum MyPluginFlags {
+        #[flags_value(name = "Flag A", nick = "nick-a")]
+        A = 0b00000001,
+        #[flags_value(name = "Flag B")]
+        B = 0b00000010,
+        #[flags_value(skip)]
+        AB = Self::A.bits() | Self::B.bits(),
+        C = 0b00000100,
+    }
+
+    // flags to lazy register as a dynamic type.
+    #[glib::flags(name = "MyPluginFlagsLazy")]
+    #[flags_dynamic(plugin_type = MyPlugin, lazy_registration = true)]
+    enum MyPluginFlagsLazy {
+        #[flags_value(name = "Flag A", nick = "nick-a")]
+        A = 0b00000001,
+        #[flags_value(name = "Flag B")]
+        B = 0b00000010,
+        #[flags_value(skip)]
+        AB = Self::A.bits() | Self::B.bits(),
+        C = 0b00000100,
+    }
+
+    // a plugin (must implement `glib::TypePlugin`).
+    glib::wrapper! {
+        pub struct MyPlugin(ObjectSubclass<imp::MyPlugin>) @implements glib::TypePlugin;
+    }
+
+    #[test]
+    fn dynamic_flags() {
+        // 1st: creates a single plugin to test with.
+        let plugin = glib::Object::new::<MyPlugin>();
+        // 1st: uses it to test lifecycle of flags registered as dynamic types.
+        dynamic_flags_lifecycle(&plugin);
+        // 2nd: uses it to test behavior of flags registered as dynamic types.
+        dynamic_flags_behavior(&plugin);
+    }
+
+    // tests lifecycle of flags registered as dynamic types within a plugin.
+    fn dynamic_flags_lifecycle(plugin: &MyPlugin) {
+        use glib::prelude::*;
+
+        // checks types of flags to register as dynamic types are invalid (plugin is not used yet).
+        assert!(!MyPluginFlags::static_type().is_valid());
+        assert!(!MyPluginFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to use/unuse the plugin.
+        TypePluginExt::use_(plugin);
+        TypePluginExt::unuse(plugin);
+
+        // checks types of flags registered as dynamic types are valid (plugin is unused).
+        assert!(MyPluginFlags::static_type().is_valid());
+        // checks types of flags that are lazy registered as dynamic types are still invalid (plugin is unused).
+        assert!(!MyPluginFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to use the plugin.
+        TypePluginExt::use_(plugin);
+
+        // checks types of flags registered as dynamic types are valid (plugin is used).
+        let flags_type = MyPluginFlags::static_type();
+        assert!(flags_type.is_valid());
+        let flags_lazy_type = MyPluginFlagsLazy::static_type();
+        assert!(flags_lazy_type.is_valid());
+
+        // checks plugin of flags registered as dynamic types is `MyPlugin`.
+        assert_eq!(
+            flags_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+        assert_eq!(
+            flags_lazy_type.plugin().as_ref(),
+            Some(plugin.upcast_ref::<glib::TypePlugin>())
+        );
+
+        // simulates the GLib type system to unuse the plugin.
+        TypePluginExt::unuse(plugin);
+
+        // checks types of flags registered as dynamic types are still valid.
+        assert!(MyPluginFlags::static_type().is_valid());
+        assert!(MyPluginFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to reuse the plugin.
+        TypePluginExt::use_(plugin);
+
+        // checks types of flags registered as dynamic types are still valid.
+        assert!(MyPluginFlags::static_type().is_valid());
+        assert!(MyPluginFlagsLazy::static_type().is_valid());
+
+        // simulates the GLib type system to unuse the plugin.
+        TypePluginExt::unuse(plugin);
+    }
+
+    // tests behavior of flags registered as dynamic types within a plugin.
+    fn dynamic_flags_behavior(plugin: &MyPlugin) {
+        use glib::prelude::*;
+        use glib::translate::{FromGlib, IntoGlib};
+
+        // simulates the GLib type system to use the plugin.
+        TypePluginExt::use_(plugin);
+
+        assert_eq!(MyPluginFlags::A.bits(), 1);
+        assert_eq!(MyPluginFlags::B.bits(), 2);
+        assert_eq!(MyPluginFlags::AB.bits(), 3);
+
+        assert_eq!(MyPluginFlags::empty().into_glib(), 0);
+        assert_eq!(MyPluginFlags::A.into_glib(), 1);
+        assert_eq!(MyPluginFlags::B.into_glib(), 2);
+        assert_eq!(MyPluginFlags::AB.into_glib(), 3);
+
+        assert_eq!(
+            unsafe { MyPluginFlags::from_glib(0) },
+            MyPluginFlags::empty()
+        );
+        assert_eq!(unsafe { MyPluginFlags::from_glib(1) }, MyPluginFlags::A);
+        assert_eq!(unsafe { MyPluginFlags::from_glib(2) }, MyPluginFlags::B);
+        assert_eq!(unsafe { MyPluginFlags::from_glib(3) }, MyPluginFlags::AB);
+
+        let t = MyPluginFlags::static_type();
+        assert!(t.is_a(glib::Type::FLAGS));
+        assert_eq!(t.name(), "MyPluginFlags");
+
+        let e = glib::FlagsClass::with_type(t).expect("FlagsClass::new failed");
+        let values = e.values();
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0].name(), "Flag A");
+        assert_eq!(values[0].nick(), "nick-a");
+        assert_eq!(values[1].name(), "Flag B");
+        assert_eq!(values[1].nick(), "b");
+        assert_eq!(values[2].name(), "C");
+        assert_eq!(values[2].nick(), "c");
+
+        let v = e.value(1).expect("FlagsClass::get_value(1) failed");
+        assert_eq!(v.name(), "Flag A");
+        assert_eq!(v.nick(), "nick-a");
+        let v = e.value(2).expect("FlagsClass::get_value(2) failed");
+        assert_eq!(v.name(), "Flag B");
+        assert_eq!(v.nick(), "b");
+        let v = e.value(4).expect("FlagsClass::get_value(4) failed");
+        assert_eq!(v.name(), "C");
+        assert_eq!(v.nick(), "c");
+
+        // within flags registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::FlagsClass`).
+        assert_eq!(
+            MyPluginFlags::empty().to_value().get::<MyPluginFlags>(),
+            Ok(MyPluginFlags::empty())
+        );
+
+        assert_eq!(
+            MyPluginFlags::A.to_value().get::<MyPluginFlags>(),
+            Ok(MyPluginFlags::A)
+        );
+        assert_eq!(
+            MyPluginFlags::B.to_value().get::<MyPluginFlags>(),
+            Ok(MyPluginFlags::B)
+        );
+        assert_eq!(
+            MyPluginFlags::AB.to_value().get::<MyPluginFlags>(),
+            Ok(MyPluginFlags::AB)
+        );
+
+        assert!(e.value_by_name("Flag A").is_some());
+        assert!(e.value_by_name("Flag B").is_some());
+        assert!(e.value_by_name("AB").is_none());
+        assert!(e.value_by_name("C").is_some());
+
+        assert!(e.value_by_nick("nick-a").is_some());
+        assert!(e.value_by_nick("b").is_some());
+        assert!(e.value_by_nick("ab").is_none());
+        assert!(e.value_by_nick("c").is_some());
+
+        assert_eq!(MyPluginFlagsLazy::A.bits(), 1);
+        assert_eq!(MyPluginFlagsLazy::B.bits(), 2);
+        assert_eq!(MyPluginFlagsLazy::AB.bits(), 3);
+
+        assert_eq!(MyPluginFlagsLazy::empty().into_glib(), 0);
+        assert_eq!(MyPluginFlagsLazy::A.into_glib(), 1);
+        assert_eq!(MyPluginFlagsLazy::B.into_glib(), 2);
+        assert_eq!(MyPluginFlagsLazy::AB.into_glib(), 3);
+
+        assert_eq!(
+            unsafe { MyPluginFlagsLazy::from_glib(0) },
+            MyPluginFlagsLazy::empty()
+        );
+        assert_eq!(
+            unsafe { MyPluginFlagsLazy::from_glib(1) },
+            MyPluginFlagsLazy::A
+        );
+        assert_eq!(
+            unsafe { MyPluginFlagsLazy::from_glib(2) },
+            MyPluginFlagsLazy::B
+        );
+        assert_eq!(
+            unsafe { MyPluginFlagsLazy::from_glib(3) },
+            MyPluginFlagsLazy::AB
+        );
+
+        let t = MyPluginFlagsLazy::static_type();
+        assert!(t.is_a(glib::Type::FLAGS));
+        assert_eq!(t.name(), "MyPluginFlagsLazy");
+
+        let e = glib::FlagsClass::with_type(t).expect("FlagsClass::new failed");
+        let values = e.values();
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0].name(), "Flag A");
+        assert_eq!(values[0].nick(), "nick-a");
+        assert_eq!(values[1].name(), "Flag B");
+        assert_eq!(values[1].nick(), "b");
+        assert_eq!(values[2].name(), "C");
+        assert_eq!(values[2].nick(), "c");
+
+        let v = e.value(1).expect("FlagsClass::get_value(1) failed");
+        assert_eq!(v.name(), "Flag A");
+        assert_eq!(v.nick(), "nick-a");
+        let v = e.value(2).expect("FlagsClass::get_value(2) failed");
+        assert_eq!(v.name(), "Flag B");
+        assert_eq!(v.nick(), "b");
+        let v = e.value(4).expect("FlagsClass::get_value(4) failed");
+        assert_eq!(v.name(), "C");
+        assert_eq!(v.nick(), "c");
+
+        // within flags registered as dynamic types, values are usables only if
+        // at least one type class ref exists (see `glib::FlagsClass`).
+        assert_eq!(
+            MyPluginFlagsLazy::empty()
+                .to_value()
+                .get::<MyPluginFlagsLazy>(),
+            Ok(MyPluginFlagsLazy::empty())
+        );
+
+        assert_eq!(
+            MyPluginFlagsLazy::A.to_value().get::<MyPluginFlagsLazy>(),
+            Ok(MyPluginFlagsLazy::A)
+        );
+        assert_eq!(
+            MyPluginFlagsLazy::B.to_value().get::<MyPluginFlagsLazy>(),
+            Ok(MyPluginFlagsLazy::B)
+        );
+        assert_eq!(
+            MyPluginFlagsLazy::AB.to_value().get::<MyPluginFlagsLazy>(),
+            Ok(MyPluginFlagsLazy::AB)
+        );
+
+        assert!(e.value_by_name("Flag A").is_some());
+        assert!(e.value_by_name("Flag B").is_some());
+        assert!(e.value_by_name("AB").is_none());
+        assert!(e.value_by_name("C").is_some());
+
+        assert!(e.value_by_nick("nick-a").is_some());
+        assert!(e.value_by_nick("b").is_some());
+        assert!(e.value_by_nick("ab").is_none());
+        assert!(e.value_by_nick("c").is_some());
+
+        // simulates the GLib type system to unuse the plugin.
+        TypePluginExt::unuse(plugin);
+    }
+}

--- a/glib/Gir_GObject.toml
+++ b/glib/Gir_GObject.toml
@@ -25,6 +25,7 @@ manual = [
     "GObject.Object",
     "GObject.Value",
     "GObject.EnumValue",
+    "GObject.FlagsValue",
     "GObject.TypeValueTable",
     "GObject.ParamFlags",
     "GObject.ParamSpec",

--- a/glib/src/enums.rs
+++ b/glib/src/enums.rs
@@ -243,6 +243,7 @@ impl Clone for EnumClass {
 // rustdoc-stripper-ignore-next
 /// Representation of a single enum value of an `EnumClass`.
 #[doc(alias = "GEnumValue")]
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct EnumValue(gobject_ffi::GEnumValue);
 
@@ -348,77 +349,26 @@ unsafe impl<'a, 'b> FromValue<'a> for &'b EnumValue {
     }
 }
 
-#[doc(hidden)]
-impl<'a> ToGlibContainerFromSlice<'a, *const gobject_ffi::GEnumValue> for EnumValue {
-    type Storage = &'a [Self];
-    fn to_glib_none_from_slice(t: &'a [Self]) -> (*const gobject_ffi::GEnumValue, Self::Storage) {
-        (t.as_ptr() as *const gobject_ffi::GEnumValue, t)
-    }
-    fn to_glib_container_from_slice(
-        _: &'a [Self],
-    ) -> (*const gobject_ffi::GEnumValue, Self::Storage) {
-        unimplemented!();
-    }
-    fn to_glib_full_from_slice(_: &[Self]) -> *const gobject_ffi::GEnumValue {
-        unimplemented!();
-    }
+// rustdoc-stripper-ignore-next
+/// Define the zero value and the associated GLib type.
+impl EnumerationValue<EnumValue> for EnumValue {
+    type GlibType = gobject_ffi::GEnumValue;
+    const ZERO: EnumValue = unsafe {
+        EnumValue::unsafe_from(gobject_ffi::GEnumValue {
+            value: 0,
+            value_name: ptr::null(),
+            value_nick: ptr::null(),
+        })
+    };
 }
 
 // rustdoc-stripper-ignore-next
-/// Storage of enumeration values terminated by an `EnumValue` with all members
-/// being 0. Should be used only as a storage location for enumeration values
-/// when registering an enumeration as a dynamic type.
-/// see `TypePluginRegisterImpl::register_dynamic_enum()` and `TypePluginImpl::complete_type_info()`.
-/// Inner is intentionally private to ensure other modules will not access the
-/// enumeration values by this way.
-/// Use `EnumClass::values()` or `EnumClass::value()` to get enumeration values.
-#[repr(transparent)]
-pub struct EnumValuesStorage<const S: usize>([EnumValue; S]);
-
-impl<const S: usize> EnumValuesStorage<S> {
-    // rustdoc-stripper-ignore-next
-    pub const fn new<const N: usize>(values: [EnumValue; N]) -> Self {
-        const ZERO: EnumValue = unsafe {
-            EnumValue::unsafe_from(gobject_ffi::GEnumValue {
-                value: 0,
-                value_name: ptr::null(),
-                value_nick: ptr::null(),
-            })
-        };
-        unsafe {
-            let v: [EnumValue; S] = [ZERO; S];
-            ptr::copy_nonoverlapping(values.as_ptr(), v.as_ptr() as _, N);
-            Self(v)
-        }
-    }
-}
-
-impl<const S: usize> AsRef<EnumValues> for EnumValuesStorage<S> {
-    fn as_ref(&self) -> &EnumValues {
-        // SAFETY: EnumValues is repr(transparent) over [EnumValue] so the cast is safe.
-        unsafe { &*(&self.0 as *const [EnumValue] as *const EnumValues) }
-    }
-}
+/// Storage of enum values.
+pub type EnumValuesStorage<const N: usize> = EnumerationValuesStorage<EnumValue, N>;
 
 // rustdoc-stripper-ignore-next
-/// Representation of enumeration values wrapped by `EnumValuesStorage`. Easier
-/// to use because don't have a size parameter to be specify. Should be used
-/// only to register an enumeration as a dynamic type.
-/// see `TypePluginRegisterImpl::register_dynamic_enum()` and `TypePluginImpl::complete_type_info()`.
-/// Field is intentionally private to ensure other modules will not access the
-/// enumeration values by this way.
-/// Use `EnumClass::values()` or `EnumClass::value()` to get the enumeration values.
-#[repr(transparent)]
-pub struct EnumValues([EnumValue]);
-
-impl Deref for EnumValues {
-    type Target = [EnumValue];
-
-    fn deref(&self) -> &Self::Target {
-        // SAFETY: EnumValues contains at least the zero `EnumValue` which terminates the enumeration values.
-        unsafe { std::slice::from_raw_parts(self.0.as_ptr(), self.0.len() - 1) }
-    }
-}
+/// Representation of enum values wrapped by `EnumValuesStorage`
+pub type EnumValues = EnumerationValues<EnumValue>;
 
 pub struct EnumTypeChecker();
 unsafe impl ValueTypeChecker for EnumTypeChecker {
@@ -886,6 +836,7 @@ impl ParseFlagsError {
 // rustdoc-stripper-ignore-next
 /// Representation of a single flags value of a `FlagsClass`.
 #[doc(alias = "GFlagsValue")]
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct FlagsValue(gobject_ffi::GFlagsValue);
 
@@ -974,77 +925,26 @@ impl UnsafeFrom<gobject_ffi::GFlagsValue> for FlagsValue {
     }
 }
 
-#[doc(hidden)]
-impl<'a> ToGlibContainerFromSlice<'a, *const gobject_ffi::GFlagsValue> for FlagsValue {
-    type Storage = &'a [Self];
-    fn to_glib_none_from_slice(t: &'a [Self]) -> (*const gobject_ffi::GFlagsValue, Self::Storage) {
-        (t.as_ptr() as *const gobject_ffi::GFlagsValue, t)
-    }
-    fn to_glib_container_from_slice(
-        _: &'a [Self],
-    ) -> (*const gobject_ffi::GFlagsValue, Self::Storage) {
-        unimplemented!();
-    }
-    fn to_glib_full_from_slice(_: &[Self]) -> *const gobject_ffi::GFlagsValue {
-        unimplemented!();
-    }
+// rustdoc-stripper-ignore-next
+/// Define the zero value and the associated GLib type.
+impl EnumerationValue<FlagsValue> for FlagsValue {
+    type GlibType = gobject_ffi::GFlagsValue;
+    const ZERO: FlagsValue = unsafe {
+        FlagsValue::unsafe_from(gobject_ffi::GFlagsValue {
+            value: 0,
+            value_name: ptr::null(),
+            value_nick: ptr::null(),
+        })
+    };
 }
 
 // rustdoc-stripper-ignore-next
-/// Storage of flags values terminated by a `FlagsValue` with all members
-/// being 0. Should be used only as a storage location for flags values
-/// when registering flags as a dynamic type.
-/// see `TypePluginRegisterImpl::register_dynamic_flags()` and `TypePluginImpl::complete_type_info()`.
-/// Inner is intentionally private to ensure other modules will not access the
-/// flags values by this way.
-/// Use `FlagsClass::values()` or `FlagsClass::value()` to get flags values.
-#[repr(transparent)]
-pub struct FlagsValuesStorage<const S: usize>([FlagsValue; S]);
-
-impl<const S: usize> FlagsValuesStorage<S> {
-    // rustdoc-stripper-ignore-next
-    pub const fn new<const N: usize>(values: [FlagsValue; N]) -> Self {
-        const ZERO: FlagsValue = unsafe {
-            FlagsValue::unsafe_from(gobject_ffi::GFlagsValue {
-                value: 0,
-                value_name: ptr::null(),
-                value_nick: ptr::null(),
-            })
-        };
-        unsafe {
-            let v: [FlagsValue; S] = [ZERO; S];
-            ptr::copy_nonoverlapping(values.as_ptr(), v.as_ptr() as _, N);
-            Self(v)
-        }
-    }
-}
-
-impl<const S: usize> AsRef<FlagsValues> for FlagsValuesStorage<S> {
-    fn as_ref(&self) -> &FlagsValues {
-        // SAFETY: FlagsValues is repr(transparent) over [FlagsValue] so the cast is safe.
-        unsafe { &*(&self.0 as *const [FlagsValue] as *const FlagsValues) }
-    }
-}
+/// Storage of flags values.
+pub type FlagsValuesStorage<const N: usize> = EnumerationValuesStorage<FlagsValue, N>;
 
 // rustdoc-stripper-ignore-next
-/// Representation of flags values wrapped by `FlagsValuesStorage`. Easier
-/// to use because don't have a size parameter to be specify. Should be used
-/// only to register flags as a dynamic type.
-/// see `TypePluginRegisterImpl::register_dynamic_flags()` and `TypePluginImpl::complete_type_info()`.
-/// Field is intentionally private to ensure other modules will not access the
-/// flags values by this way.
-/// Use `FlagsClass::values()` or `FlagsClass::value()` to get the flags values.
-#[repr(transparent)]
-pub struct FlagsValues([FlagsValue]);
-
-impl Deref for FlagsValues {
-    type Target = [FlagsValue];
-
-    fn deref(&self) -> &Self::Target {
-        // SAFETY: FlagsValues contains at least the zero `FlagsValue` which terminates the flags values.
-        unsafe { std::slice::from_raw_parts(self.0.as_ptr(), self.0.len() - 1) }
-    }
-}
+/// Representation of flags values wrapped by `FlagsValuesStorage`
+pub type FlagsValues = EnumerationValues<FlagsValue>;
 
 // rustdoc-stripper-ignore-next
 /// Builder for conveniently setting/unsetting flags and returning a `Value`.
@@ -1181,6 +1081,94 @@ impl fmt::Display for InvalidFlagsError {
 }
 
 impl std::error::Error for InvalidFlagsError {}
+
+// rustdoc-stripper-ignore-next
+/// helper trait to define the zero value and the associated GLib type.
+pub trait EnumerationValue<E>: Copy {
+    type GlibType;
+    const ZERO: E;
+}
+
+// rustdoc-stripper-ignore-next
+/// Storage of enumeration values terminated by a zero value. Should be used
+/// only as a storage location for `EnumValue` or `FlagsValue` when registering
+/// an enum or flags as a dynamic type.
+/// see `TypePluginRegisterImpl::register_dynamic_enum()`, `TypePluginRegisterImpl::register_dynamic_flags()`
+/// and `TypePluginImpl::complete_type_info()`.
+/// Inner is intentionally private to ensure other modules will not access the
+/// enum (or flags) values by this way.
+/// Use `EnumClass::values()` or `EnumClass::value()` to get the enum values.
+/// Use `FlagsClass::values()` or `FlagsClass::value()` to get the flags values.
+#[repr(C)]
+pub struct EnumerationValuesStorage<E: EnumerationValue<E>, const S: usize>([E; S]);
+
+impl<E: EnumerationValue<E>, const S: usize> EnumerationValuesStorage<E, S> {
+    // rustdoc-stripper-ignore-next
+    /// creates a new `EnumerationValuesStorage` with the given values and a final zero value.
+    pub const fn new<const N: usize>(values: [E; N]) -> Self {
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        struct Both<E: Copy, const N: usize>([E; N], [E; 1]);
+
+        #[repr(C)]
+        union Transmute<E: Copy, const N: usize, const S: usize> {
+            from: Both<E, N>,
+            to: [E; S],
+        }
+
+        // SAFETY: Transmute is repr(C) and union fields are compatible in terms of size and alignment, so the access to union fields is safe.
+        unsafe {
+            // create an array with the values and terminated by a zero value.
+            let all = Transmute {
+                from: Both(values, [E::ZERO; 1]),
+            }
+            .to;
+            Self(all)
+        }
+    }
+}
+
+impl<E: EnumerationValue<E>, const S: usize> AsRef<EnumerationValues<E>>
+    for EnumerationValuesStorage<E, S>
+{
+    fn as_ref(&self) -> &EnumerationValues<E> {
+        // SAFETY: EnumerationStorage and EnumerationValues are repr(C) and their unique field are compatible (array and slice of the same type), so the cast is safe.
+        unsafe { &*(&self.0 as *const [E] as *const EnumerationValues<E>) }
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// Representation of enumeration values wrapped by `EnumerationValuesStorage`.
+/// Easier to use because don't have a size parameter to be specify. Should be
+/// used only to register an enum or flags as a dynamic type.
+/// see `TypePluginRegisterImpl::register_dynamic_enum()`, `TypePluginRegisterImpl::register_dynamic_flags()`
+/// and `TypePluginImpl::complete_type_info()`.
+/// Field is intentionally private to ensure other modules will not access the
+/// enum (or flags) values by this way.
+/// Use `EnumClass::values()` or `EnumClass::value()` to get the enum values.
+/// Use `FlagsClass::values()` or `FlagsClass::value()` to get the flags values.
+#[repr(C)]
+pub struct EnumerationValues<E: EnumerationValue<E>>([E]);
+
+impl<E: EnumerationValue<E>> Deref for EnumerationValues<E> {
+    type Target = [E];
+
+    // rustdoc-stripper-ignore-next
+    /// Dereferences the enumeration values as a slice, but excluding the last value which is zero.
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: EnumerationValues contains at least the zero value which terminates the array.
+        unsafe { std::slice::from_raw_parts(self.0.as_ptr(), self.0.len() - 1) }
+    }
+}
+
+#[doc(hidden)]
+impl<'a, E: 'a + EnumerationValue<E>> ToGlibPtr<'a, *const E::GlibType> for EnumerationValues<E> {
+    type Storage = &'a Self;
+
+    fn to_glib_none(&'a self) -> Stash<'a, *const E::GlibType, Self> {
+        Stash(self.0.as_ptr() as *const E::GlibType, self)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/glib/src/gobject/dynamic_object.rs
+++ b/glib/src/gobject/dynamic_object.rs
@@ -1,8 +1,10 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::{
-    enums::EnumValues, prelude::*, subclass::prelude::*, InterfaceInfo, IsA, TypeFlags, TypeInfo,
-    TypeModule, TypePlugin,
+    enums::{EnumValues, FlagsValues},
+    prelude::*,
+    subclass::prelude::*,
+    InterfaceInfo, IsA, TypeFlags, TypeInfo, TypeModule, TypePlugin,
 };
 
 mod sealed {
@@ -22,6 +24,12 @@ pub trait DynamicObjectRegisterExt: AsRef<TypePlugin> + sealed::Sealed + 'static
         &self,
         name: &str,
         const_static_values: &'static EnumValues,
+    ) -> crate::types::Type;
+
+    fn register_dynamic_flags(
+        &self,
+        name: &str,
+        const_static_values: &'static FlagsValues,
     ) -> crate::types::Type;
 
     fn register_dynamic_type(
@@ -55,6 +63,14 @@ where
         self.imp().register_dynamic_enum(name, const_static_values)
     }
 
+    fn register_dynamic_flags(
+        &self,
+        name: &str,
+        const_static_values: &'static FlagsValues,
+    ) -> crate::types::Type {
+        self.imp().register_dynamic_flags(name, const_static_values)
+    }
+
     fn register_dynamic_type(
         &self,
         parent_type: crate::types::Type,
@@ -83,6 +99,14 @@ impl DynamicObjectRegisterExt for TypeModule {
         const_static_values: &'static EnumValues,
     ) -> crate::types::Type {
         <Self as TypeModuleExt>::register_enum(self, name, const_static_values)
+    }
+
+    fn register_dynamic_flags(
+        &self,
+        name: &str,
+        const_static_values: &'static FlagsValues,
+    ) -> crate::types::Type {
+        <Self as TypeModuleExt>::register_flags(self, name, const_static_values)
     }
 
     fn register_dynamic_type(

--- a/glib/src/gobject/type_module.rs
+++ b/glib/src/gobject/type_module.rs
@@ -1,7 +1,10 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use crate::{
-    enums::EnumValues, prelude::*, translate::*, InterfaceInfo, TypeFlags, TypeInfo, TypePlugin,
+    enums::{EnumValues, FlagsValues},
+    prelude::*,
+    translate::*,
+    InterfaceInfo, TypeFlags, TypeInfo, TypePlugin,
 };
 
 crate::wrapper! {
@@ -48,6 +51,21 @@ pub trait TypeModuleExt: IsA<TypeModule> + sealed::Sealed + 'static {
     ) -> crate::types::Type {
         unsafe {
             from_glib(gobject_ffi::g_type_module_register_enum(
+                self.as_ref().to_glib_none().0,
+                name.to_glib_none().0,
+                const_static_values.to_glib_none().0,
+            ))
+        }
+    }
+
+    #[doc(alias = "g_type_module_register_flags")]
+    fn register_flags(
+        &self,
+        name: &str,
+        const_static_values: &'static FlagsValues,
+    ) -> crate::types::Type {
+        unsafe {
+            from_glib(gobject_ffi::g_type_module_register_flags(
                 self.as_ref().to_glib_none().0,
                 name.to_glib_none().0,
                 const_static_values.to_glib_none().0,

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::enums::EnumValues;
+use crate::enums::{EnumValues, FlagsValues};
 use crate::translate::IntoGlib;
 use crate::translate::{FromGlib, ToGlibPtr};
 use crate::{
@@ -190,6 +190,13 @@ pub trait TypePluginRegisterImpl: ObjectImpl + TypePluginImpl {
         &self,
         _name: &str,
         _const_static_values: &'static EnumValues,
+    ) -> Type {
+        unimplemented!()
+    }
+    fn register_dynamic_flags(
+        &self,
+        _name: &str,
+        _const_static_values: &'static FlagsValues,
     ) -> Type {
         unimplemented!()
     }


### PR DESCRIPTION
This PR aims to add support of flags registered as dynamic types. See https://docs.gtk.org/gobject/class.TypeModule.html and https://docs.gtk.org/gobject/iface.TypePlugin.html.
The new macro `flags_dynamic` allows to register the flags that are part of a module or of a plugin (e.g. a shared library on linux). This helper macro generates code that support registration when the plugin (`TypePlugin`) is used, following the behavior defined in Glib doc. However it is possible to postpone the registration at first use of the flags by explicitly setting the macro attribute `lazy_registration = true`.