### PR TITLE
glib: Fix `MatchInfo::next()` handling of returning `FALSE`

### DIFF
--- a/glib/src/match_info.rs
+++ b/glib/src/match_info.rs
@@ -328,15 +328,14 @@ impl<'input> MatchInfo<'input> {
     }
 
     #[doc(alias = "g_match_info_next")]
-    pub fn next(&self) -> Result<(), crate::Error> {
+    pub fn next(&self) -> Result<bool, crate::Error> {
         unsafe {
             let mut error = std::ptr::null_mut();
             let is_ok = ffi::g_match_info_next(self.to_glib_none().0, &mut error);
-            debug_assert_eq!(is_ok == crate::ffi::GFALSE, !error.is_null());
-            if error.is_null() {
-                Ok(())
-            } else {
+            if !error.is_null() {
                 Err(from_glib_full(error))
+            } else {
+                Ok(from_glib(is_ok))
             }
         }
     }


### PR DESCRIPTION
`FALSE` is returned both on errors when the `GError*` is set as well as if there is no further match, in which case the `GError*` is not set.

Change the return type from `Result<(), glib::Error>` to `Result<bool, glib::Error>` to be able to represent that and don't assert that either `TRUE` is returned or the `GError*` is set.

Fixes https://github.com/gtk-rs/gtk4-rs/issues/1749