### PR TITLE
glib: Use a reference to a pointer of correct mutability for from_gli…

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -47,14 +47,14 @@ macro_rules! glib_boxed_wrapper {
 
             #[doc = "Borrows the underlying C value."]
             #[inline]
-            pub unsafe fn from_glib_ptr_borrow<'a>(ptr: *const *const $ffi_name) -> &'a Self {
-                &*(ptr as *const Self)
+            pub unsafe fn from_glib_ptr_borrow(ptr: &*mut $ffi_name) -> &Self {
+                &*(ptr as *const *mut $ffi_name as *const Self)
             }
 
             #[doc = "Borrows the underlying C value mutably."]
             #[inline]
-            pub unsafe fn from_glib_ptr_borrow_mut<'a>(ptr: *mut *mut $ffi_name) -> &'a mut Self {
-                &mut *(ptr as *mut Self)
+            pub unsafe fn from_glib_ptr_borrow_mut(ptr: &mut *mut $ffi_name) -> &mut Self {
+                &mut *(ptr as *mut *mut $ffi_name as *mut Self)
             }
         }
 
@@ -354,7 +354,7 @@ macro_rules! glib_boxed_wrapper {
                 debug_assert_eq!(std::mem::size_of::<Self>(), std::mem::size_of::<$crate::ffi::gpointer>());
                 let value = &*(value as *const $crate::Value as *const $crate::gobject_ffi::GValue);
                 debug_assert!(!value.data[0].v_pointer.is_null());
-                <$name $(<$($generic),+>)?>::from_glib_ptr_borrow(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *const $ffi_name)
+                <$name $(<$($generic),+>)?>::from_glib_ptr_borrow(&*(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *mut $ffi_name))
             }
         }
 

--- a/glib/src/match_info.rs
+++ b/glib/src/match_info.rs
@@ -34,12 +34,12 @@ impl MatchInfo<'_> {
     #[doc = "Return the inner pointer to the underlying C value."]
     #[inline]
     pub fn as_ptr(&self) -> *mut ffi::GMatchInfo {
-        unsafe { *(self as *const Self as *const *const ffi::GMatchInfo) as *mut ffi::GMatchInfo }
+        self.inner.as_ptr()
     }
     #[doc = "Borrows the underlying C value."]
     #[inline]
-    pub unsafe fn from_glib_ptr_borrow<'a>(ptr: *const *const ffi::GMatchInfo) -> &'a Self {
-        &*(ptr as *const Self)
+    pub unsafe fn from_glib_ptr_borrow(ptr: &*mut ffi::GMatchInfo) -> &Self {
+        &*(ptr as *const *mut ffi::GMatchInfo as *const Self)
     }
 }
 
@@ -201,8 +201,8 @@ unsafe impl<'a, 'input: 'a> crate::value::FromValue<'a> for &'a MatchInfo<'input
         let value = &*(value as *const crate::Value as *const crate::gobject_ffi::GValue);
         debug_assert!(!value.data[0].v_pointer.is_null());
         <MatchInfo<'input>>::from_glib_ptr_borrow(
-            &value.data[0].v_pointer as *const crate::ffi::gpointer
-                as *const *const ffi::GMatchInfo,
+            &*(&value.data[0].v_pointer as *const crate::ffi::gpointer
+                as *const *mut ffi::GMatchInfo),
         )
     }
 }

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -47,7 +47,7 @@ pub unsafe trait ObjectType:
     fn as_object_ref(&self) -> &ObjectRef;
     fn as_ptr(&self) -> *mut Self::GlibType;
 
-    unsafe fn from_glib_ptr_borrow<'a>(ptr: *const *const Self::GlibType) -> &'a Self;
+    unsafe fn from_glib_ptr_borrow(ptr: &*mut Self::GlibType) -> &Self;
 }
 
 // rustdoc-stripper-ignore-next
@@ -730,8 +730,8 @@ macro_rules! glib_object_wrapper {
             }
 
             #[inline]
-            unsafe fn from_glib_ptr_borrow<'a>(ptr: *const *const Self::GlibType) -> &'a Self {
-                &*(ptr as *const Self)
+            unsafe fn from_glib_ptr_borrow(ptr: &*mut Self::GlibType) -> &Self {
+                &*(ptr as *const *mut $ffi_name as *const Self)
             }
         }
 
@@ -1071,7 +1071,7 @@ macro_rules! glib_object_wrapper {
                 let value = &*(value as *const $crate::Value as *const $crate::gobject_ffi::GValue);
                 debug_assert!(!value.data[0].v_pointer.is_null());
                 debug_assert_ne!((*(value.data[0].v_pointer as *const $crate::gobject_ffi::GObject)).ref_count, 0);
-                <$name $(<$($generic),+>)? as $crate::object::ObjectType>::from_glib_ptr_borrow(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *const $ffi_name)
+                <$name $(<$($generic),+>)? as $crate::object::ObjectType>::from_glib_ptr_borrow(&*(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *mut $ffi_name))
             }
         }
 

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -45,8 +45,8 @@ macro_rules! glib_shared_wrapper {
 
             #[doc = "Borrows the underlying C value."]
             #[inline]
-            pub unsafe fn from_glib_ptr_borrow<'a>(ptr: *const *const $ffi_name) -> &'a Self {
-                &*(ptr as *const Self)
+            pub unsafe fn from_glib_ptr_borrow(ptr: &*mut $ffi_name) -> &Self {
+                &*(ptr as *const *mut $ffi_name as *const Self)
             }
         }
 
@@ -374,7 +374,7 @@ macro_rules! glib_shared_wrapper {
                 debug_assert_eq!(std::mem::size_of::<Self>(), std::mem::size_of::<$crate::ffi::gpointer>());
                 let value = &*(value as *const $crate::Value as *const $crate::gobject_ffi::GValue);
                 debug_assert!(!value.data[0].v_pointer.is_null());
-                <$name $(<$($generic),+>)?>::from_glib_ptr_borrow(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *const $ffi_name)
+                <$name $(<$($generic),+>)?>::from_glib_ptr_borrow(&*(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *mut $ffi_name))
             }
         }
 

--- a/glib/src/value_array.rs
+++ b/glib/src/value_array.rs
@@ -179,8 +179,8 @@ unsafe impl<'a> crate::value::FromValue<'a> for &'a ValueArray {
         let value = &*(value as *const Value as *const gobject_ffi::GValue);
         debug_assert!(!value.data[0].v_pointer.is_null());
         <ValueArray>::from_glib_ptr_borrow(
-            &value.data[0].v_pointer as *const ffi::gpointer
-                as *const *const gobject_ffi::GValueArray,
+            &*(&value.data[0].v_pointer as *const ffi::gpointer
+                as *const *mut gobject_ffi::GValueArray),
         )
     }
 }


### PR DESCRIPTION
…b_ptr_borrow()

This hopefully makes it easier to use and harder to get the returned lifetime wrong.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1373

----

CC @sophie-h