### PR TITLE
glib: Add `Quark::from_static_str()`

### DIFF
--- a/glib/src/quark.rs
+++ b/glib/src/quark.rs
@@ -12,13 +12,13 @@ pub struct Quark(NonZeroU32);
 impl Quark {
     #[doc(alias = "g_quark_from_string")]
     #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: impl IntoGStr) -> Quark {
+    pub fn from_str(s: impl IntoGStr) -> Self {
         unsafe { s.run_with_gstr(|s| from_glib(ffi::g_quark_from_string(s.as_ptr()))) }
     }
 
     #[doc(alias = "g_quark_from_static_string")]
     #[allow(clippy::should_implement_trait)]
-    pub fn from_static_str(s: &'static GStr) -> Quark {
+    pub fn from_static_str(s: &'static GStr) -> Self {
         unsafe { from_glib(ffi::g_quark_from_static_string(s.as_ptr())) }
     }
 
@@ -29,7 +29,7 @@ impl Quark {
     }
 
     #[doc(alias = "g_quark_try_string")]
-    pub fn try_from_str(s: &str) -> Option<Quark> {
+    pub fn try_from_str(s: &str) -> Option<Self> {
         unsafe { Self::try_from_glib(ffi::g_quark_try_string(s.to_glib_none().0)).ok() }
     }
 }

--- a/glib/src/quark.rs
+++ b/glib/src/quark.rs
@@ -16,6 +16,12 @@ impl Quark {
         unsafe { s.run_with_gstr(|s| from_glib(ffi::g_quark_from_string(s.as_ptr()))) }
     }
 
+    #[doc(alias = "g_quark_from_static_string")]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_static_str(s: &'static GStr) -> Quark {
+        unsafe { from_glib(ffi::g_quark_from_static_string(s.as_ptr())) }
+    }
+
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[doc(alias = "g_quark_to_string")]
     pub fn as_str<'a>(&self) -> &'a GStr {


### PR DESCRIPTION
This avoids an allocation if the string is already statically allocated.