### PR TITLE
glib: Implement Sync for ThreadGuard

### DIFF
--- a/glib/src/thread_guard.rs
+++ b/glib/src/thread_guard.rs
@@ -112,3 +112,4 @@ impl<T> Drop for ThreadGuard<T> {
 }
 
 unsafe impl<T> Send for ThreadGuard<T> {}
+unsafe impl<T> Sync for ThreadGuard<T> {}


### PR DESCRIPTION
Closes #1385. Wasn't sure whether there was some undocumented and esoteric reason this is unsafe to do. Seems fine to me and nobody has come forth in the issue to claim it would be unsafe.