### PR TITLE
glib: Don't misuse `slice::get_unchecked()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,18 +158,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "criterion"

--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -1479,21 +1479,21 @@ mod test {
         let items = ["str1", "str2", "str3", "str4"];
 
         items[..].run_with_strv(|s| unsafe {
-            assert!(s.get_unchecked(4).is_null());
+            assert!((*s.as_ptr().add(4)).is_null());
             assert_eq!(s.len(), items.len());
             let s = StrV::from_glib_borrow(s.as_ptr() as *const *const c_char);
             assert_eq!(s, items);
         });
 
         Vec::from(&items[..]).run_with_strv(|s| unsafe {
-            assert!(s.get_unchecked(4).is_null());
+            assert!((*s.as_ptr().add(4)).is_null());
             assert_eq!(s.len(), items.len());
             let s = StrV::from_glib_borrow(s.as_ptr() as *const *const c_char);
             assert_eq!(s, items);
         });
 
         StrV::from(&items[..]).run_with_strv(|s| unsafe {
-            assert!(s.get_unchecked(4).is_null());
+            assert!((*s.as_ptr().add(4)).is_null());
             assert_eq!(s.len(), items.len());
             let s = StrV::from_glib_borrow(s.as_ptr() as *const *const c_char);
             assert_eq!(s, items);
@@ -1501,7 +1501,7 @@ mod test {
 
         let v = items.iter().copied().map(String::from).collect::<Vec<_>>();
         items.run_with_strv(|s| unsafe {
-            assert!(s.get_unchecked(4).is_null());
+            assert!((*s.as_ptr().add(4)).is_null());
             assert_eq!(s.len(), v.len());
             let s = StrV::from_glib_borrow(s.as_ptr() as *const *const c_char);
             assert_eq!(s, items);
@@ -1509,7 +1509,7 @@ mod test {
 
         let v = items.iter().copied().map(GString::from).collect::<Vec<_>>();
         items.run_with_strv(|s| unsafe {
-            assert!(s.get_unchecked(4).is_null());
+            assert!((*s.as_ptr().add(4)).is_null());
             assert_eq!(s.len(), v.len());
             let s = StrV::from_glib_borrow(s.as_ptr() as *const *const c_char);
             assert_eq!(s, items);


### PR DESCRIPTION
It will panic in debug builds when trying to access indices outside the slice. Instead, use pointer operations here to check that there is a `NULL` at the end of the array.