### PR TITLE
docs: Move metadata back to packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,3 @@ pango = { path = "pango", version = "0.20" }
 cairo-sys-rs = { path = "cairo/sys", version = "0.20" }
 cairo-rs = { path = "cairo", version = "0.20" }
 glib-macros = { path = "glib-macros", version = "0.20" }
-
-[workspace.metadata.docs.rs]
-all-features = true
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/cairo/Cargo.toml
+++ b/cairo/Cargo.toml
@@ -45,3 +45,8 @@ freetype-rs = { version = "0.35", optional = true }
 [dev-dependencies]
 tempfile = "3.10"
 float_eq = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/cairo/sys/Cargo.toml
+++ b/cairo/sys/Cargo.toml
@@ -67,3 +67,8 @@ windows-sys = { version = "0.52", features = ["Win32_Graphics_Gdi"], optional = 
 
 [build-dependencies]
 system-deps = "6"
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/gdk-pixbuf/Cargo.toml
+++ b/gdk-pixbuf/Cargo.toml
@@ -28,3 +28,8 @@ gio.workspace = true
 
 [dev-dependencies]
 gir-format-check.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -48,3 +48,8 @@ futures = "0.3"
 futures-util = { version = "0.3", features = ["io"] }
 gir-format-check.workspace = true
 serial_test = "3"
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/glib/Cargo.toml
+++ b/glib/Cargo.toml
@@ -65,3 +65,8 @@ required-features = ["compiletests"]
 [[bench]]
 name = "gstring"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/graphene/Cargo.toml
+++ b/graphene/Cargo.toml
@@ -26,3 +26,8 @@ glib.workspace = true
 
 [dev-dependencies]
 gir-format-check.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/pango/Cargo.toml
+++ b/pango/Cargo.toml
@@ -29,3 +29,8 @@ gio.workspace = true
 
 [dev-dependencies]
 gir-format-check.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/pangocairo/Cargo.toml
+++ b/pangocairo/Cargo.toml
@@ -22,3 +22,8 @@ cairo-rs.workspace = true
 
 [dev-dependencies]
 gir-format-check.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]


### PR DESCRIPTION
The workspace one is not picked... no idea why & how

cc @sdroege 