### PR TITLE
glib-sys: fix struct size mismatches

### DIFF
--- a/glib/sys/Gir.toml
+++ b/glib/sys/Gir.toml
@@ -67,7 +67,6 @@ ignore = [
 [[object]]
 name = "GLib.*"
 status = "generate"
-    ignore = true
     [[object.function]]
     pattern = "(fopen|creat|chmod|blow_chunks|utime|slice_debug_tree_statistics|rename|remove|open|mkdir|lstat|fsync|freopen|set_prgname_once)"
     # see https://gitlab.gnome.org/GNOME/glib/-/issues/3231 + majority of those are available through std

--- a/glib/sys/Gir.toml
+++ b/glib/sys/Gir.toml
@@ -110,3 +110,34 @@ status = "ignore"
 name = "GLib.macro__has_attribute___noreturn__"
 # C-only macro
 status = "ignore"
+
+[[object]]
+name = "GLib.StaticMutex"
+# deprecated type and also the layout is broken due to mismatching gir data
+status = "ignore"
+    [[object.function]]
+    pattern = ".+"
+    ignore = true
+
+[[object]]
+name = "GLib.StaticPrivate"
+# deprecated type, no longer needed
+    [[object.function]]
+    pattern = ".+"
+    ignore = true
+
+[[object]]
+name = "GLib.StaticRecMutex"
+# deprecated type and also the layout is broken due to mismatching gir data
+status = "ignore"
+    [[object.function]]
+    pattern = ".+"
+    ignore = true
+
+[[object]]
+name = "GLib.StaticRWLock"
+# deprecated type and also the layout is broken due to mismatching gir data
+status = "ignore"
+    [[object.function]]
+    pattern = ".+"
+    ignore = true

--- a/glib/sys/src/lib.rs
+++ b/glib/sys/src/lib.rs
@@ -2197,66 +2197,6 @@ pub type GStatBuf = _GStatBuf;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct GStaticMutex {
-    pub mutex: *mut GMutex,
-}
-
-impl ::std::fmt::Debug for GStaticMutex {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        f.debug_struct(&format!("GStaticMutex @ {self:p}"))
-            .field("mutex", &self.mutex)
-            .finish()
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct GStaticPrivate {
-    pub index: c_uint,
-}
-
-impl ::std::fmt::Debug for GStaticPrivate {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        f.debug_struct(&format!("GStaticPrivate @ {self:p}"))
-            .finish()
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct GStaticRWLock {
-    pub mutex: GStaticMutex,
-    pub read_cond: *mut GCond,
-    pub write_cond: *mut GCond,
-    pub read_counter: c_uint,
-    pub have_writer: gboolean,
-    pub want_to_read: c_uint,
-    pub want_to_write: c_uint,
-}
-
-impl ::std::fmt::Debug for GStaticRWLock {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        f.debug_struct(&format!("GStaticRWLock @ {self:p}"))
-            .finish()
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C)]
-pub struct GStaticRecMutex {
-    pub mutex: GStaticMutex,
-    pub depth: c_uint,
-}
-
-impl ::std::fmt::Debug for GStaticRecMutex {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        f.debug_struct(&format!("GStaticRecMutex @ {self:p}"))
-            .finish()
-    }
-}
-
-#[derive(Copy, Clone)]
-#[repr(C)]
 pub struct GString {
     pub str: *mut c_char,
     pub len: size_t,
@@ -5181,44 +5121,18 @@ extern "C" {
     //=========================================================================
     // GStaticMutex
     //=========================================================================
-    pub fn g_static_mutex_free(mutex: *mut GStaticMutex);
-    pub fn g_static_mutex_get_mutex_impl(mutex: *mut GStaticMutex) -> *mut GMutex;
-    pub fn g_static_mutex_init(mutex: *mut GStaticMutex);
 
     //=========================================================================
     // GStaticPrivate
     //=========================================================================
-    pub fn g_static_private_free(private_key: *mut GStaticPrivate);
-    pub fn g_static_private_get(private_key: *mut GStaticPrivate) -> gpointer;
-    pub fn g_static_private_init(private_key: *mut GStaticPrivate);
-    pub fn g_static_private_set(
-        private_key: *mut GStaticPrivate,
-        data: gpointer,
-        notify: GDestroyNotify,
-    );
 
     //=========================================================================
     // GStaticRWLock
     //=========================================================================
-    pub fn g_static_rw_lock_free(lock: *mut GStaticRWLock);
-    pub fn g_static_rw_lock_init(lock: *mut GStaticRWLock);
-    pub fn g_static_rw_lock_reader_lock(lock: *mut GStaticRWLock);
-    pub fn g_static_rw_lock_reader_trylock(lock: *mut GStaticRWLock) -> gboolean;
-    pub fn g_static_rw_lock_reader_unlock(lock: *mut GStaticRWLock);
-    pub fn g_static_rw_lock_writer_lock(lock: *mut GStaticRWLock);
-    pub fn g_static_rw_lock_writer_trylock(lock: *mut GStaticRWLock) -> gboolean;
-    pub fn g_static_rw_lock_writer_unlock(lock: *mut GStaticRWLock);
 
     //=========================================================================
     // GStaticRecMutex
     //=========================================================================
-    pub fn g_static_rec_mutex_free(mutex: *mut GStaticRecMutex);
-    pub fn g_static_rec_mutex_init(mutex: *mut GStaticRecMutex);
-    pub fn g_static_rec_mutex_lock(mutex: *mut GStaticRecMutex);
-    pub fn g_static_rec_mutex_lock_full(mutex: *mut GStaticRecMutex, depth: c_uint);
-    pub fn g_static_rec_mutex_trylock(mutex: *mut GStaticRecMutex) -> gboolean;
-    pub fn g_static_rec_mutex_unlock(mutex: *mut GStaticRecMutex);
-    pub fn g_static_rec_mutex_unlock_full(mutex: *mut GStaticRecMutex) -> c_uint;
 
     //=========================================================================
     // GString

--- a/glib/sys/tests/abi.rs
+++ b/glib/sys/tests/abi.rs
@@ -734,34 +734,6 @@ const RUST_LAYOUTS: &[(&str, Layout)] = &[
         },
     ),
     (
-        "GStaticMutex",
-        Layout {
-            size: size_of::<GStaticMutex>(),
-            alignment: align_of::<GStaticMutex>(),
-        },
-    ),
-    (
-        "GStaticPrivate",
-        Layout {
-            size: size_of::<GStaticPrivate>(),
-            alignment: align_of::<GStaticPrivate>(),
-        },
-    ),
-    (
-        "GStaticRWLock",
-        Layout {
-            size: size_of::<GStaticRWLock>(),
-            alignment: align_of::<GStaticRWLock>(),
-        },
-    ),
-    (
-        "GStaticRecMutex",
-        Layout {
-            size: size_of::<GStaticRecMutex>(),
-            alignment: align_of::<GStaticRecMutex>(),
-        },
-    ),
-    (
         "GString",
         Layout {
             size: size_of::<GString>(),

--- a/glib/sys/tests/layout.c
+++ b/glib/sys/tests/layout.c
@@ -83,10 +83,6 @@ int main() {
     printf("%s;%zu;%zu\n", "GSourceFuncs", sizeof(GSourceFuncs), alignof(GSourceFuncs));
     printf("%s;%zu;%zu\n", "GSpawnError", sizeof(GSpawnError), alignof(GSpawnError));
     printf("%s;%zu;%zu\n", "GSpawnFlags", sizeof(GSpawnFlags), alignof(GSpawnFlags));
-    printf("%s;%zu;%zu\n", "GStaticMutex", sizeof(GStaticMutex), alignof(GStaticMutex));
-    printf("%s;%zu;%zu\n", "GStaticPrivate", sizeof(GStaticPrivate), alignof(GStaticPrivate));
-    printf("%s;%zu;%zu\n", "GStaticRWLock", sizeof(GStaticRWLock), alignof(GStaticRWLock));
-    printf("%s;%zu;%zu\n", "GStaticRecMutex", sizeof(GStaticRecMutex), alignof(GStaticRecMutex));
     printf("%s;%zu;%zu\n", "GString", sizeof(GString), alignof(GString));
     printf("%s;%zu;%zu\n", "GStrv", sizeof(GStrv), alignof(GStrv));
     printf("%s;%zu;%zu\n", "GTestConfig", sizeof(GTestConfig), alignof(GTestConfig));


### PR DESCRIPTION
This pull request fixes the `GStaticMutex` and `GStaticRecMutex` size mismatches by removing them from the bindings.

See #1353 for more information.