### PR TITLE
Replace `once_cell` usage with std::sync::OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,6 @@ dependencies = [
  "freetype-rs",
  "glib",
  "libc",
- "once_cell",
  "tempfile",
  "thiserror",
 ]
@@ -419,7 +418,6 @@ dependencies = [
  "gir-format-check",
  "glib",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -459,7 +457,6 @@ dependencies = [
  "gir-format-check",
  "glib",
  "libc",
- "once_cell",
  "pin-project-lite",
  "serial_test",
  "smallvec",
@@ -504,7 +501,6 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "once_cell",
  "smallvec",
  "tempfile",
  "thiserror",
@@ -524,7 +520,6 @@ version = "0.19.0"
 dependencies = [
  "glib",
  "heck",
- "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -736,7 +731,6 @@ dependencies = [
  "gir-format-check",
  "glib",
  "libc",
- "once_cell",
  "pango-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ edition = "2021"
 rust-version = "1.70"
 
 [workspace.dependencies]
-once_cell = "1.19"
 libc = "0.2"
 bitflags = "2.4"
 thiserror = "1"

--- a/cairo/Cargo.toml
+++ b/cairo/Cargo.toml
@@ -40,7 +40,6 @@ ffi = { package = "cairo-sys-rs", path = "sys" }
 libc.workspace = true
 bitflags.workspace = true
 thiserror.workspace = true
-once_cell.workspace = true
 freetype-rs = { version = "0.35", optional = true }
 
 [dev-dependencies]

--- a/cairo/src/font/user_fonts.rs
+++ b/cairo/src/font/user_fonts.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::sync::OnceLock;
+
 use super::{FontExtents, FontFace, ScaledFont, TextCluster, TextClusterFlags, TextExtents};
 use crate::{utils::status_to_result, Context, Error, Glyph};
 
@@ -34,7 +36,7 @@ impl UserFontFace {
     where
         F: Fn(&ScaledFont, &Context, &mut FontExtents) -> Result<(), Error> + Send + Sync + 'static,
     {
-        static INIT_FUNC: once_cell::sync::OnceCell<BoxInitFunc> = once_cell::sync::OnceCell::new();
+        static INIT_FUNC: OnceLock<BoxInitFunc> = OnceLock::new();
         if INIT_FUNC.set(Box::new(func)).is_err() {
             panic!("Init func can only be set once")
         }
@@ -68,8 +70,7 @@ impl UserFontFace {
             + Sync
             + 'static,
     {
-        static RENDER_GLYPH_FUNC: once_cell::sync::OnceCell<BoxRenderGlyphFunc> =
-            once_cell::sync::OnceCell::new();
+        static RENDER_GLYPH_FUNC: OnceLock<BoxRenderGlyphFunc> = OnceLock::new();
         if RENDER_GLYPH_FUNC.set(Box::new(func)).is_err() {
             panic!("RenderGlyph func can only be set once")
         }
@@ -108,8 +109,7 @@ impl UserFontFace {
             + Sync
             + 'static,
     {
-        static RENDER_COLOR_GLYPH_FUNC: once_cell::sync::OnceCell<BoxRenderGlyphFunc> =
-            once_cell::sync::OnceCell::new();
+        static RENDER_COLOR_GLYPH_FUNC: OnceLock<BoxRenderGlyphFunc> = OnceLock::new();
         if RENDER_COLOR_GLYPH_FUNC.set(Box::new(func)).is_err() {
             panic!("RenderColorGlyph func can only be set once")
         }
@@ -145,8 +145,7 @@ impl UserFontFace {
     where
         F: Fn(&ScaledFont, libc::c_ulong) -> Result<libc::c_ulong, Error> + Send + Sync + 'static,
     {
-        static UNICODE_TO_GLYPH_FUNC: once_cell::sync::OnceCell<BoxUnicodeToGlyphFunc> =
-            once_cell::sync::OnceCell::new();
+        static UNICODE_TO_GLYPH_FUNC: OnceLock<BoxUnicodeToGlyphFunc> = OnceLock::new();
         if UNICODE_TO_GLYPH_FUNC.set(Box::new(func)).is_err() {
             panic!("UnicodeToGlyph func can only be set once")
         }
@@ -180,8 +179,7 @@ impl UserFontFace {
             + Sync
             + 'static,
     {
-        static TEXT_TO_GLYPHS_FUNC: once_cell::sync::OnceCell<BoxTextToGlyphsFunc> =
-            once_cell::sync::OnceCell::new();
+        static TEXT_TO_GLYPHS_FUNC: OnceLock<BoxTextToGlyphsFunc> = OnceLock::new();
         if TEXT_TO_GLYPHS_FUNC.set(Box::new(func)).is_err() {
             panic!("TextToGlyphs func can only be set once")
         }

--- a/examples/object_subclass/author.rs
+++ b/examples/object_subclass/author.rs
@@ -1,12 +1,12 @@
 // You can copy/paste this file every time you need a simple GObject
 // to hold some data
 
-use glib::once_cell::sync::Lazy;
 use glib::prelude::*;
 use glib::subclass::prelude::*;
 use glib::subclass::Signal;
 use glib::Properties;
 use std::cell::RefCell;
+use std::sync::OnceLock;
 
 mod imp {
     use super::*;
@@ -23,9 +23,8 @@ mod imp {
     #[glib::derived_properties]
     impl ObjectImpl for Author {
         fn signals() -> &'static [Signal] {
-            static SIGNALS: Lazy<Vec<Signal>> =
-                Lazy::new(|| vec![Signal::builder("awarded").build()]);
-            SIGNALS.as_ref()
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| vec![Signal::builder("awarded").build()])
         }
     }
 

--- a/gdk-pixbuf/Cargo.toml
+++ b/gdk-pixbuf/Cargo.toml
@@ -25,7 +25,6 @@ ffi = { package = "gdk-pixbuf-sys", path = "sys" }
 libc.workspace = true
 glib.workspace = true
 gio.workspace = true
-once_cell.workspace = true
 
 [dev-dependencies]
 gir-format-check.workspace = true

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -33,7 +33,6 @@ v2_80 = ["v2_78", "ffi/v2_80", "glib/v2_80"]
 
 [dependencies]
 libc.workspace = true
-once_cell.workspace = true
 futures-core = { version = "0.3", default-features = false }
 futures-channel = "0.3"
 futures-io = "0.3"

--- a/gio/src/subclass/io_stream.rs
+++ b/gio/src/subclass/io_stream.rs
@@ -1,9 +1,8 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::ptr;
+use std::{ptr, sync::OnceLock};
 
 use glib::{prelude::*, subclass::prelude::*, translate::*, Cast, Error};
-use once_cell::sync::Lazy;
 
 use crate::{Cancellable, IOStream, InputStream, OutputStream};
 
@@ -84,11 +83,6 @@ unsafe impl<T: IOStreamImpl> IsSubclassable<T> for IOStream {
     }
 }
 
-static OUTPUT_STREAM_QUARK: Lazy<glib::Quark> =
-    Lazy::new(|| glib::Quark::from_str("gtk-rs-subclass-output-stream"));
-static INPUT_STREAM_QUARK: Lazy<glib::Quark> =
-    Lazy::new(|| glib::Quark::from_str("gtk-rs-subclass-input-stream"));
-
 unsafe extern "C" fn stream_get_input_stream<T: IOStreamImpl>(
     ptr: *mut ffi::GIOStream,
 ) -> *mut ffi::GInputStream {
@@ -101,14 +95,18 @@ unsafe extern "C" fn stream_get_input_stream<T: IOStreamImpl>(
     // Ensure that a) the stream stays alive as long as the IO stream instance and
     // b) that the same stream is returned every time. This is a requirement by the
     // IO stream API.
-    if let Some(old_stream) = instance.qdata::<InputStream>(*INPUT_STREAM_QUARK) {
+    let input_stream_quark = {
+        static QUARK: OnceLock<glib::Quark> = OnceLock::new();
+        *QUARK.get_or_init(|| glib::Quark::from_str("gtk-rs-subclass-input-stream"))
+    };
+    if let Some(old_stream) = instance.qdata::<InputStream>(input_stream_quark) {
         assert_eq!(
             old_stream.as_ref(),
             &ret,
             "Did not return same input stream again"
         );
     }
-    instance.set_qdata(*INPUT_STREAM_QUARK, ret.clone());
+    instance.set_qdata(input_stream_quark, ret.clone());
     ret.to_glib_none().0
 }
 
@@ -124,14 +122,18 @@ unsafe extern "C" fn stream_get_output_stream<T: IOStreamImpl>(
     // Ensure that a) the stream stays alive as long as the IO stream instance and
     // b) that the same stream is returned every time. This is a requirement by the
     // IO stream API.
-    if let Some(old_stream) = instance.qdata::<OutputStream>(*OUTPUT_STREAM_QUARK) {
+    let output_stream_quark = {
+        static QUARK: OnceLock<glib::Quark> = OnceLock::new();
+        *QUARK.get_or_init(|| glib::Quark::from_str("gtk-rs-subclass-output-stream"))
+    };
+    if let Some(old_stream) = instance.qdata::<OutputStream>(output_stream_quark) {
         assert_eq!(
             old_stream.as_ref(),
             &ret,
             "Did not return same output stream again"
         );
     }
-    instance.set_qdata(*OUTPUT_STREAM_QUARK, ret.clone());
+    instance.set_qdata(output_stream_quark, ret.clone());
     ret.to_glib_none().0
 }
 

--- a/glib-macros/Cargo.toml
+++ b/glib-macros/Cargo.toml
@@ -25,4 +25,3 @@ proc-macro = true
 [dev-dependencies]
 glib.workspace = true
 trybuild2 = "1.2"
-once_cell.workspace = true

--- a/glib-macros/src/boxed_derive.rs
+++ b/glib-macros/src/boxed_derive.rs
@@ -135,19 +135,10 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> syn::Result<TokenStream> {
         impl #crate_ident::StaticType for #name {
             #[inline]
             fn static_type() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-                static mut TYPE_: #crate_ident::Type = #crate_ident::Type::INVALID;
-
-                ONCE.call_once(|| {
-                    let type_ = #crate_ident::subclass::register_boxed_type::<#name>();
-                    unsafe {
-                        TYPE_ = type_;
-                    }
-                });
-
-                unsafe {
-                    TYPE_
-                }
+                static TYPE: ::std::sync::OnceLock<#crate_ident::Type> = ::std::sync::OnceLock::new();
+                *TYPE.get_or_init(|| {
+                    #crate_ident::subclass::register_boxed_type::<#name>()
+                })
             }
         }
 

--- a/glib-macros/src/enum_derive.rs
+++ b/glib-macros/src/enum_derive.rs
@@ -236,10 +236,8 @@ fn register_enum_as_static(
             /// Registers the enum only once.
             #[inline]
             fn register_enum() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
-
-                ONCE.call_once(|| {
+                static TYPE: ::std::sync::OnceLock<#crate_ident::Type> = ::std::sync::OnceLock::new();
+                *TYPE.get_or_init(|| {
                     static mut VALUES: [#crate_ident::gobject_ffi::GEnumValue; #nb_enum_values] = [
                         #g_enum_values
                         #crate_ident::gobject_ffi::GEnumValue {
@@ -253,13 +251,9 @@ fn register_enum_as_static(
                         let type_ = #crate_ident::gobject_ffi::g_enum_register_static(name.as_ptr(), VALUES.as_ptr());
                         let type_: #crate_ident::Type = #crate_ident::translate::from_glib(type_);
                         assert!(type_.is_valid());
-                        TYPE = type_;
+                        type_
                     }
-                });
-
-                unsafe {
-                    TYPE
-                }
+                })
             }
         }
     }

--- a/glib-macros/src/error_domain_derive.rs
+++ b/glib-macros/src/error_domain_derive.rs
@@ -41,11 +41,10 @@ pub fn impl_error_domain(input: &syn::DeriveInput) -> syn::Result<TokenStream> {
             fn domain() -> #crate_ident::Quark {
                 use #crate_ident::translate::from_glib;
 
-                static QUARK: #crate_ident::once_cell::sync::Lazy<#crate_ident::Quark> =
-                    #crate_ident::once_cell::sync::Lazy::new(|| unsafe {
-                        from_glib(#crate_ident::ffi::g_quark_from_static_string(concat!(#domain_name, "\0") as *const ::core::primitive::str as *const _))
-                    });
-                *QUARK
+                static QUARK: ::std::sync::OnceLock<#crate_ident::Quark> = ::std::sync::OnceLock::new();
+                *QUARK.get_or_init(|| unsafe {
+                    from_glib(#crate_ident::ffi::g_quark_from_static_string(concat!(#domain_name, "\0") as *const ::core::primitive::str as *const _))
+                })
             }
 
             #[inline]

--- a/glib-macros/src/flags_attribute.rs
+++ b/glib-macros/src/flags_attribute.rs
@@ -267,10 +267,8 @@ fn register_flags_as_static(
             /// Registers the flags only once.
             #[inline]
             fn register_flags() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
-
-                ONCE.call_once(|| {
+                static TYPE: ::std::sync::OnceLock<#crate_ident::Type> = ::std::sync::OnceLock::new();
+                *TYPE.get_or_init(|| {
                     static mut VALUES: [#crate_ident::gobject_ffi::GFlagsValue; #nb_flags_values] = [
                         #g_flags_values
                         #crate_ident::gobject_ffi::GFlagsValue {
@@ -285,13 +283,9 @@ fn register_flags_as_static(
                         let type_ = #crate_ident::gobject_ffi::g_flags_register_static(name.as_ptr(), VALUES.as_ptr());
                         let type_: #crate_ident::Type = #crate_ident::translate::from_glib(type_);
                         assert!(type_.is_valid());
-                        TYPE = type_;
+                        type_
                     }
-                });
-
-                unsafe {
-                    TYPE
-                }
+                })
             }
         }
     }

--- a/glib-macros/src/object_interface_attribute.rs
+++ b/glib-macros/src/object_interface_attribute.rs
@@ -110,16 +110,10 @@ fn register_object_interface_as_static(
             /// Registers the interface only once.
             #[inline]
             fn register_interface() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-                static mut TYPE: #crate_ident::Type = #crate_ident::Type::INVALID;
-
-                ONCE.call_once(|| unsafe {
-                    TYPE = #crate_ident::subclass::register_interface::<Self>();
-                });
-
-                unsafe {
-                    TYPE
-                }
+                static TYPE: ::std::sync::OnceLock<#crate_ident::Type> = ::std::sync::OnceLock::new();
+                *TYPE.get_or_init(|| unsafe {
+                    #crate_ident::subclass::register_interface::<Self>()
+                })
             }
         }
     }

--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -398,11 +398,10 @@ fn expand_properties_fn(props: &[PropDesc]) -> TokenStream2 {
     quote!(
         fn derived_properties() -> &'static [#crate_ident::ParamSpec] {
             use #crate_ident::ParamSpecBuilderExt;
-            use #crate_ident::once_cell::sync::Lazy;
-            static PROPERTIES: Lazy<[#crate_ident::ParamSpec; #n_props]> = Lazy::new(|| [
+            static PROPERTIES: ::std::sync::OnceLock<[#crate_ident::ParamSpec; #n_props]> = ::std::sync::OnceLock::new();
+            PROPERTIES.get_or_init(|| [
                 #(#param_specs,)*
-            ]);
-            PROPERTIES.as_ref()
+            ])
         }
     )
 }

--- a/glib-macros/src/shared_boxed_derive.rs
+++ b/glib-macros/src/shared_boxed_derive.rs
@@ -157,17 +157,10 @@ pub fn impl_shared_boxed(input: &syn::DeriveInput) -> syn::Result<proc_macro2::T
         impl #crate_ident::StaticType for #name {
             #[inline]
             fn static_type() -> #crate_ident::Type {
-                static ONCE: ::std::sync::Once = ::std::sync::Once::new();
-                static mut TYPE_: #crate_ident::Type = #crate_ident::Type::INVALID;
-
-                ONCE.call_once(|| {
-                    let type_ = #crate_ident::subclass::shared::register_shared_type::<#name>();
-                    unsafe {
-                        TYPE_ = type_;
-                    }
-                });
-
-                unsafe { TYPE_ }
+                static TYPE: ::std::sync::OnceLock<#crate_ident::Type> = ::std::sync::OnceLock::new();
+                *TYPE.get_or_init(|| {
+                    #crate_ident::subclass::shared::register_shared_type::<#name>()
+                })
             }
         }
 

--- a/glib-macros/src/variant_derive.rs
+++ b/glib-macros/src/variant_derive.rs
@@ -60,7 +60,8 @@ fn derive_variant_for_struct(
                 impl #impl_generics #glib::StaticVariantType for #ident #type_generics #where_clause {
                     #[inline]
                     fn static_variant_type() -> ::std::borrow::Cow<'static, #glib::VariantTy> {
-                        static TYP: #glib::once_cell::sync::Lazy<#glib::VariantType> = #glib::once_cell::sync::Lazy::new(|| {
+                        static TYP: ::std::sync::OnceLock<#glib::VariantType> = ::std::sync::OnceLock::new();
+                        ::std::borrow::Cow::Borrowed(TYP.get_or_init(|| {
 
                             let mut builder = #glib::GStringBuilder::new("(");
 
@@ -73,9 +74,7 @@ fn derive_variant_for_struct(
                             builder.append_c(')');
 
                             #glib::VariantType::from_string(builder.into_string()).unwrap()
-                        });
-
-                        ::std::borrow::Cow::Borrowed(&*TYP)
+                        }))
                     }
                 }
             };
@@ -137,7 +136,8 @@ fn derive_variant_for_struct(
                 impl #impl_generics #glib::StaticVariantType for #ident #type_generics #where_clause {
                     #[inline]
                     fn static_variant_type() -> ::std::borrow::Cow<'static, #glib::VariantTy> {
-                        static TYP: #glib::once_cell::sync::Lazy<#glib::VariantType> = #glib::once_cell::sync::Lazy::new(|| unsafe {
+                        static TYP: ::std::sync::OnceLock<#glib::VariantType> = ::std::sync::OnceLock::new();
+                        ::std::borrow::Cow::Borrowed(TYP.get_or_init(|| unsafe {
                             let ptr = #glib::ffi::g_string_sized_new(16);
                             #glib::ffi::g_string_append_c(ptr, b'(' as _);
 
@@ -156,9 +156,7 @@ fn derive_variant_for_struct(
                             #glib::translate::from_glib_full(
                                 #glib::ffi::g_string_free(ptr, #glib::ffi::GFALSE) as *mut #glib::ffi::GVariantType
                             )
-                        });
-
-                        ::std::borrow::Cow::Borrowed(&*TYP)
+                        }))
                     }
                 }
             };

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -50,7 +50,6 @@ mod foo {
     use glib::prelude::*;
     use glib::subclass::prelude::*;
     use glib_macros::{Properties, ValueDelegate};
-    use once_cell::sync::OnceCell;
     use std::cell::Cell;
     use std::cell::RefCell;
     use std::marker::PhantomData;
@@ -79,7 +78,7 @@ mod foo {
     }
 
     pub mod imp {
-        use std::rc::Rc;
+        use std::{cell::OnceCell, rc::Rc};
 
         use super::*;
 

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -17,7 +17,6 @@ version.workspace = true
 name = "glib"
 
 [dependencies]
-once_cell.workspace = true
 libc.workspace = true
 bitflags.workspace = true
 futures-core = { version = "0.3", default-features = false }

--- a/glib/src/gobject/binding.rs
+++ b/glib/src/gobject/binding.rs
@@ -219,9 +219,7 @@ mod test {
     }
 
     mod imp {
-        use std::cell::RefCell;
-
-        use once_cell::sync::Lazy;
+        use std::{cell::RefCell, sync::OnceLock};
 
         use super::*;
         use crate as glib;
@@ -240,7 +238,8 @@ mod test {
 
         impl ObjectImpl for TestObject {
             fn properties() -> &'static [crate::ParamSpec] {
-                static PROPERTIES: Lazy<Vec<crate::ParamSpec>> = Lazy::new(|| {
+                static PROPERTIES: OnceLock<Vec<crate::ParamSpec>> = OnceLock::new();
+                PROPERTIES.get_or_init(|| {
                     vec![
                         crate::ParamSpecString::builder("name")
                             .explicit_notify()
@@ -249,8 +248,7 @@ mod test {
                             .explicit_notify()
                             .build(),
                     ]
-                });
-                PROPERTIES.as_ref()
+                })
             }
 
             fn property(&self, _id: usize, pspec: &crate::ParamSpec) -> crate::Value {

--- a/glib/src/gobject/binding_group.rs
+++ b/glib/src/gobject/binding_group.rs
@@ -419,9 +419,7 @@ mod test {
     }
 
     mod imp {
-        use std::cell::RefCell;
-
-        use once_cell::sync::Lazy;
+        use std::{cell::RefCell, sync::OnceLock};
 
         use super::*;
         use crate as glib;
@@ -440,7 +438,8 @@ mod test {
 
         impl ObjectImpl for TestObject {
             fn properties() -> &'static [crate::ParamSpec] {
-                static PROPERTIES: Lazy<Vec<crate::ParamSpec>> = Lazy::new(|| {
+                static PROPERTIES: OnceLock<Vec<crate::ParamSpec>> = OnceLock::new();
+                PROPERTIES.get_or_init(|| {
                     vec![
                         crate::ParamSpecString::builder("name")
                             .explicit_notify()
@@ -449,8 +448,7 @@ mod test {
                             .explicit_notify()
                             .build(),
                     ]
-                });
-                PROPERTIES.as_ref()
+                })
             }
 
             fn property(&self, _id: usize, pspec: &crate::ParamSpec) -> crate::Value {

--- a/glib/src/gobject/signal_group.rs
+++ b/glib/src/gobject/signal_group.rs
@@ -173,7 +173,7 @@ impl SignalGroup {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{cell::RefCell, rc::Rc, sync::OnceLock};
 
     use super::*;
     use crate as glib;
@@ -194,8 +194,8 @@ mod tests {
 
         impl ObjectImpl for SignalObject {
             fn signals() -> &'static [Signal] {
-                use once_cell::sync::Lazy;
-                static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
+                static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+                SIGNALS.get_or_init(|| {
                     vec![
                         Signal::builder("sig-with-args")
                             .param_types([u32::static_type(), String::static_type()])
@@ -204,8 +204,7 @@ mod tests {
                             .return_type::<String>()
                             .build(),
                     ]
-                });
-                SIGNALS.as_ref()
+                })
             }
         }
     }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -14,7 +14,6 @@ pub use glib_macros::{
     Boxed, Downgrade, Enum, ErrorDomain, Properties, SharedBoxed, ValueDelegate, Variant,
 };
 pub use gobject_ffi;
-pub use once_cell;
 
 pub use self::{
     byte_array::ByteArray,

--- a/glib/src/log.rs
+++ b/glib/src/log.rs
@@ -4,10 +4,8 @@
 use std::os::unix::io::AsRawFd;
 use std::{
     boxed::Box as Box_,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
-
-use once_cell::sync::Lazy;
 
 use crate::{translate::*, GStr, GString, LogWriterOutput};
 
@@ -218,14 +216,17 @@ pub fn log_set_fatal_mask(log_domain: Option<&str>, fatal_levels: LogLevels) -> 
 
 type PrintCallback = dyn Fn(&str) + Send + Sync + 'static;
 
-static PRINT_HANDLER: Lazy<Mutex<Option<Arc<PrintCallback>>>> = Lazy::new(|| Mutex::new(None));
+fn print_handler() -> &'static Mutex<Option<Arc<PrintCallback>>> {
+    static MUTEX: OnceLock<Mutex<Option<Arc<PrintCallback>>>> = OnceLock::new();
+    MUTEX.get_or_init(|| Mutex::new(None))
+}
 
 // rustdoc-stripper-ignore-next
 /// To set back the default print handler, use the [`unset_print_handler`] function.
 #[doc(alias = "g_set_print_handler")]
 pub fn set_print_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
     unsafe extern "C" fn func_func(string: *const libc::c_char) {
-        if let Some(callback) = PRINT_HANDLER
+        if let Some(callback) = print_handler()
             .lock()
             .expect("Failed to lock PRINT_HANDLER")
             .as_ref()
@@ -235,7 +236,7 @@ pub fn set_print_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
             (*callback)(string.as_str())
         }
     }
-    *PRINT_HANDLER
+    *print_handler()
         .lock()
         .expect("Failed to lock PRINT_HANDLER to change callback") = Some(Arc::new(func));
     unsafe { ffi::g_set_print_handler(Some(func_func as _)) };
@@ -244,20 +245,23 @@ pub fn set_print_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
 // rustdoc-stripper-ignore-next
 /// To set the default print handler, use the [`set_print_handler`] function.
 pub fn unset_print_handler() {
-    *PRINT_HANDLER
+    *print_handler()
         .lock()
         .expect("Failed to lock PRINT_HANDLER to remove callback") = None;
     unsafe { ffi::g_set_print_handler(None) };
 }
 
-static PRINTERR_HANDLER: Lazy<Mutex<Option<Arc<PrintCallback>>>> = Lazy::new(|| Mutex::new(None));
+fn printerr_handler() -> &'static Mutex<Option<Arc<PrintCallback>>> {
+    static MUTEX: OnceLock<Mutex<Option<Arc<PrintCallback>>>> = OnceLock::new();
+    MUTEX.get_or_init(|| Mutex::new(None))
+}
 
 // rustdoc-stripper-ignore-next
 /// To set back the default print handler, use the [`unset_printerr_handler`] function.
 #[doc(alias = "g_set_printerr_handler")]
 pub fn set_printerr_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
     unsafe extern "C" fn func_func(string: *const libc::c_char) {
-        if let Some(callback) = PRINTERR_HANDLER
+        if let Some(callback) = printerr_handler()
             .lock()
             .expect("Failed to lock PRINTERR_HANDLER")
             .as_ref()
@@ -267,7 +271,7 @@ pub fn set_printerr_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
             (*callback)(string.as_str())
         }
     }
-    *PRINTERR_HANDLER
+    *printerr_handler()
         .lock()
         .expect("Failed to lock PRINTERR_HANDLER to change callback") = Some(Arc::new(func));
     unsafe { ffi::g_set_printerr_handler(Some(func_func as _)) };
@@ -276,7 +280,7 @@ pub fn set_printerr_handler<P: Fn(&str) + Send + Sync + 'static>(func: P) {
 // rustdoc-stripper-ignore-next
 /// To set the default print handler, use the [`set_printerr_handler`] function.
 pub fn unset_printerr_handler() {
-    *PRINTERR_HANDLER
+    *printerr_handler()
         .lock()
         .expect("Failed to lock PRINTERR_HANDLER to remove callback") = None;
     unsafe { ffi::g_set_printerr_handler(None) };
@@ -284,7 +288,10 @@ pub fn unset_printerr_handler() {
 
 type LogCallback = dyn Fn(Option<&str>, LogLevel, &str) + Send + Sync + 'static;
 
-static DEFAULT_HANDLER: Lazy<Mutex<Option<Arc<LogCallback>>>> = Lazy::new(|| Mutex::new(None));
+fn default_handler() -> &'static Mutex<Option<Arc<LogCallback>>> {
+    static MUTEX: OnceLock<Mutex<Option<Arc<LogCallback>>>> = OnceLock::new();
+    MUTEX.get_or_init(|| Mutex::new(None))
+}
 
 // rustdoc-stripper-ignore-next
 /// To set back the default print handler, use the [`log_unset_default_handler`] function.
@@ -298,7 +305,7 @@ pub fn log_set_default_handler<P: Fn(Option<&str>, LogLevel, &str) + Send + Sync
         message: *const libc::c_char,
         _user_data: ffi::gpointer,
     ) {
-        if let Some(callback) = DEFAULT_HANDLER
+        if let Some(callback) = default_handler()
             .lock()
             .expect("Failed to lock DEFAULT_HANDLER")
             .as_ref()
@@ -313,7 +320,7 @@ pub fn log_set_default_handler<P: Fn(Option<&str>, LogLevel, &str) + Send + Sync
             );
         }
     }
-    *DEFAULT_HANDLER
+    *default_handler()
         .lock()
         .expect("Failed to lock DEFAULT_HANDLER to change callback") = Some(Arc::new(log_func));
     unsafe { ffi::g_log_set_default_handler(Some(func_func as _), std::ptr::null_mut()) };
@@ -323,7 +330,7 @@ pub fn log_set_default_handler<P: Fn(Option<&str>, LogLevel, &str) + Send + Sync
 /// To set the default print handler, use the [`log_set_default_handler`] function.
 #[doc(alias = "g_log_set_default_handler")]
 pub fn log_unset_default_handler() {
-    *DEFAULT_HANDLER
+    *default_handler()
         .lock()
         .expect("Failed to lock DEFAULT_HANDLER to remove callback") = None;
     unsafe {
@@ -431,8 +438,7 @@ impl<'a> LogField<'a> {
 
 type WriterCallback = dyn Fn(LogLevel, &[LogField<'_>]) -> LogWriterOutput + Send + Sync + 'static;
 
-static WRITER_FUNC: once_cell::sync::OnceCell<Box<WriterCallback>> =
-    once_cell::sync::OnceCell::new();
+static WRITER_FUNC: OnceLock<Box<WriterCallback>> = OnceLock::new();
 
 #[doc(alias = "g_log_set_writer_func")]
 pub fn log_set_writer_func<

--- a/glib/src/property.rs
+++ b/glib/src/property.rs
@@ -41,12 +41,6 @@ impl<T: Property> Property for Mutex<T> {
 impl<T: Property> Property for RwLock<T> {
     type Value = T::Value;
 }
-impl<T: Property> Property for once_cell::sync::OnceCell<T> {
-    type Value = T::Value;
-}
-impl<T: Property> Property for once_cell::unsync::OnceCell<T> {
-    type Value = T::Value;
-}
 impl<T: Property> Property for std::cell::OnceCell<T> {
     type Value = T::Value;
 }
@@ -151,37 +145,6 @@ impl<T> PropertySetNested for RwLock<T> {
     type SetNestedValue = T;
     fn set_nested<F: FnOnce(&mut Self::SetNestedValue)>(&self, f: F) {
         f(&mut self.write().unwrap());
-    }
-}
-
-impl<T> PropertyGet for once_cell::sync::OnceCell<T> {
-    type Value = T;
-    fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {
-        f(self.get().unwrap())
-    }
-}
-impl<T> PropertyGet for once_cell::unsync::OnceCell<T> {
-    type Value = T;
-    fn get<R, F: Fn(&Self::Value) -> R>(&self, f: F) -> R {
-        f(self.get().unwrap())
-    }
-}
-impl<T> PropertySet for once_cell::sync::OnceCell<T> {
-    type SetValue = T;
-    fn set(&self, v: Self::SetValue) {
-        // I can't use `unwrap` because I would have to add a `Debug` bound to _v
-        if let Err(_v) = self.set(v) {
-            panic!("can't set value of OnceCell multiple times")
-        };
-    }
-}
-impl<T> PropertySet for once_cell::unsync::OnceCell<T> {
-    type SetValue = T;
-    fn set(&self, v: Self::SetValue) {
-        // I can't use `unwrap` because I would have to add a `Debug` bound to _v
-        if let Err(_v) = self.set(v) {
-            panic!("can't set value of OnceCell multiple times")
-        };
     }
 }
 

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -95,8 +95,9 @@
 //!     impl ObjectImpl for SimpleObject {
 //!         // Called once in the very beginning to list all properties of this class.
 //!         fn properties() -> &'static [glib::ParamSpec] {
-//!             use once_cell::sync::Lazy;
-//!             static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+//!             use std::sync::OnceLock;
+//!             static PROPERTIES: OnceLock<Vec<glib::ParamSpec>> = OnceLock::new();
+//!             PROPERTIES.get_or_init(|| {
 //!                 vec![
 //!                     glib::ParamSpecString::builder("name")
 //!                         .build(),
@@ -107,9 +108,7 @@
 //!                     glib::ParamSpecVariant::builder("variant", glib::VariantTy::ANY)
 //!                         .build(),
 //!                 ]
-//!             });
-//!
-//!             PROPERTIES.as_ref()
+//!             })
 //!         }
 //!
 //!         // Called whenever a property is set on this instance. The id

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -329,6 +329,8 @@ mod test {
     use crate as glib;
 
     mod imp {
+        use std::sync::OnceLock;
+
         use super::*;
 
         // A dummy `Object` to test setting an `Object` property and returning an `Object` in signals
@@ -359,8 +361,8 @@ mod test {
 
         impl ObjectImpl for SimpleObject {
             fn properties() -> &'static [ParamSpec] {
-                use once_cell::sync::Lazy;
-                static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
+                static PROPERTIES: OnceLock<Vec<ParamSpec>> = OnceLock::new();
+                PROPERTIES.get_or_init(|| {
                     vec![
                         crate::ParamSpecString::builder("name").build(),
                         crate::ParamSpecString::builder("construct-name")
@@ -371,14 +373,12 @@ mod test {
                             .build(),
                         crate::ParamSpecObject::builder::<super::ChildObject>("child").build(),
                     ]
-                });
-
-                PROPERTIES.as_ref()
+                })
             }
 
             fn signals() -> &'static [super::Signal] {
-                use once_cell::sync::Lazy;
-                static SIGNALS: Lazy<Vec<super::Signal>> = Lazy::new(|| {
+                static SIGNALS: OnceLock<Vec<super::Signal>> = OnceLock::new();
+                SIGNALS.get_or_init(|| {
                     vec![
                         super::Signal::builder("name-changed")
                             .param_types([String::static_type()])
@@ -410,9 +410,7 @@ mod test {
                             .return_type::<super::ChildObject>()
                             .build(),
                     ]
-                });
-
-                SIGNALS.as_ref()
+                })
             }
 
             fn set_property(&self, _id: usize, value: &Value, pspec: &crate::ParamSpec) {

--- a/glib/src/utils.rs
+++ b/glib/src/utils.rs
@@ -192,15 +192,18 @@ pub fn uri_unescape_segment(
 
 #[cfg(test)]
 mod tests {
-    use std::{env, sync::Mutex};
+    use std::{env, sync::Mutex, sync::OnceLock};
 
     //Mutex to prevent run environment tests parallel
-    static LOCK: once_cell::sync::Lazy<Mutex<()>> = once_cell::sync::Lazy::new(|| Mutex::new(()));
+    fn lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     const VAR_NAME: &str = "function_environment_test";
 
     fn check_getenv(val: &str) {
-        let _data = LOCK.lock().unwrap();
+        let _data = lock().lock().unwrap();
 
         env::set_var(VAR_NAME, val);
         assert_eq!(env::var_os(VAR_NAME), Some(val.into()));
@@ -211,7 +214,7 @@ mod tests {
     }
 
     fn check_setenv(val: &str) {
-        let _data = LOCK.lock().unwrap();
+        let _data = lock().lock().unwrap();
 
         crate::setenv(VAR_NAME, val, true).unwrap();
         assert_eq!(env::var_os(VAR_NAME), Some(val.into()));

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -24,7 +24,6 @@ v1_52 = ["v1_50", "ffi/v1_52"]
 [dependencies]
 ffi = { package = "pango-sys", path = "sys" }
 libc.workspace = true
-once_cell.workspace = true
 glib.workspace = true
 gio.workspace = true
 


### PR DESCRIPTION
Closes #30 
Closes #1141 

See also ~~https://github.com/gtk-rs/gir/pull/1532~~ https://github.com/gtk-rs/gir/pull/1537

This change does not fully remove `once_cell`. Full removal will break a contract of `glib::Properties` macro. 