### PR TITLE
glib: Decouple ObjectInterface impl from interface class struct

### DIFF
--- a/glib-macros/tests/object_subclass_dynamic.rs
+++ b/glib-macros/tests/object_subclass_dynamic.rs
@@ -11,13 +11,21 @@ mod static_ {
         // impl for an object interface to register as a static type.
         #[derive(Clone, Copy)]
         #[repr(C)]
-        pub struct MyStaticInterface {
+        pub struct MyStaticInterfaceClass {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
+        unsafe impl InterfaceStruct for MyStaticInterfaceClass {
+            type Type = MyStaticInterface;
+        }
+
+        pub enum MyStaticInterface {}
+
         #[glib::object_interface]
-        unsafe impl ObjectInterface for MyStaticInterface {
+        impl ObjectInterface for MyStaticInterface {
             const NAME: &'static str = "MyStaticInterface";
+
+            type Interface = MyStaticInterfaceClass;
         }
 
         pub trait MyStaticInterfaceImpl: ObjectImpl + ObjectSubclass {}
@@ -69,15 +77,22 @@ mod module {
         // impl for a object interface to register as a dynamic type and that extends `MyStaticInterface`.
         #[derive(Clone, Copy)]
         #[repr(C)]
-        pub struct MyModuleInterface {
+        pub struct MyModuleInterfaceClass {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
+        unsafe impl InterfaceStruct for MyModuleInterfaceClass {
+            type Type = MyModuleInterface;
+        }
+
+        pub enum MyModuleInterface {}
+
         #[glib::object_interface]
         #[object_interface_dynamic]
-        unsafe impl ObjectInterface for MyModuleInterface {
+        impl ObjectInterface for MyModuleInterface {
             const NAME: &'static str = "MyModuleInterface";
             type Prerequisites = (MyStaticInterface,);
+            type Interface = MyModuleInterfaceClass;
         }
 
         pub trait MyModuleInterfaceImpl: ObjectImpl + ObjectSubclass {}
@@ -106,15 +121,22 @@ mod module {
         // impl for an object interface to lazy register as a dynamic type and that extends `MyStaticInterface`.
         #[derive(Clone, Copy)]
         #[repr(C)]
-        pub struct MyModuleInterfaceLazy {
+        pub struct MyModuleInterfaceLazyClass {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
+        unsafe impl InterfaceStruct for MyModuleInterfaceLazyClass {
+            type Type = MyModuleInterfaceLazy;
+        }
+
+        pub enum MyModuleInterfaceLazy {}
+
         #[glib::object_interface]
         #[object_interface_dynamic(lazy_registration = true)]
-        unsafe impl ObjectInterface for MyModuleInterfaceLazy {
+        impl ObjectInterface for MyModuleInterfaceLazy {
             const NAME: &'static str = "MyModuleInterfaceLazy";
             type Prerequisites = (MyStaticInterface,);
+            type Interface = MyModuleInterfaceLazyClass;
         }
 
         pub trait MyModuleInterfaceLazyImpl: ObjectImpl + ObjectSubclass {}
@@ -295,15 +317,22 @@ pub mod plugin {
         // impl for a object interface to register as a dynamic type and that extends `MyStaticInterface`.
         #[derive(Clone, Copy)]
         #[repr(C)]
-        pub struct MyPluginInterface {
+        pub struct MyPluginInterfaceClass {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
+        unsafe impl InterfaceStruct for MyPluginInterfaceClass {
+            type Type = MyPluginInterface;
+        }
+
+        pub enum MyPluginInterface {}
+
         #[glib::object_interface]
         #[object_interface_dynamic(plugin_type = super::MyPlugin)]
-        unsafe impl ObjectInterface for MyPluginInterface {
+        impl ObjectInterface for MyPluginInterface {
             const NAME: &'static str = "MyPluginInterface";
             type Prerequisites = (MyStaticInterface,);
+            type Interface = MyPluginInterfaceClass;
         }
 
         pub trait MyPluginInterfaceImpl: ObjectImpl + ObjectSubclass {}
@@ -332,15 +361,22 @@ pub mod plugin {
         // impl for an object interface to lazy register as a dynamic type and that extends `MyStaticInterface`.
         #[derive(Clone, Copy)]
         #[repr(C)]
-        pub struct MyPluginInterfaceLazy {
+        pub struct MyPluginInterfaceLazyClass {
             parent: glib::gobject_ffi::GTypeInterface,
         }
 
+        unsafe impl InterfaceStruct for MyPluginInterfaceLazyClass {
+            type Type = MyPluginInterfaceLazy;
+        }
+
+        pub enum MyPluginInterfaceLazy {}
+
         #[glib::object_interface]
         #[object_interface_dynamic(plugin_type = super::MyPlugin, lazy_registration = true)]
-        unsafe impl ObjectInterface for MyPluginInterfaceLazy {
+        impl ObjectInterface for MyPluginInterfaceLazy {
             const NAME: &'static str = "MyPluginInterfaceLazy";
             type Prerequisites = (MyStaticInterface,);
+            type Interface = MyPluginInterfaceLazyClass;
         }
 
         pub trait MyPluginInterfaceLazyImpl: ObjectImpl + ObjectSubclass {}

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1317,6 +1317,15 @@ macro_rules! glib_object_wrapper {
         );
     };
 
+    (@object_interface [$($attr:meta)*] $visibility:vis $name:ident $(<$($generic:ident $(: $bound:tt $(+ $bound2:tt)*)?),+>)?, $iface:ty,
+    @type_ $get_type_expr:expr, @requires [$($requires:tt)*]) => {
+       $crate::glib_object_wrapper!(
+           @interface [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, $iface, std::os::raw::c_void,
+           @ffi_class  <$iface as $crate::subclass::interface::ObjectInterface>::Interface,
+           @type_ $get_type_expr, @requires [$($requires)*]
+       );
+   };
+
     (@interface [$($attr:meta)*] $visibility:vis $name:ident $(<$($generic:ident $(: $bound:tt $(+ $bound2:tt)*)?),+>)?, $impl_type:ty, $ffi_name:ty, @ffi_class $ffi_class_name:ty,
      @type_ $get_type_expr:expr, @requires [$($requires:tt)*]) => {
         $crate::glib_object_wrapper!(

--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -450,9 +450,9 @@ pub mod prelude {
         type_module::{TypeModuleImpl, TypeModuleImplExt},
         type_plugin::{TypePluginImpl, TypePluginImplExt, TypePluginRegisterImpl},
         types::{
-            ClassStruct, InstanceStruct, InstanceStructExt, IsImplementable, IsSubclassable,
-            IsSubclassableExt, ObjectSubclass, ObjectSubclassExt, ObjectSubclassIsExt,
-            ObjectSubclassType,
+            ClassStruct, InstanceStruct, InstanceStructExt, InterfaceStruct, IsImplementable,
+            IsSubclassable, IsSubclassableExt, ObjectSubclass, ObjectSubclassExt,
+            ObjectSubclassIsExt, ObjectSubclassType,
         },
     };
 }

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -460,9 +460,16 @@ mod test {
             parent: gobject_ffi::GTypeInterface,
         }
 
+        unsafe impl InterfaceStruct for DummyInterface {
+            type Type = Dummy;
+        }
+
+        pub enum Dummy {}
+
         #[glib::object_interface]
-        unsafe impl ObjectInterface for DummyInterface {
+        impl ObjectInterface for Dummy {
             const NAME: &'static str = "Dummy";
+            type Interface = DummyInterface;
         }
     }
 
@@ -475,7 +482,7 @@ mod test {
     }
 
     wrapper! {
-        pub struct Dummy(ObjectInterface<imp::DummyInterface>);
+        pub struct Dummy(ObjectInterface<imp::Dummy>);
     }
 
     unsafe impl<T: ObjectSubclass> IsImplementable<T> for Dummy {}

--- a/glib/src/wrapper.rs
+++ b/glib/src/wrapper.rs
@@ -436,8 +436,7 @@ macro_rules! wrapper {
         $visibility:vis struct $name:ident $(<$($generic:ident $(: $bound:tt $(+ $bound2:tt)*)?),+>)? (ObjectInterface<$iface_name:ty>) $(@requires $($requires:path),+)?;
     ) => {
         $crate::glib_object_wrapper!(
-            @interface [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, *mut std::os::raw::c_void, std::os::raw::c_void,
-            @ffi_class $iface_name,
+            @object_interface [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, $iface_name,
             @type_ $crate::translate::IntoGlib::into_glib(<$iface_name as $crate::subclass::interface::ObjectInterfaceType>::type_()),
             @requires [$( $($requires),+ )?]
         );


### PR DESCRIPTION
This makes ObjectInterface and ObjectSubclass more similar to each other and allows for cleaner separation between the unsafe ffi code and rust implementation.

There is some bikeshedding left to be done: `InterfaceClassStruct` is quite clumsy, but reusing `ClassStruct` is not possible, as it is tailored towards object subclasses. We could call it `InterfaceStruct` to align it with `IsClass` ->`IsInterface` and similar traits that omit `Class`. Then we should also name `ObjectInterface::Class` `ObjectInterface::Interface` I suppose.

Do we need something like `glib::subclass::basic::ClassStruct` for `InterfaceClassStruct`? I would say we don't, as most interfaces define vfuncs anyway.

Closes #1382 