### PR TITLE
glib: Drop the main context future return value sender on finalize

### DIFF
--- a/glib/src/subclass/shared.rs
+++ b/glib/src/subclass/shared.rs
@@ -271,6 +271,10 @@ mod test {
         }
 
         assert_eq!(std::sync::Arc::strong_count(&b.0), 2);
+        unsafe {
+            let _ = std::sync::Arc::from_raw(inner_raw_ptr);
+        }
+        assert_eq!(std::sync::Arc::strong_count(&b.0), 1);
     }
 
     #[test]
@@ -291,5 +295,9 @@ mod test {
         }
 
         assert_eq!(std::rc::Rc::strong_count(&b.0), 2);
+        unsafe {
+            let _ = std::rc::Rc::from_raw(inner_raw_ptr);
+        }
+        assert_eq!(std::rc::Rc::strong_count(&b.0), 1);
     }
 }


### PR DESCRIPTION
Otherwise it's going to be leaked if the future is dropped/aborted before it yields a value.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1326