### PR TITLE
glib: fix UB in VariantStrIter::impl_get

### DIFF
--- a/glib/src/variant_iter.rs
+++ b/glib/src/variant_iter.rs
@@ -117,13 +117,13 @@ impl<'a> VariantStrIter<'a> {
 
     fn impl_get(&self, i: usize) -> &'a str {
         unsafe {
-            let p: *mut libc::c_char = std::ptr::null_mut();
+            let mut p: *mut libc::c_char = std::ptr::null_mut();
             let s = b"&s\0";
             ffi::g_variant_get_child(
                 self.variant.to_glib_none().0,
                 i,
                 s as *const u8 as *const _,
-                &p,
+                &mut p,
                 std::ptr::null::<i8>(),
             );
             let p = std::ffi::CStr::from_ptr(p);


### PR DESCRIPTION
Passing an immutable reference (&p) to a function that mutates the data behind the pointer violates Rust's invariants.

This causes multiple tests in the test suite to crash when compiling it with optimizations (either `--release` mode or with `opt-level` of 2 or 3) with recent Rust versions, which is easy to reproduce, especially with nightly Rust:

```
$ cargo +nightly test --release --package glib
(...)
error: test failed, to rerun pass `--lib`
Caused by:
  process didn't exit successfully: (...) (signal: 11, SIGSEGV: invalid memory reference)
```

Looks like this wasn't caught earlier because the wrapped C function is variadic and there's less type checking happening because of that.
