### PR TITLE
Fix clippy warnings

### DIFF
--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -511,7 +511,7 @@ fn keyword_propnames() {
 /// This is useful for refactoring.
 #[test]
 #[allow(unreachable_code)]
-fn empty() {
+fn empty_struct() {
     mod empty {
         mod imp {
             use glib::subclass::prelude::*;

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -281,12 +281,16 @@ fn subclassable() {
             }
 
             impl ObjectImpl for Foo {}
+
+            impl Foo {
+                pub(super) fn test(&self) {}
+            }
         }
 
         pub trait FooExt: IsA<Foo> + 'static {
             fn test(&self) {
-                let _self = self.as_ref().downcast_ref::<Foo>().unwrap().imp();
-                unimplemented!()
+                let imp = self.as_ref().upcast_ref::<Foo>().imp();
+                imp.test();
             }
         }
 
@@ -296,6 +300,11 @@ fn subclassable() {
             pub struct Foo(ObjectSubclass<imp::Foo>);
         }
     }
+
+    use foo::FooExt;
+
+    let obj = glib::Object::new::<foo::Foo>();
+    obj.test();
 }
 
 #[test]

--- a/glib/src/main_context_futures.rs
+++ b/glib/src/main_context_futures.rs
@@ -355,9 +355,9 @@ impl<T: 'static> futures_core::FusedFuture for JoinHandle<T> {
     }
 }
 
-/// Safety: We can't rely on the auto implementation because we are retrieving
-/// the result as a `Box<dyn Any + 'static>` from the [`Source`]. We need to
-/// rely on type erasure here, so we have to manually assert the Send bound too.
+// Safety: We can't rely on the auto implementation because we are retrieving
+// the result as a `Box<dyn Any + 'static>` from the [`Source`]. We need to
+// rely on type erasure here, so we have to manually assert the Send bound too.
 unsafe impl<T: Send> Send for JoinHandle<T> {}
 
 // rustdoc-stripper-ignore-next


### PR DESCRIPTION
* Fix clippy warnings in glib-macros/tests
* Annotate automatically generated property getters and setters with `#[allow(dead_code]`