### PR TITLE
glib: Only implement Send on JoinHandle if the result is Send

### DIFF
--- a/glib/src/main_context_futures.rs
+++ b/glib/src/main_context_futures.rs
@@ -355,7 +355,10 @@ impl<T: 'static> futures_core::FusedFuture for JoinHandle<T> {
     }
 }
 
-unsafe impl<T> Send for JoinHandle<T> {}
+/// Safety: We can't rely on the auto implementation because we are retrieving
+/// the result as a `Box<dyn Any + 'static>` from the [`Source`]. We need to
+/// rely on type erasure here, so we have to manually assert the Send bound too.
+unsafe impl<T: Send> Send for JoinHandle<T> {}
 
 // rustdoc-stripper-ignore-next
 /// Variant of [`JoinHandle`] that is returned from [`MainContext::spawn_from_within`].


### PR DESCRIPTION
Other runtimes need to do this too https://docs.rs/async-std/latest/async_std/task/struct.JoinHandle.html#impl-Send