### PR TITLE
glib: Re-add and rename manual Win32 API additions

### DIFF
--- a/glib/src/win32.rs
+++ b/glib/src/win32.rs
@@ -4,18 +4,22 @@ use std::path::PathBuf;
 
 use crate::{translate::*, GString, StrV};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum OSType {
+#[doc(alias = "GWin32OSType")]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+#[non_exhaustive]
+pub enum Win32OSType {
     #[doc(alias = "G_WIN32_OS_ANY")]
     Any,
     #[doc(alias = "G_WIN32_OS_WORKSTATION")]
     Workstation,
     #[doc(alias = "G_WIN32_OS_SERVER")]
     Server,
+    #[doc(hidden)]
+    __Unknown(i32),
 }
 
 #[doc(hidden)]
-impl IntoGlib for OSType {
+impl IntoGlib for Win32OSType {
     type GlibType = ffi::GWin32OSType;
 
     #[inline]
@@ -24,12 +28,31 @@ impl IntoGlib for OSType {
             Self::Any => ffi::G_WIN32_OS_ANY,
             Self::Workstation => ffi::G_WIN32_OS_WORKSTATION,
             Self::Server => ffi::G_WIN32_OS_SERVER,
+            Self::__Unknown(value) => value,
+        }
+    }
+}
+
+#[doc(hidden)]
+impl FromGlib<ffi::GWin32OSType> for Win32OSType {
+    #[inline]
+    unsafe fn from_glib(value: ffi::GWin32OSType) -> Self {
+        match value {
+            ffi::G_WIN32_OS_ANY => Self::Any,
+            ffi::G_WIN32_OS_WORKSTATION => Self::Workstation,
+            ffi::G_WIN32_OS_SERVER => Self::Server,
+            value => Self::__Unknown(value),
         }
     }
 }
 
 #[doc(alias = "g_win32_check_windows_version")]
-pub fn check_windows_version(major: i32, minor: i32, spver: i32, os_type: OSType) -> bool {
+pub fn win32_check_windows_version(
+    major: i32,
+    minor: i32,
+    spver: i32,
+    os_type: Win32OSType,
+) -> bool {
     unsafe {
         from_glib(ffi::g_win32_check_windows_version(
             major,
@@ -42,23 +65,23 @@ pub fn check_windows_version(major: i32, minor: i32, spver: i32, os_type: OSType
 
 #[doc(alias = "g_win32_get_command_line")]
 #[doc(alias = "get_command_line")]
-pub fn command_line() -> StrV {
+pub fn win32_command_line() -> StrV {
     unsafe { FromGlibPtrContainer::from_glib_full(ffi::g_win32_get_command_line()) }
 }
 
 #[doc(alias = "g_win32_error_message")]
-pub fn error_message(error: i32) -> GString {
+pub fn win32_error_message(error: i32) -> GString {
     unsafe { from_glib_full(ffi::g_win32_error_message(error)) }
 }
 
 #[doc(alias = "g_win32_getlocale")]
-pub fn getlocale() -> GString {
+pub fn win32_getlocale() -> GString {
     unsafe { from_glib_full(ffi::g_win32_getlocale()) }
 }
 
 #[doc(alias = "g_win32_get_package_installation_directory_of_module")]
 #[doc(alias = "get_package_installation_directory_of_module")]
-pub fn package_installation_directory_of_module(
+pub fn win32_package_installation_directory_of_module(
     hmodule: std::os::windows::raw::HANDLE,
 ) -> Result<PathBuf, std::io::Error> {
     // # Safety

--- a/glib/sys/src/manual.rs
+++ b/glib/sys/src/manual.rs
@@ -77,7 +77,7 @@ pub use self::win32::*;
 
 #[cfg(target_family = "windows")]
 mod win32 {
-    use libc::{c_char, c_int};
+    use libc::{c_char, c_int, c_uint};
 
     pub type GWin32OSType = c_int;
     pub const G_WIN32_OS_ANY: GWin32OSType = 0;
@@ -104,5 +104,17 @@ mod win32 {
         ) -> *mut c_char;
 
         pub fn g_win32_locale_filename_from_utf8(utf8filename: *const c_char) -> *mut c_char;
+
+        pub fn g_win32_ftruncate(f: c_int, size: c_uint) -> c_int;
+        pub fn g_win32_get_package_installation_directory(
+            package: *const c_char,
+            dll_name: *const c_char,
+        ) -> *mut c_char;
+        pub fn g_win32_get_package_installation_subdirectory(
+            package: *const c_char,
+            dll_name: *const c_char,
+            subdir: *const c_char,
+        ) -> *mut c_char;
+        pub fn g_win32_get_windows_version() -> c_uint;
     }
 }


### PR DESCRIPTION
These were temporarily auto-generated in 0.19 but then disappeared from the .gir file again. Re-add them with the auto-generated names, and add all missing ones.