### PR TITLE
cairo: Fix version of the v1_18 feature

### DIFF
--- a/cairo/sys/Cargo.toml
+++ b/cairo/sys/Cargo.toml
@@ -20,7 +20,7 @@ version = "1.14"
 version = "1.16"
 
 [package.metadata.system-deps.cairo.v1_18]
-version = "1.17"
+version = "1.18"
 
 [package.metadata.system-deps."cairo-gobject"]
 name = "cairo-gobject"
@@ -31,7 +31,7 @@ feature = "use_glib"
 version = "1.16"
 
 [package.metadata.system-deps."cairo-gobject".v1_18]
-version = "1.17"
+version = "1.18"
 
 [lib]
 name = "cairo_sys"


### PR DESCRIPTION
Hi,

This PR fixes a typo in the requested version of Cairo when the feature `v1_18` is enabled.

Without this patch, this error occurs:

```
   Compiling rsvg_convert v2.57.91 (E:\librsvg\rsvg_convert)
error: linking with `link.exe` failed: exit code: 1120
  |
  = note: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Preview\\VC\\Tools\\MSVC\\14.39.33428\\bin\\HostX64\\x64\\link.exe" "/NOLOGO" <snip> "windows.0.52.0.lib" "cairo-gobject.lib" "png16.lib" "z.lib" "gio-2.0.lib" "xml2.lib" "pangocairo-1.0.lib" "cairo.lib" "pangoft2-1.0.lib" "pango-1.0.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "harfbuzz.lib" "fontconfig.lib" "freetype.lib" "pangocairo-1.0.lib" "pango-1.0.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "harfbuzz.lib" "cairo.lib" "cairo-gobject.lib" "cairo.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "pango-1.0.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "harfbuzz.lib" "windows.0.48.5.lib" "kernel32.lib" "gdk_pixbuf-2.0.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "gobject-2.0.lib" "gio-2.0.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "gobject-2.0.lib" "glib-2.0.lib" "intl.lib" "legacy_stdio_definitions.lib" "windows.0.52.0.lib" "kernel32.lib" "advapi32.lib" "bcrypt.lib" "kernel32.lib" "ntdll.lib" "userenv.lib" "ws2_32.lib" "kernel32.lib" "ws2_32.lib" "kernel32.lib" "ntdll.lib" "kernel32.lib" "msvcrt.lib" 
"/NXCOMPAT" "/LIBPATH:C:\\Users\\Amalia\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib" "/OUT:E:/librsvg/build/rsvg_convert/target\\debug\\deps\\rsvg_convert.exe" "/OPT:REF,NOICF" "/DEBUG" "/NATVIS:C:\\Users\\Amalia\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\intrinsic.natvis" "/NATVIS:C:\\Users\\Amalia\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\liballoc.natvis" "/NATVIS:C:\\Users\\Amalia\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libcore.natvis" "/NATVIS:C:\\Users\\Amalia\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\etc\\libstd.natvis"
  = note: libcairo-1cdbb704108cdc7b.rlib(cairo-1cdbb704108cdc7b.cairo.7725b6cd3b7f4ef1-cgu.3.rcgu.o) : error LNK2019: unresolved external symbol cairo_pdf_surface_set_custom_metadata referenced in function _ZN5cairo3pdf10PdfSurface19set_custom_metadata17h53367c8d57ee67e0E
          libcairo-1cdbb704108cdc7b.rlib(cairo-1cdbb704108cdc7b.cairo.7725b6cd3b7f4ef1-cgu.4.rcgu.o) : error LNK2019: unresolved external symbol cairo_set_hairline referenced in function _ZN5cairo7context7Context12set_hairline17h230aded59309a7d7E
          libcairo-1cdbb704108cdc7b.rlib(cairo-1cdbb704108cdc7b.cairo.7725b6cd3b7f4ef1-cgu.4.rcgu.o) : error LNK2019: unresolved external symbol cairo_get_hairline referenced in function _ZN5cairo7context7Context8hairline17h488d8f80b5445f8bE
          E:\librsvg\build\rsvg_convert\target\debug\deps\rsvg_convert.exe : fatal error LNK1120: 3 unresolved externals
```

These three APIs were introduced in [v1.18](https://www.cairographics.org/manual/api-index-1-18.html#api-index-1.18), not 1.17.