### PR TITLE
glib-macros/properties: Allow structs with no properties

### DIFF
--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -85,12 +85,6 @@ impl Parse for PropsMacroInput {
                 ))
             }
         };
-        if props.is_empty() {
-            return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "Struct must have at least one field with the #[property(…)] attribute",
-            ));
-        }
         Ok(Self {
             wrapper_ty: attrs.wrapper_ty,
             ext_trait: attrs.ext_trait,
@@ -513,6 +507,7 @@ fn expand_set_property_fn(props: &[PropDesc]) -> TokenStream2 {
         })
     });
     quote!(
+        #[allow(unreachable_code)]
         fn derived_set_property(&self,
             id: usize,
             value: &#crate_ident::Value,
@@ -662,29 +657,43 @@ fn name_to_enum_ident(name: String) -> syn::Ident {
 }
 
 fn expand_properties_enum(props: &[PropDesc]) -> TokenStream2 {
-    let properties: Vec<syn::Ident> = props
-        .iter()
-        .map(|p| {
-            let name: String = p.name.value();
+    if props.is_empty() {
+        quote! {
+            #[derive(Debug, Copy, Clone)]
+            enum DerivedPropertiesEnum {}
+            impl std::convert::TryFrom<usize> for DerivedPropertiesEnum {
+                type Error = usize;
 
-            name_to_enum_ident(name)
-        })
-        .collect();
-    let props = properties.iter();
-    let indices = 0..properties.len();
-    quote! {
-        #[repr(usize)]
-        #[derive(Debug, Copy, Clone)]
-        enum DerivedPropertiesEnum {
-            #(#props,)*
+                fn try_from(item: usize) -> ::core::result::Result<Self, <Self as std::convert::TryFrom<usize>>::Error> {
+                    ::core::result::Result::Err(item)
+                }
+            }
         }
-        impl std::convert::TryFrom<usize> for DerivedPropertiesEnum {
-            type Error = usize;
+    } else {
+        let properties: Vec<syn::Ident> = props
+            .iter()
+            .map(|p| {
+                let name: String = p.name.value();
 
-            fn try_from(item: usize) -> ::core::result::Result<Self, <Self as std::convert::TryFrom<usize>>::Error> {
-                match item {
-                    #(#indices => ::core::result::Result::Ok(Self::#properties),)*
-                    _ => ::core::result::Result::Err(item)
+                name_to_enum_ident(name)
+            })
+            .collect();
+        let props = properties.iter();
+        let indices = 0..properties.len();
+        quote! {
+            #[repr(usize)]
+            #[derive(Debug, Copy, Clone)]
+            enum DerivedPropertiesEnum {
+                #(#props,)*
+            }
+            impl std::convert::TryFrom<usize> for DerivedPropertiesEnum {
+                type Error = usize;
+
+                fn try_from(item: usize) -> ::core::result::Result<Self, <Self as std::convert::TryFrom<usize>>::Error> {
+                    match item {
+                        #(#indices => ::core::result::Result::Ok(Self::#properties),)*
+                        _ => ::core::result::Result::Err(item)
+                    }
                 }
             }
         }

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -504,3 +504,35 @@ fn keyword_propnames() {
     mykwnames.set_property("try", 255_u8);
     assert_eq!(mykwnames.r#try(), 255_u8);
 }
+
+/// This struct is intentionally left empty.
+///
+/// Ensure the code compiles even when no properties are specified at all.
+/// This is useful for refactoring.
+#[test]
+#[allow(unreachable_code)]
+fn empty() {
+    mod empty {
+        mod imp {
+            use glib::subclass::prelude::*;
+            use glib_macros::Properties;
+
+            #[derive(Properties, Default)]
+            #[properties(wrapper_type = super::Empty)]
+            pub struct Empty {}
+
+            #[glib::object_subclass]
+            impl ObjectSubclass for Empty {
+                const NAME: &'static str = "Empty";
+                type Type = super::Empty;
+            }
+
+            #[glib::derived_properties]
+            impl ObjectImpl for Empty {}
+        }
+
+        glib::wrapper! {
+            pub struct Empty(ObjectSubclass<imp::Empty>);
+        }
+    }
+}


### PR DESCRIPTION
As discussed in matrix. The rationale would be that this is useful for refactoring. We unfortunately can't emit custom warnings inside property macros. Otherwise I would prefer if the macro emitted a helpful warning.

Right now the macro emits one `unreachable expression` warning at the macro site if the enum is empty. Does this make sense to keep or should I silence it as well?