### PR TITLE
glib-sys: Add missing includes in `manual.h`

### DIFF
--- a/glib/sys/tests/manual.h
+++ b/glib/sys/tests/manual.h
@@ -3,6 +3,23 @@
 #include <glib.h>
 #include <glib-object.h>
 
+#ifndef G_PLATFORM_WIN32
+// glib-unix.h is not included automatically
+#include <glib-unix.h>
+// polyfill the WIN32 constants on non-Win32 platforms
+typedef enum
+{
+  G_WIN32_OS_ANY,
+  G_WIN32_OS_WORKSTATION,
+  G_WIN32_OS_SERVER,
+} GWin32OSType;
+#endif
+
+// polyfill when the platform doesn't define tracing macros
+#ifndef G_TRACE_CURRENT_TIME
+#define G_TRACE_CURRENT_TIME 0
+#endif
+
 // included in Gir on all platforms even though it is only present on windows
 #ifndef G_WIN32_MSG_HANDLE
 #define G_WIN32_MSG_HANDLE 19981206


### PR DESCRIPTION
This pull request adds missing includes and fallback definitions in `manual.h` when performing unit tests on Unix platforms.