### PR TITLE
Update `clone!` and `closure!` macro to new syntax

### DIFF
--- a/examples/gio_futures_await/main.rs
+++ b/examples/gio_futures_await/main.rs
@@ -10,13 +10,17 @@ fn main() {
 
     let file = gio::File::for_path("Cargo.toml");
 
-    let future = clone!(@strong l => async move {
-        match read_file(file).await {
-            Ok(()) => (),
-            Err(err) => eprintln!("Got error: {err}"),
+    let future = clone!(
+        #[strong]
+        l,
+        async move {
+            match read_file(file).await {
+                Ok(()) => (),
+                Err(err) => eprintln!("Got error: {err}"),
+            }
+            l.quit();
         }
-        l.quit();
-    });
+    );
 
     c.spawn_local(future);
 

--- a/examples/gio_task/main.rs
+++ b/examples/gio_task/main.rs
@@ -21,12 +21,16 @@ fn main() {
         run_in_thread(send_threaded);
     });
 
-    main_context.spawn_local(clone!(@strong main_loop => async move {
-        recv_safe.await.unwrap();
-        recv_unsafe.await.unwrap();
-        recv_threaded.await.unwrap();
-        main_loop.quit();
-    }));
+    main_context.spawn_local(clone!(
+        #[strong]
+        main_loop,
+        async move {
+            recv_safe.await.unwrap();
+            recv_unsafe.await.unwrap();
+            recv_threaded.await.unwrap();
+            main_loop.quit();
+        }
+    ));
 
     main_loop.run();
 }

--- a/gio/src/action_map.rs
+++ b/gio/src/action_map.rs
@@ -20,16 +20,24 @@ pub trait ActionMapExtManual: sealed::Sealed + IsA<ActionMap> {
             };
             let action_map = self.as_ref();
             if let Some(callback) = entry.activate {
-                action.connect_activate(clone!(@weak action_map =>  move |action, state| {
-                    // safe to unwrap as O: IsA<ActionMap>
-                    callback(action_map.downcast_ref::<Self>().unwrap(), action, state);
-                }));
+                action.connect_activate(clone!(
+                    #[weak]
+                    action_map,
+                    move |action, state| {
+                        // safe to unwrap as O: IsA<ActionMap>
+                        callback(action_map.downcast_ref::<Self>().unwrap(), action, state);
+                    }
+                ));
             }
             if let Some(callback) = entry.change_state {
-                action.connect_change_state(clone!(@weak action_map => move |action, state| {
-                    // safe to unwrap as O: IsA<ActionMap>
-                    callback(action_map.downcast_ref::<Self>().unwrap(), action, state);
-                }));
+                action.connect_change_state(clone!(
+                    #[weak]
+                    action_map,
+                    move |action, state| {
+                        // safe to unwrap as O: IsA<ActionMap>
+                        callback(action_map.downcast_ref::<Self>().unwrap(), action, state);
+                    }
+                ));
             }
             self.as_ref().add_action(&action);
         }

--- a/gio/src/async_initable.rs
+++ b/gio/src/async_initable.rs
@@ -68,9 +68,13 @@ impl AsyncInitable {
             obj.unsafe_cast_ref::<Self>().init_async(
                 io_priority,
                 cancellable,
-                glib::clone!(@strong obj => move |res| {
-                    callback(res.map(|_| obj));
-                }),
+                glib::clone!(
+                    #[strong]
+                    obj,
+                    move |res| {
+                        callback(res.map(|_| obj));
+                    }
+                ),
             )
         };
     }
@@ -98,9 +102,13 @@ impl AsyncInitable {
                     obj.unsafe_cast_ref::<Self>().init_async(
                         io_priority,
                         Some(cancellable),
-                        glib::clone!(@strong obj => move |res| {
-                            send.resolve(res.map(|_| obj));
-                        }),
+                        glib::clone!(
+                            #[strong]
+                            obj,
+                            move |res| {
+                                send.resolve(res.map(|_| obj));
+                            }
+                        ),
                     );
                 },
             ))
@@ -130,9 +138,13 @@ impl AsyncInitable {
             obj.unsafe_cast_ref::<Self>().init_async(
                 io_priority,
                 cancellable,
-                glib::clone!(@strong obj => move |res| {
-                    callback(res.map(|_| obj));
-                }),
+                glib::clone!(
+                    #[strong]
+                    obj,
+                    move |res| {
+                        callback(res.map(|_| obj));
+                    }
+                ),
             )
         };
     }
@@ -162,9 +174,13 @@ impl AsyncInitable {
                     obj.unsafe_cast_ref::<Self>().init_async(
                         io_priority,
                         Some(cancellable),
-                        glib::clone!(@strong obj => move |res| {
-                            send.resolve(res.map(|_| obj));
-                        }),
+                        glib::clone!(
+                            #[strong]
+                            obj,
+                            move |res| {
+                                send.resolve(res.map(|_| obj));
+                            }
+                        ),
                     );
                 },
             ))

--- a/glib-macros/src/clone.rs
+++ b/glib-macros/src/clone.rs
@@ -1,952 +1,547 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::iter::Peekable;
-
-use proc_macro::{
-    token_stream::IntoIter as ProcIter, Delimiter, Group, Ident, Literal, Punct, Spacing, Span,
-    TokenStream, TokenTree,
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    spanned::Spanned,
+    Attribute, Expr, ExprAsync, ExprClosure, Token,
 };
 
 use crate::utils::crate_ident_new;
 
-struct PeekableProcIter {
-    inner: Peekable<ProcIter>,
-    current_span: Option<Span>,
-    next_span: Option<Span>,
-}
-
-impl<'a> From<&'a Group> for PeekableProcIter {
-    fn from(f: &'a Group) -> Self {
-        let current_span = Some(f.span());
-        let mut inner = f.stream().into_iter().peekable();
-        let next_span = inner.peek().map(|n| n.span());
-        Self {
-            inner,
-            current_span,
-            next_span,
-        }
-    }
-}
-
-impl From<TokenStream> for PeekableProcIter {
-    fn from(f: TokenStream) -> Self {
-        let mut inner = f.into_iter().peekable();
-        let next_span = inner.peek().map(|n| n.span());
-        Self {
-            inner,
-            current_span: None,
-            next_span,
-        }
-    }
-}
-
-impl Iterator for PeekableProcIter {
-    type Item = TokenTree;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let next = self.inner.next()?;
-        self.current_span = Some(next.span());
-        self.next_span = self.inner.peek().map(|n| n.span());
-        Some(next)
-    }
-}
-
-impl PeekableProcIter {
-    fn peek(&mut self) -> Option<&TokenTree> {
-        self.inner.peek()
-    }
-
-    fn generate_error(&self, message: &str) -> TokenStream {
-        self.generate_error_with_span(message, self.current_span)
-    }
-
-    fn generate_error_with_next_span(&self, message: &str) -> TokenStream {
-        self.generate_error_with_span(message, self.next_span)
-    }
-
-    fn generate_error_with_span(&self, message: &str, span: Option<Span>) -> TokenStream {
-        let span = span.unwrap_or_else(Span::call_site);
-        // We generate a `compile_error` macro and assign it to the current span so the error
-        // displayed by rustc points to the right location.
-        let mut stream = TokenStream::new();
-        stream.extend(vec![TokenTree::Literal(Literal::string(message))]);
-
-        let mut tokens = vec![
-            TokenTree::Ident(Ident::new("compile_error", span)),
-            TokenTree::Punct(Punct::new('!', Spacing::Alone)),
-            TokenTree::Group(Group::new(Delimiter::Parenthesis, stream)),
-            TokenTree::Punct(Punct::new(';', Spacing::Alone)),
-        ];
-
-        for tok in &mut tokens {
-            tok.set_span(span);
-        }
-
-        let mut stream = TokenStream::new();
-        stream.extend(tokens);
-        let mut t = TokenTree::Group(Group::new(Delimiter::Brace, stream));
-        t.set_span(span);
-
-        let mut stream = TokenStream::new();
-        stream.extend(vec![t]);
-        stream
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-enum BorrowKind {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CaptureKind {
+    Watch,
     Weak,
     WeakAllowNone,
     Strong,
     ToOwned,
 }
 
-impl BorrowKind {
-    fn to_str(self) -> &'static str {
-        match self {
-            Self::Weak => "@weak",
-            Self::WeakAllowNone => "@weak-allow-none",
-            Self::Strong => "@strong",
-            Self::ToOwned => "@to-owned",
-        }
+impl<'a> TryFrom<&'a Ident> for CaptureKind {
+    type Error = syn::Error;
+
+    fn try_from(s: &Ident) -> Result<Self, Self::Error> {
+        Ok(match s.to_string().as_str() {
+            "watch" => CaptureKind::Watch,
+            "strong" => CaptureKind::Strong,
+            "weak" => CaptureKind::Weak,
+            "weak_allow_none" => CaptureKind::WeakAllowNone,
+            "to_owned" => CaptureKind::ToOwned,
+            _ => {
+                // This is actually never shown to the user but we need some kind of error type for
+                // TryFrom, () would be enough but then clippy complains.
+                //
+                // We'll keep it here in case it is useful somewhere at a later time.
+                return Err(syn::Error::new(
+                    s.span(),
+                    format!("unknown capture type `{s}`"),
+                ));
+            }
+        })
     }
 }
 
-enum WrapperKind {
-    DefaultPanic,
-    DefaultReturn(String),
+#[derive(Default)]
+pub(crate) enum UpgradeBehaviour {
+    #[default]
+    Unit,
+    Panic,
+    Default,
+    Expression(Expr),
+    Closure(ExprClosure),
 }
 
-impl WrapperKind {
-    fn to_str(&self) -> String {
-        match *self {
-            Self::DefaultPanic => "@default-panic".to_owned(),
-            Self::DefaultReturn(ref r) => format!("@default-return {r}"),
-        }
-    }
+impl UpgradeBehaviour {
+    pub(crate) fn maybe_parse(
+        attrs: &[Attribute],
+        input: ParseStream,
+    ) -> syn::Result<Option<Self>> {
+        // Caller checked for empty
+        let attr = &attrs[0];
+        attr.meta.require_path_only()?;
 
-    fn keyword(&self) -> &'static str {
-        match *self {
-            Self::DefaultPanic => "default-panic",
-            Self::DefaultReturn(_) => "default-return",
-        }
-    }
-}
-
-#[derive(Debug)]
-struct ElemToClone {
-    name: String,
-    alias: Option<String>,
-    borrow_kind: BorrowKind,
-}
-
-impl ElemToClone {
-    fn to_str_before(&self) -> String {
-        match self.borrow_kind {
-            BorrowKind::Weak | BorrowKind::WeakAllowNone => format!(
-                "let {} = {}::clone::Downgrade::downgrade(&{});",
-                if let Some(ref a) = self.alias {
-                    a
-                } else {
-                    &self.name
-                },
-                crate_ident_new(),
-                self.name,
-            ),
-            BorrowKind::Strong => format!(
-                "let {} = {}.clone();",
-                if let Some(ref a) = self.alias {
-                    a
-                } else {
-                    &self.name
-                },
-                self.name,
-            ),
-            BorrowKind::ToOwned => format!(
-                "let {} = ::std::borrow::ToOwned::to_owned(&*{});",
-                if let Some(ref a) = self.alias {
-                    a
-                } else {
-                    &self.name
-                },
-                self.name,
-            ),
-        }
-    }
-
-    fn to_str_after(&self, wrapper_kind: &Option<WrapperKind>) -> String {
-        let name = if let Some(ref a) = self.alias {
-            a
-        } else {
-            &self.name
+        let Some(attr_name) = attr.path().get_ident() else {
+            return Ok(None);
         };
-        match (self.borrow_kind, wrapper_kind) {
-            (BorrowKind::Weak, Some(WrapperKind::DefaultPanic)) => {
+
+        let upgrade_behaviour = match attr_name.to_string().as_str() {
+            "upgrade_or" => {
+                let expr = input.parse::<Expr>()?;
+                input.parse::<Token![,]>()?;
+                UpgradeBehaviour::Expression(expr)
+            }
+            "upgrade_or_else" => {
+                let closure = input.parse::<ExprClosure>()?;
+                if closure.asyncness.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &closure,
+                        "`upgrade_or_else` closure needs to be a non-async closure",
+                    ));
+                }
+                if !closure.inputs.is_empty() {
+                    return Err(syn::Error::new_spanned(
+                        &closure,
+                        "`upgrade_or_else` closure must not have any parameters",
+                    ));
+                }
+
+                input.parse::<Token![,]>()?;
+                UpgradeBehaviour::Closure(closure)
+            }
+            "upgrade_or_default" => UpgradeBehaviour::Default,
+            "upgrade_or_panic" => UpgradeBehaviour::Panic,
+            _ => {
+                return Ok(None);
+            }
+        };
+
+        if attrs.len() > 1 {
+            return Err(syn::Error::new_spanned(
+                &attrs[1],
                 format!(
-                    "\
-let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
-    Some(val) => val,
-    None => panic!(
-        \"failed to upgrade `{0}` (if you don't want to panic, use @default-return)\",
-    ),
-}};",
-                    name,
-                    crate_ident_new(),
-                )
-            }
-            (BorrowKind::Weak, Some(WrapperKind::DefaultReturn(ref r))) => {
-                let not_unit_ret = r.chars().any(|c| c != '(' && c != ')' && c != ' ');
+                    "upgrade failure attribute must not be followed by any other attributes. Found {} more attribute{}",
+                    attrs.len() - 1,
+                    if attrs.len() > 2 { "s" } else { "" },
+            )));
+        }
+
+        let next_attrs = &input.call(Attribute::parse_outer)?;
+        if !next_attrs.is_empty() {
+            return Err(syn::Error::new_spanned(
+                &next_attrs[0],
                 format!(
-                    "\
-let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
-    Some(val) => val,
-    None => {{
-        {1}::g_debug!(
-            {1}::CLONE_MACRO_LOG_DOMAIN,
-            \"Failed to upgrade {0}\",
-        );
-        let ___return_value = || {{ {2} }};
-        return ___return_value();
-    }}
-}};",
-                    name,
-                    crate_ident_new(),
-                    if not_unit_ret { r } else { "" },
+                    "upgrade failure attribute must not be followed by any other attributes. Found {} more attribute{}",
+                    next_attrs.len(),
+                    if next_attrs.len() > 1 { "s" } else { "" },
                 )
-            }
-            (BorrowKind::Weak, None) => {
-                format!(
-                    "\
-let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
-    Some(val) => val,
-    None => {{
-        {1}::g_debug!(
-            {1}::CLONE_MACRO_LOG_DOMAIN,
-            \"Failed to upgrade {0}\",
-        );
-        return;
-    }}
-}};",
-                    name,
-                    crate_ident_new(),
-                )
-            }
-            (BorrowKind::WeakAllowNone, _) => format!(
-                "let {0} = {1}::clone::Upgrade::upgrade(&{0});",
-                name,
-                crate_ident_new(),
-            ),
-            _ => String::new(),
-        }
-    }
-}
-
-enum SimpleToken {
-    Punct(&'static str),
-    Ident(&'static str),
-}
-
-impl SimpleToken {
-    fn to_str(&self) -> &str {
-        match *self {
-            Self::Punct(p) => p,
-            Self::Ident(i) => i,
-        }
-    }
-}
-
-impl PartialEq<TokenTree> for SimpleToken {
-    fn eq(&self, other: &TokenTree) -> bool {
-        match (self, other) {
-            (SimpleToken::Punct(p1), TokenTree::Punct(ref p2)) => *p1 == p2.to_string(),
-            (SimpleToken::Ident(i1), TokenTree::Ident(ref i2)) => *i1 == i2.to_string(),
-            _ => false,
-        }
-    }
-}
-
-fn is_punct(elem: &TokenTree, punct: &str) -> bool {
-    match elem {
-        TokenTree::Punct(ref p) => p.to_string() == punct,
-        _ => false,
-    }
-}
-
-enum TokenCheck {
-    UnexpectedToken(String, String),
-    UnexpectedEnd(String),
-}
-
-fn check_tokens(
-    tokens_to_check: &[SimpleToken],
-    parts: &mut PeekableProcIter,
-) -> Result<(), TokenCheck> {
-    let mut tokens = String::new();
-
-    for token in tokens_to_check {
-        if let Some(next) = parts.peek() {
-            if token != next {
-                return Err(TokenCheck::UnexpectedToken(tokens, next.to_string()));
-            }
-            tokens.push_str(token.to_str());
-            parts.next();
-        } else {
-            return Err(TokenCheck::UnexpectedEnd(tokens));
-        }
-    }
-    Ok(())
-}
-
-#[doc(alias = "get_full_ident")]
-fn full_ident(
-    parts: &mut PeekableProcIter,
-    borrow_kind: BorrowKind,
-) -> Result<String, TokenStream> {
-    let mut name = String::new();
-    let mut prev_is_ident = false;
-
-    loop {
-        match parts.peek() {
-            Some(TokenTree::Punct(p)) => {
-                let p_s = p.to_string();
-                if p_s == "," || p_s == "=" {
-                    break;
-                } else if p_s == "." {
-                    if !prev_is_ident {
-                        return Err(parts.generate_error_with_next_span(&format!(
-                            "Unexpected `.` after `{}`",
-                            borrow_kind.to_str()
-                        )));
-                    }
-                    prev_is_ident = false;
-                    name.push('.');
-                    parts.next();
-                } else if name.is_empty() {
-                    return Err(parts
-                        .generate_error_with_next_span(&format!("Expected ident, found `{p_s}`")));
-                } else {
-                    return Err(parts.generate_error_with_next_span(&format!(
-                        "Expected ident, found `{p_s}` after `{name}`"
-                    )));
-                }
-            }
-            Some(TokenTree::Ident(i)) => {
-                if prev_is_ident {
-                    break;
-                }
-                prev_is_ident = true;
-                name.push_str(&i.to_string());
-                parts.next();
-            }
-            Some(x) if name.is_empty() => {
-                let err = format!("Expected ident, found `{x}`");
-                return Err(parts.generate_error_with_next_span(&err));
-            }
-            Some(x) => {
-                let err = &format!("Expected ident, found `{x}` after `{name}`");
-                return Err(parts.generate_error_with_next_span(err));
-            }
-            None => {
-                return Err(parts.generate_error(&format!("Unexpected end after ident `{name}`")));
-            }
-        }
-    }
-    if name.is_empty() {
-        if let Some(next) = parts.next() {
-            return Err(parts.generate_error(&format!("Expected ident, found `{next}`")));
-        }
-        return Err(parts.generate_error("Expected something after, found nothing"));
-    }
-    Ok(name)
-}
-
-#[doc(alias = "get_keyword")]
-fn keyword(parts: &mut PeekableProcIter) -> Result<BorrowKind, TokenStream> {
-    let mut ret = String::new();
-    let mut prev_is_ident = false;
-    let mut stored = false;
-    // We unfortunately can't join spans since the `Span::join` method is nightly-only. Well, we'll
-    // do our best...
-    let start_span = parts.next_span;
-
-    loop {
-        match parts.peek() {
-            Some(TokenTree::Ident(i)) => {
-                if prev_is_ident {
-                    break;
-                }
-                prev_is_ident = true;
-                if stored {
-                    ret.push('-');
-                    stored = false;
-                }
-                ret.push_str(&i.to_string());
-            }
-            Some(TokenTree::Punct(p)) if p.to_string() == "-" => {
-                if !prev_is_ident {
-                    break;
-                }
-                // This is to prevent to push `-` if the next item isn't an ident.
-                prev_is_ident = false;
-                stored = true;
-            }
-            _ => break,
-        }
-        parts.next();
-    }
-    let ret = match ret.as_str() {
-        "strong" => BorrowKind::Strong,
-        "weak" => BorrowKind::Weak,
-        "weak-allow-none" => BorrowKind::WeakAllowNone,
-        "to-owned" => BorrowKind::ToOwned,
-        "default-return" => {
-            return Err(parts
-                .generate_error_with_span("`@default-return` should be after `=>`", start_span));
-        }
-        "default-panic" => {
-            return Err(
-                parts.generate_error_with_span("`@default-panic` should be after `=>`", start_span)
-            );
-        }
-        k => {
-            return Err(parts.generate_error_with_span(
-                &format!(
-                    "Unknown keyword `{k}`, only `weak`, `weak-allow-none`, `to-owned` and \
-                    `strong` are allowed"
-                ),
-                start_span,
             ));
         }
-    };
-    Ok(ret)
-}
 
-fn parse_ident(
-    parts: &mut PeekableProcIter,
-    elements: &mut Vec<ElemToClone>,
-) -> Result<(), TokenStream> {
-    let borrow_kind = keyword(parts)?;
-    let name = full_ident(parts, borrow_kind)?;
-    let name_span = parts.current_span;
-    if name.ends_with('.') {
-        return Err(
-            parts.generate_error_with_span(&format!("Invalid variable name: `{name}`"), name_span)
-        );
-    }
-    let alias = match parts.peek() {
-        Some(TokenTree::Ident(p)) if p.to_string() == "as" => {
-            parts.next();
-            let current_span = parts.current_span;
-            match parts.next() {
-                Some(TokenTree::Ident(i)) => Some(i.to_string()),
-                Some(x) => {
-                    let err = format!("Expected ident after `as` keyword, found `{x}`");
-                    return Err(parts.generate_error(&err));
-                }
-                None => {
-                    return Err(parts.generate_error_with_span(
-                        "Unexpected end after `as` keyword",
-                        current_span,
-                    ))
-                }
-            }
-        }
-        Some(TokenTree::Ident(p)) => {
-            let err = format!("Unexpected `{p}`");
-            return Err(parts.generate_error(&err));
-        }
-        _ => None,
-    };
-    if name == "self" && alias.is_none() {
-        return Err(parts.generate_error_with_span(
-            "Can't use `self` as variable name. Try storing it in a temporary variable or \
-                rename it using `as`.",
-            name_span,
-        ));
-    } else if name.contains('.') && alias.is_none() {
-        let err = format!("`{name}`: Field accesses are not allowed as is, you must rename it!");
-        return Err(parts.generate_error_with_span(&err, name_span));
-    }
-
-    elements.push(ElemToClone {
-        name,
-        alias,
-        borrow_kind,
-    });
-    Ok(())
-}
-
-fn delimiter_to_string(delimiter: Delimiter, open: bool) -> &'static str {
-    match delimiter {
-        Delimiter::Parenthesis => {
-            if open {
-                "("
-            } else {
-                ")"
-            }
-        }
-        Delimiter::Brace => {
-            if open {
-                "{"
-            } else {
-                "}"
-            }
-        }
-        Delimiter::Bracket => {
-            if open {
-                "["
-            } else {
-                "]"
-            }
-        }
-        Delimiter::None => "",
+        Ok(Some(upgrade_behaviour))
     }
 }
 
-fn group_to_string(g: &Group) -> String {
-    format!(
-        "{}{}{}",
-        delimiter_to_string(g.delimiter(), true),
-        tokens_to_string(PeekableProcIter::from(g)),
-        delimiter_to_string(g.delimiter(), false),
-    )
+pub(crate) struct Capture {
+    pub(crate) name: Expr,
+    pub(crate) alias: Option<Ident>,
+    pub(crate) kind: CaptureKind,
 }
 
-#[doc(alias = "get_expr")]
-fn expr(parts: &mut PeekableProcIter) -> Result<String, TokenStream> {
-    let mut ret = String::new();
-    let mut total = 0;
-    let span = parts.current_span;
-    match parts.next() {
-        Some(TokenTree::Literal(l)) => ret.push_str(&l.to_string()),
-        Some(TokenTree::Ident(i)) => ret.push_str(&i.to_string()),
-        Some(TokenTree::Punct(p)) => match p.to_string().as_str() {
-            "[" | "{" | "(" => {
-                total += 1;
-            }
-            x => {
-                return Err(parts
-                    .generate_error(&format!("Unexpected token `{x}` after `@default-return`")))
-            }
-        },
-        Some(TokenTree::Group(g)) => return Ok(group_to_string(&g)),
-        None => {
-            return Err(
-                parts.generate_error_with_span("Unexpected end after `@default-return`", span)
-            )
+impl Capture {
+    pub(crate) fn maybe_parse(
+        attrs: &[Attribute],
+        input: ParseStream,
+    ) -> syn::Result<Option<Self>> {
+        // Caller checked for empty
+        let attr = &attrs[0];
+
+        let Some(attr_name) = attr.path().get_ident() else {
+            return Ok(None);
+        };
+        let Ok(kind) = CaptureKind::try_from(attr_name) else {
+            return Ok(None);
+        };
+
+        if attrs.len() > 1 {
+            return Err(syn::Error::new_spanned(
+                &attrs[1],
+                "variable capture attributes must be followed by an identifier",
+            ));
         }
-    };
-    loop {
-        match parts.peek() {
-            Some(TokenTree::Punct(p)) => {
-                let p_s = p.to_string();
-                if p_s == "{" || p_s == "(" || p_s == "[" || p_s == "<" {
-                    total += 1;
-                } else if p_s == "}" || p_s == ")" || p_s == "]" || p_s == ">" {
-                    total -= 1;
-                } else if p_s == "," && total == 0 {
-                    return Ok(ret);
+
+        let mut alias = None;
+        if let syn::Meta::List(ref list) = attr.meta {
+            list.parse_nested_meta(|meta| {
+                if meta.path.is_ident("rename_to") {
+                    let value = meta.value()?;
+                    let id = value.parse::<Ident>()?;
+                    if alias.is_some() {
+                        return Err(meta.error("multiple `rename_to` properties are not allowed"));
+                    }
+                    alias = Some(id);
+                } else if let Some(ident) = meta.path.get_ident() {
+                    return Err(
+                        meta.error(
+                            format!(
+                                "unsupported capture attribute property `{ident}`: only `rename_to` is supported"
+                            ),
+                        ),
+                    );
+                } else {
+                    return Err(meta.error("unsupported capture attribute property"));
                 }
-                ret.push_str(&p_s);
-            }
-            Some(TokenTree::Group(g)) => {
-                ret.push_str(&group_to_string(g));
-            }
-            Some(x) => {
-                if total == 0 && !ret.ends_with(':') {
-                    return Ok(ret);
+                Ok(())
+            })?;
+        }
+
+        let name = input.parse::<Expr>()?;
+        match name {
+            Expr::Path(ref p) if p.path.get_ident().is_some() => {
+                if p.path.get_ident().unwrap() == "self" && alias.is_none() {
+                    return Err(
+                        syn::Error::new_spanned(
+                            attr,
+                            "capture attribute for `self` requires usage of the `rename_to` attribute property",
+                        ),
+                    );
                 }
-                ret.push_str(&x.to_string())
+                // Nothing to do, it's just an identifier
             }
-            None => return Err(parts.generate_error(
-                "Unexpected end after `{ret}`. Did you forget a `,` after the @default-return value?",
+            _ if alias.is_some() => {
+                // Nothing to do, it's an alias
+            }
+            _ => {
+                return Err(
+                    syn::Error::new_spanned(
+                        attr,
+                        "capture attribute for an expression requires usage of the `rename_to` attribute property",
+                    ),
+                );
+            }
+        }
+
+        input.parse::<Token![,]>()?;
+
+        Ok(Some(Capture { name, alias, kind }))
+    }
+
+    pub(crate) fn alias(&self) -> TokenStream {
+        if let Some(ref alias) = self.alias {
+            alias.to_token_stream()
+        } else {
+            self.name.to_token_stream()
+        }
+    }
+
+    pub(crate) fn outer_before_tokens(&self, crate_ident: &TokenStream) -> TokenStream {
+        let alias = self.alias();
+        let name = &self.name;
+        match self.kind {
+            CaptureKind::Watch => quote! {
+                let #alias = #crate_ident::object::Watchable::watched_object(&#name);
+            },
+            CaptureKind::Weak | CaptureKind::WeakAllowNone => quote! {
+                let #alias = #crate_ident::clone::Downgrade::downgrade(&#name);
+            },
+            CaptureKind::Strong => quote! {
+                let #alias = #name.clone();
+            },
+            CaptureKind::ToOwned => quote! {
+                let #alias = ::std::borrow::ToOwned::to_owned(&*#name);
+            },
+        }
+    }
+
+    pub(crate) fn outer_after_tokens(
+        &self,
+        crate_ident: &TokenStream,
+        closure_ident: &Ident,
+    ) -> TokenStream {
+        let name = &self.name;
+        match self.kind {
+            CaptureKind::Watch => quote! {
+                #crate_ident::object::Watchable::watch_closure(&#name, &#closure_ident);
+            },
+            _ => Default::default(),
+        }
+    }
+
+    pub(crate) fn inner_before_tokens(
+        &self,
+        crate_ident: &TokenStream,
+        weak_upgrade_failure_kind: &UpgradeBehaviour,
+        upgrade_failure_closure_ident: &Ident,
+    ) -> TokenStream {
+        let alias = self.alias();
+        match self.kind {
+            CaptureKind::Watch => {
+                quote! {
+                    let #alias = unsafe { #alias.borrow() };
+                    let #alias = ::core::convert::AsRef::as_ref(&#alias);
+                }
+            }
+            CaptureKind::Weak => match weak_upgrade_failure_kind {
+                UpgradeBehaviour::Panic => {
+                    let err_msg = format!(
+                        "Failed to upgrade `{}`. If you don't want to panic, use `#[upgrade_or]`, `#[upgrade_or_else]` or `#[upgrade_or_default]`",
+                        alias,
+                    );
+                    quote! {
+                        let Some(#alias) = #crate_ident::clone::Upgrade::upgrade(&#alias) else {
+                            panic!(#err_msg);
+                        };
+                    }
+                }
+                UpgradeBehaviour::Default
+                | UpgradeBehaviour::Expression(_)
+                | UpgradeBehaviour::Closure(_) => {
+                    let err_msg = format!("Failed to upgrade `{}`", alias);
+                    quote! {
+                        let Some(#alias) = #crate_ident::clone::Upgrade::upgrade(&#alias) else {
+                            #crate_ident::g_debug!(
+                                #crate_ident::CLONE_MACRO_LOG_DOMAIN,
+                                #err_msg,
+                            );
+                            return (#upgrade_failure_closure_ident)();
+                        };
+                    }
+                }
+                UpgradeBehaviour::Unit => {
+                    let err_msg = format!("Failed to upgrade `{}`", alias);
+                    quote! {
+                        let Some(#alias) = #crate_ident::clone::Upgrade::upgrade(&#alias) else {
+                            #crate_ident::g_debug!(
+                                #crate_ident::CLONE_MACRO_LOG_DOMAIN,
+                                #err_msg,
+                            );
+                            return;
+                        };
+                    }
+                }
+            },
+            CaptureKind::WeakAllowNone => quote! {
+                let #alias = #crate_ident::clone::Upgrade::upgrade(&#alias);
+            },
+            _ => Default::default(),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum ClosureOrAsync {
+    Closure(ExprClosure),
+    Async(ExprAsync),
+}
+
+impl Parse for ClosureOrAsync {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let expr = input.parse::<Expr>()?;
+        match expr {
+            Expr::Async(async_) => {
+                if async_.capture.is_none() {
+                    return Err(syn::Error::new_spanned(
+                        async_,
+                        "async blocks need to capture variables by move. Please add the `move` keyword",
+                    ));
+                }
+
+                Ok(ClosureOrAsync::Async(async_))
+            }
+            Expr::Closure(closure) => {
+                if closure.capture.is_none() {
+                    return Err(syn::Error::new_spanned(
+                        closure,
+                        "closures need to capture variables by move. Please add the `move` keyword",
+                    ));
+                }
+
+                Ok(ClosureOrAsync::Closure(closure))
+            }
+            _ => Err(syn::Error::new_spanned(
+                expr,
+                "only closures and async blocks are supported",
             )),
         }
-        parts.next();
     }
 }
 
-#[doc(alias = "get_return_kind")]
-fn return_kind(parts: &mut PeekableProcIter) -> Result<WrapperKind, TokenStream> {
-    match check_tokens(
-        &[SimpleToken::Ident("default"), SimpleToken::Punct("-")],
-        parts,
-    ) {
-        Err(TokenCheck::UnexpectedToken(tokens, unexpected_token)) => {
-            return Err(
-                parts.generate_error(&format!("Unknown keyword `{tokens}{unexpected_token}`"))
-            );
-        }
-        Err(TokenCheck::UnexpectedEnd(tokens)) => {
-            return Err(parts.generate_error(&format!("Unexpected end after tokens `{tokens}`")));
-        }
-        Ok(()) => {}
-    }
-    let prev = parts.current_span;
-    match parts.next() {
-        Some(TokenTree::Ident(i)) => {
-            let i_s = i.to_string();
-            if i_s == "panic" {
-                return Ok(WrapperKind::DefaultPanic);
-            }
-            assert!(i_s == "return", "Unknown keyword `@default-{i_s}`");
-        }
-        Some(x) => {
-            let err = format!("Unknown token `{x}` after `@default-`");
-            return Err(parts.generate_error(&err));
-        }
-        None => {
-            return Err(parts.generate_error_with_span("Unexpected end after `@default-`", prev))
-        }
-    }
-    Ok(WrapperKind::DefaultReturn(expr(parts)?))
-}
-
-fn parse_return_kind(parts: &mut PeekableProcIter) -> Result<Option<WrapperKind>, TokenStream> {
-    match parts.peek() {
-        Some(TokenTree::Punct(p)) if p.to_string() == "@" => {}
-        None => return Err(parts.generate_error("Unexpected end 2")),
-        _ => return Ok(None),
-    }
-    parts.next();
-    let ret = return_kind(parts)?;
-    match check_tokens(&[SimpleToken::Punct(",")], parts) {
-        Err(TokenCheck::UnexpectedToken(_, unexpected_token)) => {
-            let err = format!(
-                "Expected `,` after `{}`, found `{unexpected_token}`",
-                ret.to_str(),
-            );
-            return Err(parts.generate_error_with_next_span(&err));
-        }
-        Err(TokenCheck::UnexpectedEnd(tokens)) => {
-            let err = format!("Expected `,` after `{}{tokens}`", ret.to_str());
-            return Err(parts.generate_error(&err));
-        }
-        Ok(()) => {}
-    }
-    Ok(Some(ret))
-}
-
-enum BlockKind {
-    Closure(Vec<TokenTree>),
-    ClosureWrappingAsync(Vec<TokenTree>),
-    AsyncClosure(Vec<TokenTree>),
-    AsyncBlock,
-}
-
-impl BlockKind {
-    #[doc(alias = "get_closure")]
-    fn closure(self) -> Option<Vec<TokenTree>> {
+impl ToTokens for ClosureOrAsync {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            Self::AsyncBlock => None,
-            Self::Closure(c) | Self::ClosureWrappingAsync(c) | Self::AsyncClosure(c) => Some(c),
+            ClosureOrAsync::Closure(ref c) => c.to_tokens(tokens),
+            ClosureOrAsync::Async(ref a) => a.to_tokens(tokens),
         }
     }
 }
 
-fn check_move_after_async(parts: &mut PeekableProcIter) -> Result<(), TokenStream> {
-    let span = parts.current_span;
-    match parts.next() {
-        Some(TokenTree::Ident(i)) if i.to_string() == "move" => Ok(()),
-        // The next checks are just for better error messages.
-        Some(TokenTree::Ident(i)) => {
-            let err = format!("Expected `move` after `async`, found `{i}`");
-            Err(parts.generate_error(&err))
+struct Clone {
+    captures: Vec<Capture>,
+    upgrade_behaviour: UpgradeBehaviour,
+    body: ClosureOrAsync,
+}
+
+impl Parse for Clone {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut captures: Vec<Capture> = vec![];
+        let mut upgrade_behaviour: Option<(UpgradeBehaviour, Span)> = None;
+
+        loop {
+            // There must either be one or no attributes here. Multiple attributes are not
+            // supported.
+            //
+            // If this is a capture attribute, it must be followed by an identifier.
+            // If this is an upgrade failure attribute, it might be followed by a closure. After the
+            // upgrade failure attribute there must not be any further attributes.
+            //
+            // If this is not an attribute then it is a closure, async closure or async block which
+            // is handled outside the loop
+            let attrs = input.call(Attribute::parse_outer)?;
+            if attrs.is_empty() {
+                break;
+            };
+
+            if let Some(capture) = Capture::maybe_parse(&attrs, input)? {
+                if capture.kind == CaptureKind::Watch {
+                    return Err(syn::Error::new_spanned(
+                        &attrs[0],
+                        "watch variable captures are not supported",
+                    ));
+                }
+
+                captures.push(capture);
+            } else if let Some(behaviour) = UpgradeBehaviour::maybe_parse(&attrs, input)? {
+                if upgrade_behaviour.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        &attrs[0],
+                        "multiple upgrade failure attributes are not supported",
+                    ));
+                }
+
+                upgrade_behaviour = Some((behaviour, attrs[0].span()));
+                break;
+            } else if let Some(ident) = attrs[0].path().get_ident() {
+                return Err(syn::Error::new_spanned(
+                        &attrs[0],
+                        format!(
+                            "unsupported attribute `{ident}`: only `strong`, `weak`, `weak_allow_none`, `to_owned`, `upgrade_or`, `upgrade_or_else`, `upgrade_or_default` and `upgrade_or_panic` are supported",
+                        ),
+                ));
+            } else {
+                return Err(syn::Error::new_spanned(
+                        &attrs[0],
+                        "unsupported attribute: only `strong`, `weak`, `weak_allow_none`, `to_owned`, `upgrade_or_else`, `upgrade_or_default` and `upgrade_or_panic` are supported",
+                ));
+            }
         }
-        Some(TokenTree::Punct(p)) => {
-            let err = format!("Expected `move` after `async`, found `{p}`");
-            Err(parts.generate_error(&err))
+
+        if let Some((_, ref span)) = upgrade_behaviour {
+            if captures.iter().all(|c| c.kind != CaptureKind::Weak) {
+                return Err(syn::Error::new(
+                    *span,
+                    "upgrade failure attribute can only be used together with weak variable captures",
+                ));
+            }
         }
-        Some(TokenTree::Group(g)) => {
-            let err = format!(
-                "Expected `move` after `async`, found `{}`",
-                delimiter_to_string(g.delimiter(), true),
-            );
-            Err(parts.generate_error(&err))
+
+        let upgrade_behaviour = upgrade_behaviour.map(|x| x.0).unwrap_or_default();
+
+        // Following is a closure or async block
+        let body = input.parse::<ClosureOrAsync>()?;
+
+        // Trailing comma, if any
+        if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
         }
-        _ => Err(parts.generate_error_with_span("Expected `move` after `async`", span)),
+
+        Ok(Clone {
+            captures,
+            upgrade_behaviour,
+            body,
+        })
     }
 }
 
-fn check_async_syntax(parts: &mut PeekableProcIter) -> Result<BlockKind, TokenStream> {
-    check_move_after_async(parts)?;
-    match parts.peek() {
-        Some(TokenTree::Punct(p)) if p.to_string() == "|" => {
-            parts.next();
-            Ok(BlockKind::AsyncClosure(closure(parts)?))
-        }
-        Some(TokenTree::Punct(p)) => {
-            let err = format!("Expected closure or block after `async move`, found `{p}`");
-            Err(parts.generate_error_with_next_span(&err))
-        }
-        Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Brace => Ok(BlockKind::AsyncBlock),
-        Some(TokenTree::Group(g)) => {
-            let err = format!(
-                "Expected closure or block after `async move`, found `{}`",
-                delimiter_to_string(g.delimiter(), true),
-            );
-            Err(parts.generate_error_with_next_span(&err))
-        }
-        _ => Err(parts.generate_error("Expected closure or block after `async move`")),
-    }
-}
+impl ToTokens for Clone {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let crate_ident = crate_ident_new();
 
-// Returns `true` if this is an async context.
-fn check_before_closure(parts: &mut PeekableProcIter) -> Result<BlockKind, TokenStream> {
-    let is_async = match parts.peek() {
-        Some(TokenTree::Ident(i)) if i.to_string() == "move" => false,
-        Some(TokenTree::Ident(i)) if i.to_string() == "async" => true,
-        Some(TokenTree::Ident(i)) if i.to_string() == "default" => {
-            let span = parts.next_span;
-            let ret = return_kind(parts)?;
-            let err = format!("Missing `@` before `{}`", ret.keyword());
-            return Err(parts.generate_error_with_span(&err, span));
-        }
-        Some(TokenTree::Punct(p)) if p.to_string() == "|" => {
-            return Err(parts.generate_error_with_next_span(
-                "Closure needs to be \"moved\" so please add `move` before closure",
-            ));
-        }
-        _ => {
-            return Err(
-                parts.generate_error_with_next_span("Missing `move` and closure declaration")
+        let upgrade_failure_closure_ident =
+            Ident::new("____upgrade_failure_closure", Span::call_site());
+
+        let outer_before = self
+            .captures
+            .iter()
+            .map(|c| c.outer_before_tokens(&crate_ident));
+        let inner_before = self.captures.iter().map(|c| {
+            c.inner_before_tokens(
+                &crate_ident,
+                &self.upgrade_behaviour,
+                &upgrade_failure_closure_ident,
             )
-        }
-    };
-    parts.next();
-    if is_async {
-        return check_async_syntax(parts);
-    }
-    match parts.peek() {
-        Some(TokenTree::Punct(p)) if p.to_string() == "|" => {}
-        Some(x) => {
-            let err = format!("Expected closure, found `{x}`");
-            return Err(parts.generate_error_with_next_span(&err));
-        }
-        None => return Err(parts.generate_error("Expected closure")),
-    }
-    parts.next();
+        });
 
-    let closure = closure(parts)?;
-    match parts.peek() {
-        Some(TokenTree::Ident(i)) if i.to_string() == "async" => {
-            parts.next();
-            check_move_after_async(parts)?;
-            match parts.peek() {
-                Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Brace => {
-                    Ok(BlockKind::ClosureWrappingAsync(closure))
-                }
-                // The next matchings are for better error messages.
-                Some(TokenTree::Punct(p)) => {
-                    let err = format!("Expected block after `| async move`, found `{p}`");
-                    Err(parts.generate_error_with_next_span(&err))
-                }
-                Some(TokenTree::Group(g)) => {
-                    let err = format!(
-                        "Expected block after `| async move`, found `{}`",
-                        delimiter_to_string(g.delimiter(), true),
-                    );
-                    Err(parts.generate_error_with_next_span(&err))
-                }
-                _ => {
-                    Err(parts.generate_error_with_next_span("Expected block after `| async move`"))
-                }
-            }
-        }
-        _ => Ok(BlockKind::Closure(closure)),
-    }
-}
+        let upgrade_failure_closure = match self.upgrade_behaviour {
+            UpgradeBehaviour::Default => Some(quote! {
+                let #upgrade_failure_closure_ident = ::std::default::Default::default;
+            }),
+            UpgradeBehaviour::Expression(ref expr) => Some(quote! {
+                let #upgrade_failure_closure_ident = move || {
+                    #expr
+                };
+            }),
+            UpgradeBehaviour::Closure(ref closure) => Some(quote! {
+                let #upgrade_failure_closure_ident = #closure;
+            }),
+            _ => None,
+        };
 
-#[doc(alias = "get_closure")]
-fn closure(parts: &mut PeekableProcIter) -> Result<Vec<TokenTree>, TokenStream> {
-    let mut ret = Vec::new();
+        let body = match self.body {
+            ClosureOrAsync::Closure(ref c) => {
+                let ExprClosure {
+                    attrs,
+                    lifetimes,
+                    constness,
+                    movability,
+                    asyncness,
+                    capture,
+                    or1_token,
+                    inputs,
+                    or2_token,
+                    output,
+                    body,
+                } = c;
 
-    loop {
-        let span = parts.current_span;
-        match parts.next() {
-            Some(TokenTree::Punct(p)) if p.to_string() == "|" => break,
-            Some(x) => ret.push(x),
-            None => return Err(parts.generate_error_with_span("Unexpected end 3", span)),
-        }
-    }
-    Ok(ret)
-}
-
-pub fn tokens_to_string(parts: impl Iterator<Item = TokenTree>) -> String {
-    let mut ret = String::new();
-    // This is used in case of "if ident" or other similar cases.
-    let mut prev_is_ident = false;
-    let handle_ident_like = |i: String, ret: &mut String, prev_is_ident: &mut bool| {
-        if *prev_is_ident {
-            ret.push(' ');
-        }
-        ret.push_str(&i);
-        *prev_is_ident = true;
-    };
-
-    for token in parts {
-        match token {
-            TokenTree::Punct(p) => {
-                prev_is_ident = false;
-                ret.push_str(&p.to_string());
-            }
-            TokenTree::Ident(i) => handle_ident_like(i.to_string(), &mut ret, &mut prev_is_ident),
-            TokenTree::Literal(l) => handle_ident_like(l.to_string(), &mut ret, &mut prev_is_ident),
-            TokenTree::Group(g) => {
-                prev_is_ident = false;
-                ret.push_str(&group_to_string(&g));
-            }
-        }
-    }
-    ret
-}
-
-fn build_closure(
-    parts: PeekableProcIter,
-    elements: Vec<ElemToClone>,
-    return_kind: Option<WrapperKind>,
-    kind: BlockKind,
-) -> TokenStream {
-    let mut body = TokenStream::new();
-
-    for el in &elements {
-        let stream: TokenStream = el
-            .to_str_after(&return_kind)
-            .parse()
-            .expect("failed to convert element after");
-        body.extend(stream.into_iter().collect::<Vec<_>>());
-    }
-    body.extend(parts.collect::<Vec<_>>());
-
-    // To prevent to lose the spans in case some errors occur in the code, we need to keep `body`!
-    //
-    // If we replaced everything that follows with a `format!`, it'd look like this:
-    //
-    // format!(
-    //     "{{\n{}\nmove |{}| {{\n{}\nlet ____ret = {{ {} }};\n____ret\n}}\n}}",
-    //     elements
-    //         .iter()
-    //         .map(|x| x.to_str_before())
-    //         .collect::<Vec<_>>()
-    //         .join("\n"),
-    //     closure,
-    //     elements
-    //         .iter()
-    //         .map(|x| x.to_str_after(&return_kind))
-    //         .collect::<Vec<_>>()
-    //         .join("\n"),
-    //     body,
-    // )
-    let mut ret: Vec<TokenTree> = vec![];
-    for el in elements {
-        let stream: TokenStream = el
-            .to_str_before()
-            .parse()
-            .expect("failed to convert element");
-        ret.extend(stream.into_iter().collect::<Vec<_>>());
-    }
-
-    // This part is creating the TokenStream using the variables that needs to be cloned (from the
-    // @weak and @strong annotations).
-    let mut inner: Vec<TokenTree> = Vec::new();
-    if matches!(kind, BlockKind::ClosureWrappingAsync(_)) {
-        inner.extend(vec![
-            TokenTree::Ident(Ident::new("async", Span::call_site())),
-            TokenTree::Ident(Ident::new("move", Span::call_site())),
-        ]);
-    }
-
-    let is_async_closure_kind = matches!(kind, BlockKind::AsyncClosure(_));
-    if let Some(closure) = kind.closure() {
-        if is_async_closure_kind {
-            ret.push(TokenTree::Ident(Ident::new("async", Span::call_site())));
-        }
-        ret.extend(vec![
-            TokenTree::Ident(Ident::new("move", Span::call_site())),
-            TokenTree::Punct(Punct::new('|', Spacing::Alone)),
-        ]);
-        ret.extend(closure);
-        ret.extend(vec![TokenTree::Punct(Punct::new('|', Spacing::Alone))]);
-    } else {
-        ret.extend(vec![
-            TokenTree::Ident(Ident::new("async", Span::call_site())),
-            TokenTree::Ident(Ident::new("move", Span::call_site())),
-        ]);
-    }
-    // The commented lines that follow *might* be useful, don't know. Just in case, I'm keeping
-    // them around. You're welcome future me!
-    inner.extend(vec![
-        // TokenTree::Ident(Ident::new("let", Span::call_site())),
-        // TokenTree::Ident(Ident::new("____ret", Span::call_site())),
-        // TokenTree::Punct(Punct::new('=', Spacing::Alone)),
-        TokenTree::Group(Group::new(Delimiter::Brace, body)),
-        // TokenTree::Punct(Punct::new(';', Spacing::Alone)),
-        // TokenTree::Ident(Ident::new("____ret", Span::call_site())),
-    ]);
-    let mut inners = TokenStream::new();
-    inners.extend(inner);
-    ret.extend(vec![TokenTree::Group(Group::new(Delimiter::Brace, inners))]);
-
-    let mut rets = TokenStream::new();
-    rets.extend(ret);
-
-    TokenTree::Group(Group::new(Delimiter::Brace, rets)).into()
-}
-
-pub(crate) fn clone_inner(item: TokenStream) -> TokenStream {
-    let mut parts: PeekableProcIter = item.into();
-    let mut elements = Vec::new();
-    let mut prev_is_ident = false;
-
-    loop {
-        let prev = parts.current_span;
-        match parts.next() {
-            Some(TokenTree::Punct(ref p)) => {
-                let p_s = p.to_string();
-                if p_s == "=" && parts.peek().map_or_else(|| false, |n| is_punct(n, ">")) {
-                    parts.next();
-                    break;
-                } else if p_s == "@" {
-                    if let Err(e) = parse_ident(&mut parts, &mut elements) {
-                        return e;
+                quote! {
+                    #(#attrs)*
+                    #lifetimes
+                    #constness
+                    #movability
+                    #asyncness
+                    #capture
+                    #or1_token
+                    #inputs
+                    #or2_token
+                    #output
+                    {
+                        #upgrade_failure_closure
+                        #(#inner_before)*
+                        #body
                     }
-                    prev_is_ident = true;
-                } else if p_s == "," {
-                    assert!(prev_is_ident, "Unexpected `,`");
-                    prev_is_ident = false;
-                } else if p_s == "|" {
-                    assert!(
-                        !elements.is_empty(),
-                        "If you have nothing to clone, no need to use this macro!"
-                    );
-                    return parts.generate_error("Expected `=>` before closure");
                 }
             }
-            Some(TokenTree::Ident(i)) => {
-                let err = format!(
-                    "Unexpected ident `{i}`: you need to specify if this is a weak or a strong \
-                     clone.",
-                );
-                return parts.generate_error(&err);
+            ClosureOrAsync::Async(ref a) => {
+                let ExprAsync {
+                    attrs,
+                    async_token,
+                    capture,
+                    block,
+                } = a;
+
+                quote! {
+                    #(#attrs)*
+                    #async_token
+                    #capture
+                    {
+                        #upgrade_failure_closure
+                        #(#inner_before)*
+                        #block
+                    }
+                }
             }
-            Some(t) => {
-                let err = format!("Unexpected token `{t}`");
-                return parts.generate_error(&err);
+        };
+
+        tokens.extend(quote! {
+            {
+                #(#outer_before)*
+                #body
             }
-            None => return parts.generate_error_with_span("Unexpected end 4", prev),
-        }
+        });
     }
-    assert!(
-        !elements.is_empty(),
-        "If you have nothing to clone, no need to use this macro!"
-    );
-    let return_kind = match parse_return_kind(&mut parts) {
-        Ok(r) => r,
-        Err(e) => return e,
-    };
-    let kind = match check_before_closure(&mut parts) {
-        Ok(r) => r,
-        Err(e) => return e,
-    };
-    build_closure(parts, elements, return_kind, kind)
+}
+
+pub(crate) fn clone_inner(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let clone = syn::parse_macro_input!(input as Clone);
+    clone.into_token_stream().into()
 }

--- a/glib-macros/src/clone_old.rs
+++ b/glib-macros/src/clone_old.rs
@@ -1,0 +1,965 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use std::iter::Peekable;
+
+use proc_macro::{
+    token_stream::IntoIter as ProcIter, Delimiter, Group, Ident, Literal, Punct, Spacing, Span,
+    TokenStream, TokenTree,
+};
+
+use crate::utils::crate_ident_new;
+
+struct PeekableProcIter {
+    inner: Peekable<ProcIter>,
+    current_span: Option<Span>,
+    next_span: Option<Span>,
+}
+
+impl<'a> From<&'a Group> for PeekableProcIter {
+    fn from(f: &'a Group) -> Self {
+        let current_span = Some(f.span());
+        let mut inner = f.stream().into_iter().peekable();
+        let next_span = inner.peek().map(|n| n.span());
+        Self {
+            inner,
+            current_span,
+            next_span,
+        }
+    }
+}
+
+impl From<TokenStream> for PeekableProcIter {
+    fn from(f: TokenStream) -> Self {
+        let mut inner = f.into_iter().peekable();
+        let next_span = inner.peek().map(|n| n.span());
+        Self {
+            inner,
+            current_span: None,
+            next_span,
+        }
+    }
+}
+
+impl Iterator for PeekableProcIter {
+    type Item = TokenTree;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.inner.next()?;
+        self.current_span = Some(next.span());
+        self.next_span = self.inner.peek().map(|n| n.span());
+        Some(next)
+    }
+}
+
+impl PeekableProcIter {
+    fn peek(&mut self) -> Option<&TokenTree> {
+        self.inner.peek()
+    }
+
+    fn generate_error(&self, message: &str) -> TokenStream {
+        self.generate_error_with_span(message, self.current_span)
+    }
+
+    fn generate_error_with_next_span(&self, message: &str) -> TokenStream {
+        self.generate_error_with_span(message, self.next_span)
+    }
+
+    fn generate_error_with_span(&self, message: &str, span: Option<Span>) -> TokenStream {
+        let span = span.unwrap_or_else(Span::call_site);
+        // We generate a `compile_error` macro and assign it to the current span so the error
+        // displayed by rustc points to the right location.
+        let mut stream = TokenStream::new();
+        stream.extend(vec![TokenTree::Literal(Literal::string(message))]);
+
+        let mut tokens = vec![
+            TokenTree::Ident(Ident::new("compile_error", span)),
+            TokenTree::Punct(Punct::new('!', Spacing::Alone)),
+            TokenTree::Group(Group::new(Delimiter::Parenthesis, stream)),
+            TokenTree::Punct(Punct::new(';', Spacing::Alone)),
+        ];
+
+        for tok in &mut tokens {
+            tok.set_span(span);
+        }
+
+        let mut stream = TokenStream::new();
+        stream.extend(tokens);
+        let mut t = TokenTree::Group(Group::new(Delimiter::Brace, stream));
+        t.set_span(span);
+
+        let mut stream = TokenStream::new();
+        stream.extend(vec![t]);
+        stream
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum BorrowKind {
+    Weak,
+    WeakAllowNone,
+    Strong,
+    ToOwned,
+}
+
+impl BorrowKind {
+    fn to_str(self) -> &'static str {
+        match self {
+            Self::Weak => "@weak",
+            Self::WeakAllowNone => "@weak-allow-none",
+            Self::Strong => "@strong",
+            Self::ToOwned => "@to-owned",
+        }
+    }
+}
+
+enum WrapperKind {
+    DefaultPanic,
+    DefaultReturn(String),
+}
+
+impl WrapperKind {
+    fn to_str(&self) -> String {
+        match *self {
+            Self::DefaultPanic => "@default-panic".to_owned(),
+            Self::DefaultReturn(ref r) => format!("@default-return {r}"),
+        }
+    }
+
+    fn keyword(&self) -> &'static str {
+        match *self {
+            Self::DefaultPanic => "default-panic",
+            Self::DefaultReturn(_) => "default-return",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ElemToClone {
+    name: String,
+    alias: Option<String>,
+    borrow_kind: BorrowKind,
+}
+
+impl ElemToClone {
+    fn to_str_before(&self) -> String {
+        match self.borrow_kind {
+            BorrowKind::Weak | BorrowKind::WeakAllowNone => format!(
+                "let {} = {}::clone::Downgrade::downgrade(&{});",
+                if let Some(ref a) = self.alias {
+                    a
+                } else {
+                    &self.name
+                },
+                crate_ident_new(),
+                self.name,
+            ),
+            BorrowKind::Strong => format!(
+                "let {} = {}.clone();",
+                if let Some(ref a) = self.alias {
+                    a
+                } else {
+                    &self.name
+                },
+                self.name,
+            ),
+            BorrowKind::ToOwned => format!(
+                "let {} = ::std::borrow::ToOwned::to_owned(&*{});",
+                if let Some(ref a) = self.alias {
+                    a
+                } else {
+                    &self.name
+                },
+                self.name,
+            ),
+        }
+    }
+
+    fn to_str_after(&self, wrapper_kind: &Option<WrapperKind>) -> String {
+        let name = if let Some(ref a) = self.alias {
+            a
+        } else {
+            &self.name
+        };
+        match (self.borrow_kind, wrapper_kind) {
+            (BorrowKind::Weak, Some(WrapperKind::DefaultPanic)) => {
+                format!(
+                    "\
+let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
+    Some(val) => val,
+    None => panic!(
+        \"failed to upgrade `{0}` (if you don't want to panic, use @default-return)\",
+    ),
+}};",
+                    name,
+                    crate_ident_new(),
+                )
+            }
+            (BorrowKind::Weak, Some(WrapperKind::DefaultReturn(ref r))) => {
+                let not_unit_ret = r.chars().any(|c| c != '(' && c != ')' && c != ' ');
+                format!(
+                    "\
+let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
+    Some(val) => val,
+    None => {{
+        {1}::g_debug!(
+            {1}::CLONE_MACRO_LOG_DOMAIN,
+            \"Failed to upgrade {0}\",
+        );
+        let ___return_value = || {{ {2} }};
+        return ___return_value();
+    }}
+}};",
+                    name,
+                    crate_ident_new(),
+                    if not_unit_ret { r } else { "" },
+                )
+            }
+            (BorrowKind::Weak, None) => {
+                format!(
+                    "\
+let {0} = match {1}::clone::Upgrade::upgrade(&{0}) {{
+    Some(val) => val,
+    None => {{
+        {1}::g_debug!(
+            {1}::CLONE_MACRO_LOG_DOMAIN,
+            \"Failed to upgrade {0}\",
+        );
+        return;
+    }}
+}};",
+                    name,
+                    crate_ident_new(),
+                )
+            }
+            (BorrowKind::WeakAllowNone, _) => format!(
+                "let {0} = {1}::clone::Upgrade::upgrade(&{0});",
+                name,
+                crate_ident_new(),
+            ),
+            _ => String::new(),
+        }
+    }
+}
+
+enum SimpleToken {
+    Punct(&'static str),
+    Ident(&'static str),
+}
+
+impl SimpleToken {
+    fn to_str(&self) -> &str {
+        match *self {
+            Self::Punct(p) => p,
+            Self::Ident(i) => i,
+        }
+    }
+}
+
+impl PartialEq<TokenTree> for SimpleToken {
+    fn eq(&self, other: &TokenTree) -> bool {
+        match (self, other) {
+            (SimpleToken::Punct(p1), TokenTree::Punct(ref p2)) => *p1 == p2.to_string(),
+            (SimpleToken::Ident(i1), TokenTree::Ident(ref i2)) => *i1 == i2.to_string(),
+            _ => false,
+        }
+    }
+}
+
+fn is_punct(elem: &TokenTree, punct: &str) -> bool {
+    match elem {
+        TokenTree::Punct(ref p) => p.to_string() == punct,
+        _ => false,
+    }
+}
+
+enum TokenCheck {
+    UnexpectedToken(String, String),
+    UnexpectedEnd(String),
+}
+
+fn check_tokens(
+    tokens_to_check: &[SimpleToken],
+    parts: &mut PeekableProcIter,
+) -> Result<(), TokenCheck> {
+    let mut tokens = String::new();
+
+    for token in tokens_to_check {
+        if let Some(next) = parts.peek() {
+            if token != next {
+                return Err(TokenCheck::UnexpectedToken(tokens, next.to_string()));
+            }
+            tokens.push_str(token.to_str());
+            parts.next();
+        } else {
+            return Err(TokenCheck::UnexpectedEnd(tokens));
+        }
+    }
+    Ok(())
+}
+
+#[doc(alias = "get_full_ident")]
+fn full_ident(
+    parts: &mut PeekableProcIter,
+    borrow_kind: BorrowKind,
+) -> Result<String, TokenStream> {
+    let mut name = String::new();
+    let mut prev_is_ident = false;
+
+    loop {
+        match parts.peek() {
+            Some(TokenTree::Punct(p)) => {
+                let p_s = p.to_string();
+                if p_s == "," || p_s == "=" {
+                    break;
+                } else if p_s == "." {
+                    if !prev_is_ident {
+                        return Err(parts.generate_error_with_next_span(&format!(
+                            "Unexpected `.` after `{}`",
+                            borrow_kind.to_str()
+                        )));
+                    }
+                    prev_is_ident = false;
+                    name.push('.');
+                    parts.next();
+                } else if name.is_empty() {
+                    return Err(parts
+                        .generate_error_with_next_span(&format!("Expected ident, found `{p_s}`")));
+                } else {
+                    return Err(parts.generate_error_with_next_span(&format!(
+                        "Expected ident, found `{p_s}` after `{name}`"
+                    )));
+                }
+            }
+            Some(TokenTree::Ident(i)) => {
+                if prev_is_ident {
+                    break;
+                }
+                prev_is_ident = true;
+                name.push_str(&i.to_string());
+                parts.next();
+            }
+            Some(x) if name.is_empty() => {
+                let err = format!("Expected ident, found `{x}`");
+                return Err(parts.generate_error_with_next_span(&err));
+            }
+            Some(x) => {
+                let err = &format!("Expected ident, found `{x}` after `{name}`");
+                return Err(parts.generate_error_with_next_span(err));
+            }
+            None => {
+                return Err(parts.generate_error(&format!("Unexpected end after ident `{name}`")));
+            }
+        }
+    }
+    if name.is_empty() {
+        if let Some(next) = parts.next() {
+            return Err(parts.generate_error(&format!("Expected ident, found `{next}`")));
+        }
+        return Err(parts.generate_error("Expected something after, found nothing"));
+    }
+    Ok(name)
+}
+
+#[doc(alias = "get_keyword")]
+fn keyword(parts: &mut PeekableProcIter) -> Result<BorrowKind, TokenStream> {
+    let mut ret = String::new();
+    let mut prev_is_ident = false;
+    let mut stored = false;
+    // We unfortunately can't join spans since the `Span::join` method is nightly-only. Well, we'll
+    // do our best...
+    let start_span = parts.next_span;
+
+    loop {
+        match parts.peek() {
+            Some(TokenTree::Ident(i)) => {
+                if prev_is_ident {
+                    break;
+                }
+                prev_is_ident = true;
+                if stored {
+                    ret.push('-');
+                    stored = false;
+                }
+                ret.push_str(&i.to_string());
+            }
+            Some(TokenTree::Punct(p)) if p.to_string() == "-" => {
+                if !prev_is_ident {
+                    break;
+                }
+                // This is to prevent to push `-` if the next item isn't an ident.
+                prev_is_ident = false;
+                stored = true;
+            }
+            _ => break,
+        }
+        parts.next();
+    }
+    let ret = match ret.as_str() {
+        "strong" => BorrowKind::Strong,
+        "weak" => BorrowKind::Weak,
+        "weak-allow-none" => BorrowKind::WeakAllowNone,
+        "to-owned" => BorrowKind::ToOwned,
+        "default-return" => {
+            return Err(parts
+                .generate_error_with_span("`@default-return` should be after `=>`", start_span));
+        }
+        "default-panic" => {
+            return Err(
+                parts.generate_error_with_span("`@default-panic` should be after `=>`", start_span)
+            );
+        }
+        k => {
+            return Err(parts.generate_error_with_span(
+                &format!(
+                    "Unknown keyword `{k}`, only `weak`, `weak-allow-none`, `to-owned` and \
+                    `strong` are allowed"
+                ),
+                start_span,
+            ));
+        }
+    };
+    Ok(ret)
+}
+
+fn parse_ident(
+    parts: &mut PeekableProcIter,
+    elements: &mut Vec<ElemToClone>,
+) -> Result<(), TokenStream> {
+    let borrow_kind = keyword(parts)?;
+    let name = full_ident(parts, borrow_kind)?;
+    let name_span = parts.current_span;
+    if name.ends_with('.') {
+        return Err(
+            parts.generate_error_with_span(&format!("Invalid variable name: `{name}`"), name_span)
+        );
+    }
+    let alias = match parts.peek() {
+        Some(TokenTree::Ident(p)) if p.to_string() == "as" => {
+            parts.next();
+            let current_span = parts.current_span;
+            match parts.next() {
+                Some(TokenTree::Ident(i)) => Some(i.to_string()),
+                Some(x) => {
+                    let err = format!("Expected ident after `as` keyword, found `{x}`");
+                    return Err(parts.generate_error(&err));
+                }
+                None => {
+                    return Err(parts.generate_error_with_span(
+                        "Unexpected end after `as` keyword",
+                        current_span,
+                    ))
+                }
+            }
+        }
+        Some(TokenTree::Ident(p)) => {
+            let err = format!("Unexpected `{p}`");
+            return Err(parts.generate_error(&err));
+        }
+        _ => None,
+    };
+    if name == "self" && alias.is_none() {
+        return Err(parts.generate_error_with_span(
+            "Can't use `self` as variable name. Try storing it in a temporary variable or \
+                rename it using `as`.",
+            name_span,
+        ));
+    } else if name.contains('.') && alias.is_none() {
+        let err = format!("`{name}`: Field accesses are not allowed as is, you must rename it!");
+        return Err(parts.generate_error_with_span(&err, name_span));
+    }
+
+    elements.push(ElemToClone {
+        name,
+        alias,
+        borrow_kind,
+    });
+    Ok(())
+}
+
+fn delimiter_to_string(delimiter: Delimiter, open: bool) -> &'static str {
+    match delimiter {
+        Delimiter::Parenthesis => {
+            if open {
+                "("
+            } else {
+                ")"
+            }
+        }
+        Delimiter::Brace => {
+            if open {
+                "{"
+            } else {
+                "}"
+            }
+        }
+        Delimiter::Bracket => {
+            if open {
+                "["
+            } else {
+                "]"
+            }
+        }
+        Delimiter::None => "",
+    }
+}
+
+fn group_to_string(g: &Group) -> String {
+    format!(
+        "{}{}{}",
+        delimiter_to_string(g.delimiter(), true),
+        tokens_to_string(PeekableProcIter::from(g)),
+        delimiter_to_string(g.delimiter(), false),
+    )
+}
+
+#[doc(alias = "get_expr")]
+fn expr(parts: &mut PeekableProcIter) -> Result<String, TokenStream> {
+    let mut ret = String::new();
+    let mut total = 0;
+    let span = parts.current_span;
+    match parts.next() {
+        Some(TokenTree::Literal(l)) => ret.push_str(&l.to_string()),
+        Some(TokenTree::Ident(i)) => ret.push_str(&i.to_string()),
+        Some(TokenTree::Punct(p)) => match p.to_string().as_str() {
+            "[" | "{" | "(" => {
+                total += 1;
+            }
+            x => {
+                return Err(parts
+                    .generate_error(&format!("Unexpected token `{x}` after `@default-return`")))
+            }
+        },
+        Some(TokenTree::Group(g)) => return Ok(group_to_string(&g)),
+        None => {
+            return Err(
+                parts.generate_error_with_span("Unexpected end after `@default-return`", span)
+            )
+        }
+    };
+    loop {
+        match parts.peek() {
+            Some(TokenTree::Punct(p)) => {
+                let p_s = p.to_string();
+                if p_s == "{" || p_s == "(" || p_s == "[" || p_s == "<" {
+                    total += 1;
+                } else if p_s == "}" || p_s == ")" || p_s == "]" || p_s == ">" {
+                    total -= 1;
+                } else if p_s == "," && total == 0 {
+                    return Ok(ret);
+                }
+                ret.push_str(&p_s);
+            }
+            Some(TokenTree::Group(g)) => {
+                ret.push_str(&group_to_string(g));
+            }
+            Some(x) => {
+                if total == 0 && !ret.ends_with(':') {
+                    return Ok(ret);
+                }
+                ret.push_str(&x.to_string())
+            }
+            None => return Err(parts.generate_error(
+                "Unexpected end after `{ret}`. Did you forget a `,` after the @default-return value?",
+            )),
+        }
+        parts.next();
+    }
+}
+
+#[doc(alias = "get_return_kind")]
+fn return_kind(parts: &mut PeekableProcIter) -> Result<WrapperKind, TokenStream> {
+    match check_tokens(
+        &[SimpleToken::Ident("default"), SimpleToken::Punct("-")],
+        parts,
+    ) {
+        Err(TokenCheck::UnexpectedToken(tokens, unexpected_token)) => {
+            return Err(
+                parts.generate_error(&format!("Unknown keyword `{tokens}{unexpected_token}`"))
+            );
+        }
+        Err(TokenCheck::UnexpectedEnd(tokens)) => {
+            return Err(parts.generate_error(&format!("Unexpected end after tokens `{tokens}`")));
+        }
+        Ok(()) => {}
+    }
+    let prev = parts.current_span;
+    match parts.next() {
+        Some(TokenTree::Ident(i)) => {
+            let i_s = i.to_string();
+            if i_s == "panic" {
+                return Ok(WrapperKind::DefaultPanic);
+            }
+            assert!(i_s == "return", "Unknown keyword `@default-{i_s}`");
+        }
+        Some(x) => {
+            let err = format!("Unknown token `{x}` after `@default-`");
+            return Err(parts.generate_error(&err));
+        }
+        None => {
+            return Err(parts.generate_error_with_span("Unexpected end after `@default-`", prev))
+        }
+    }
+    Ok(WrapperKind::DefaultReturn(expr(parts)?))
+}
+
+fn parse_return_kind(parts: &mut PeekableProcIter) -> Result<Option<WrapperKind>, TokenStream> {
+    match parts.peek() {
+        Some(TokenTree::Punct(p)) if p.to_string() == "@" => {}
+        None => return Err(parts.generate_error("Unexpected end 2")),
+        _ => return Ok(None),
+    }
+    parts.next();
+    let ret = return_kind(parts)?;
+    match check_tokens(&[SimpleToken::Punct(",")], parts) {
+        Err(TokenCheck::UnexpectedToken(_, unexpected_token)) => {
+            let err = format!(
+                "Expected `,` after `{}`, found `{unexpected_token}`",
+                ret.to_str(),
+            );
+            return Err(parts.generate_error_with_next_span(&err));
+        }
+        Err(TokenCheck::UnexpectedEnd(tokens)) => {
+            let err = format!("Expected `,` after `{}{tokens}`", ret.to_str());
+            return Err(parts.generate_error(&err));
+        }
+        Ok(()) => {}
+    }
+    Ok(Some(ret))
+}
+
+enum BlockKind {
+    Closure(Vec<TokenTree>),
+    ClosureWrappingAsync(Vec<TokenTree>),
+    AsyncClosure(Vec<TokenTree>),
+    AsyncBlock,
+}
+
+impl BlockKind {
+    #[doc(alias = "get_closure")]
+    fn closure(self) -> Option<Vec<TokenTree>> {
+        match self {
+            Self::AsyncBlock => None,
+            Self::Closure(c) | Self::ClosureWrappingAsync(c) | Self::AsyncClosure(c) => Some(c),
+        }
+    }
+}
+
+fn check_move_after_async(parts: &mut PeekableProcIter) -> Result<(), TokenStream> {
+    let span = parts.current_span;
+    match parts.next() {
+        Some(TokenTree::Ident(i)) if i.to_string() == "move" => Ok(()),
+        // The next checks are just for better error messages.
+        Some(TokenTree::Ident(i)) => {
+            let err = format!("Expected `move` after `async`, found `{i}`");
+            Err(parts.generate_error(&err))
+        }
+        Some(TokenTree::Punct(p)) => {
+            let err = format!("Expected `move` after `async`, found `{p}`");
+            Err(parts.generate_error(&err))
+        }
+        Some(TokenTree::Group(g)) => {
+            let err = format!(
+                "Expected `move` after `async`, found `{}`",
+                delimiter_to_string(g.delimiter(), true),
+            );
+            Err(parts.generate_error(&err))
+        }
+        _ => Err(parts.generate_error_with_span("Expected `move` after `async`", span)),
+    }
+}
+
+fn check_async_syntax(parts: &mut PeekableProcIter) -> Result<BlockKind, TokenStream> {
+    check_move_after_async(parts)?;
+    match parts.peek() {
+        Some(TokenTree::Punct(p)) if p.to_string() == "|" => {
+            parts.next();
+            Ok(BlockKind::AsyncClosure(closure(parts)?))
+        }
+        Some(TokenTree::Punct(p)) => {
+            let err = format!("Expected closure or block after `async move`, found `{p}`");
+            Err(parts.generate_error_with_next_span(&err))
+        }
+        Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Brace => Ok(BlockKind::AsyncBlock),
+        Some(TokenTree::Group(g)) => {
+            let err = format!(
+                "Expected closure or block after `async move`, found `{}`",
+                delimiter_to_string(g.delimiter(), true),
+            );
+            Err(parts.generate_error_with_next_span(&err))
+        }
+        _ => Err(parts.generate_error("Expected closure or block after `async move`")),
+    }
+}
+
+// Returns `true` if this is an async context.
+fn check_before_closure(parts: &mut PeekableProcIter) -> Result<BlockKind, TokenStream> {
+    let is_async = match parts.peek() {
+        Some(TokenTree::Ident(i)) if i.to_string() == "move" => false,
+        Some(TokenTree::Ident(i)) if i.to_string() == "async" => true,
+        Some(TokenTree::Ident(i)) if i.to_string() == "default" => {
+            let span = parts.next_span;
+            let ret = return_kind(parts)?;
+            let err = format!("Missing `@` before `{}`", ret.keyword());
+            return Err(parts.generate_error_with_span(&err, span));
+        }
+        Some(TokenTree::Punct(p)) if p.to_string() == "|" => {
+            return Err(parts.generate_error_with_next_span(
+                "Closure needs to be \"moved\" so please add `move` before closure",
+            ));
+        }
+        _ => {
+            return Err(
+                parts.generate_error_with_next_span("Missing `move` and closure declaration")
+            )
+        }
+    };
+    parts.next();
+    if is_async {
+        return check_async_syntax(parts);
+    }
+    match parts.peek() {
+        Some(TokenTree::Punct(p)) if p.to_string() == "|" => {}
+        Some(x) => {
+            let err = format!("Expected closure, found `{x}`");
+            return Err(parts.generate_error_with_next_span(&err));
+        }
+        None => return Err(parts.generate_error("Expected closure")),
+    }
+    parts.next();
+
+    let closure = closure(parts)?;
+    match parts.peek() {
+        Some(TokenTree::Ident(i)) if i.to_string() == "async" => {
+            parts.next();
+            check_move_after_async(parts)?;
+            match parts.peek() {
+                Some(TokenTree::Group(g)) if g.delimiter() == Delimiter::Brace => {
+                    Ok(BlockKind::ClosureWrappingAsync(closure))
+                }
+                // The next matchings are for better error messages.
+                Some(TokenTree::Punct(p)) => {
+                    let err = format!("Expected block after `| async move`, found `{p}`");
+                    Err(parts.generate_error_with_next_span(&err))
+                }
+                Some(TokenTree::Group(g)) => {
+                    let err = format!(
+                        "Expected block after `| async move`, found `{}`",
+                        delimiter_to_string(g.delimiter(), true),
+                    );
+                    Err(parts.generate_error_with_next_span(&err))
+                }
+                _ => {
+                    Err(parts.generate_error_with_next_span("Expected block after `| async move`"))
+                }
+            }
+        }
+        _ => Ok(BlockKind::Closure(closure)),
+    }
+}
+
+#[doc(alias = "get_closure")]
+fn closure(parts: &mut PeekableProcIter) -> Result<Vec<TokenTree>, TokenStream> {
+    let mut ret = Vec::new();
+
+    loop {
+        let span = parts.current_span;
+        match parts.next() {
+            Some(TokenTree::Punct(p)) if p.to_string() == "|" => break,
+            Some(x) => ret.push(x),
+            None => return Err(parts.generate_error_with_span("Unexpected end 3", span)),
+        }
+    }
+    Ok(ret)
+}
+
+fn tokens_to_string(parts: impl Iterator<Item = TokenTree>) -> String {
+    let mut ret = String::new();
+    // This is used in case of "if ident" or other similar cases.
+    let mut prev_is_ident = false;
+    let handle_ident_like = |i: String, ret: &mut String, prev_is_ident: &mut bool| {
+        if *prev_is_ident {
+            ret.push(' ');
+        }
+        ret.push_str(&i);
+        *prev_is_ident = true;
+    };
+
+    for token in parts {
+        match token {
+            TokenTree::Punct(p) => {
+                prev_is_ident = false;
+                ret.push_str(&p.to_string());
+            }
+            TokenTree::Ident(i) => handle_ident_like(i.to_string(), &mut ret, &mut prev_is_ident),
+            TokenTree::Literal(l) => handle_ident_like(l.to_string(), &mut ret, &mut prev_is_ident),
+            TokenTree::Group(g) => {
+                prev_is_ident = false;
+                ret.push_str(&group_to_string(&g));
+            }
+        }
+    }
+    ret
+}
+
+fn build_closure(
+    parts: PeekableProcIter,
+    elements: Vec<ElemToClone>,
+    return_kind: Option<WrapperKind>,
+    kind: BlockKind,
+) -> TokenStream {
+    let mut body = TokenStream::new();
+
+    for el in &elements {
+        let stream: TokenStream = el
+            .to_str_after(&return_kind)
+            .parse()
+            .expect("failed to convert element after");
+        body.extend(stream.into_iter().collect::<Vec<_>>());
+    }
+    body.extend(parts.collect::<Vec<_>>());
+
+    // To prevent to lose the spans in case some errors occur in the code, we need to keep `body`!
+    //
+    // If we replaced everything that follows with a `format!`, it'd look like this:
+    //
+    // format!(
+    //     "{{\n{}\nmove |{}| {{\n{}\nlet ____ret = {{ {} }};\n____ret\n}}\n}}",
+    //     elements
+    //         .iter()
+    //         .map(|x| x.to_str_before())
+    //         .collect::<Vec<_>>()
+    //         .join("\n"),
+    //     closure,
+    //     elements
+    //         .iter()
+    //         .map(|x| x.to_str_after(&return_kind))
+    //         .collect::<Vec<_>>()
+    //         .join("\n"),
+    //     body,
+    // )
+    let mut ret: Vec<TokenTree> = vec![];
+    for el in elements {
+        let stream: TokenStream = el
+            .to_str_before()
+            .parse()
+            .expect("failed to convert element");
+        ret.extend(stream.into_iter().collect::<Vec<_>>());
+    }
+
+    // This part is creating the TokenStream using the variables that needs to be cloned (from the
+    // @weak and @strong annotations).
+    let mut inner: Vec<TokenTree> = Vec::new();
+
+    {
+        let stream = "{
+#[deprecated = \"Using old-style clone! syntax\"]
+macro_rules! clone { () => {}; }
+clone!();
+}"
+        .parse::<TokenStream>()
+        .expect("can't parse deprecation");
+
+        inner.extend(stream);
+    }
+
+    if matches!(kind, BlockKind::ClosureWrappingAsync(_)) {
+        inner.extend(vec![
+            TokenTree::Ident(Ident::new("async", Span::call_site())),
+            TokenTree::Ident(Ident::new("move", Span::call_site())),
+        ]);
+    }
+
+    let is_async_closure_kind = matches!(kind, BlockKind::AsyncClosure(_));
+    if let Some(closure) = kind.closure() {
+        if is_async_closure_kind {
+            ret.push(TokenTree::Ident(Ident::new("async", Span::call_site())));
+        }
+        ret.extend(vec![
+            TokenTree::Ident(Ident::new("move", Span::call_site())),
+            TokenTree::Punct(Punct::new('|', Spacing::Alone)),
+        ]);
+        ret.extend(closure);
+        ret.extend(vec![TokenTree::Punct(Punct::new('|', Spacing::Alone))]);
+    } else {
+        ret.extend(vec![
+            TokenTree::Ident(Ident::new("async", Span::call_site())),
+            TokenTree::Ident(Ident::new("move", Span::call_site())),
+        ]);
+    }
+    // The commented lines that follow *might* be useful, don't know. Just in case, I'm keeping
+    // them around. You're welcome future me!
+    inner.extend(vec![
+        // TokenTree::Ident(Ident::new("let", Span::call_site())),
+        // TokenTree::Ident(Ident::new("____ret", Span::call_site())),
+        // TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+        TokenTree::Group(Group::new(Delimiter::Brace, body)),
+        // TokenTree::Punct(Punct::new(';', Spacing::Alone)),
+        // TokenTree::Ident(Ident::new("____ret", Span::call_site())),
+    ]);
+    let mut inners = TokenStream::new();
+    inners.extend(inner);
+    ret.extend(vec![TokenTree::Group(Group::new(Delimiter::Brace, inners))]);
+
+    let mut rets = TokenStream::new();
+    rets.extend(ret);
+
+    TokenTree::Group(Group::new(Delimiter::Brace, rets)).into()
+}
+
+pub(crate) fn clone_inner(item: TokenStream) -> TokenStream {
+    let mut parts: PeekableProcIter = item.into();
+    let mut elements = Vec::new();
+    let mut prev_is_ident = false;
+
+    loop {
+        let prev = parts.current_span;
+        match parts.next() {
+            Some(TokenTree::Punct(ref p)) => {
+                let p_s = p.to_string();
+                if p_s == "=" && parts.peek().map_or_else(|| false, |n| is_punct(n, ">")) {
+                    parts.next();
+                    break;
+                } else if p_s == "@" {
+                    if let Err(e) = parse_ident(&mut parts, &mut elements) {
+                        return e;
+                    }
+                    prev_is_ident = true;
+                } else if p_s == "," {
+                    assert!(prev_is_ident, "Unexpected `,`");
+                    prev_is_ident = false;
+                } else if p_s == "|" {
+                    assert!(
+                        !elements.is_empty(),
+                        "If you have nothing to clone, no need to use this macro!"
+                    );
+                    return parts.generate_error("Expected `=>` before closure");
+                }
+            }
+            Some(TokenTree::Ident(i)) => {
+                let err = format!(
+                    "Unexpected ident `{i}`: you need to specify if this is a weak or a strong \
+                     clone.",
+                );
+                return parts.generate_error(&err);
+            }
+            Some(t) => {
+                let err = format!("Unexpected token `{t}`");
+                return parts.generate_error(&err);
+            }
+            None => return parts.generate_error_with_span("Unexpected end 4", prev),
+        }
+    }
+    assert!(
+        !elements.is_empty(),
+        "If you have nothing to clone, no need to use this macro!"
+    );
+    let return_kind = match parse_return_kind(&mut parts) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    let kind = match check_before_closure(&mut parts) {
+        Ok(r) => r,
+        Err(e) => return e,
+    };
+    build_closure(parts, elements, return_kind, kind)
+}

--- a/glib-macros/src/closure_old.rs
+++ b/glib-macros/src/closure_old.rs
@@ -1,0 +1,300 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{quote, ToTokens, TokenStreamExt};
+use syn::{ext::IdentExt, spanned::Spanned, Token};
+
+use crate::utils::crate_ident_new;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CaptureKind {
+    Watch,
+    WeakAllowNone,
+    Strong,
+    ToOwned,
+}
+
+struct Capture {
+    name: TokenStream,
+    alias: Option<syn::Ident>,
+    kind: CaptureKind,
+    start: Span,
+}
+
+impl Capture {
+    fn alias(&self) -> TokenStream {
+        if let Some(ref a) = self.alias {
+            a.to_token_stream()
+        } else {
+            self.name.to_token_stream()
+        }
+    }
+    fn outer_before_tokens(&self, crate_ident: &TokenStream) -> TokenStream {
+        let alias = self.alias();
+        let name = &self.name;
+        match self.kind {
+            CaptureKind::Watch => quote! {
+                let #alias = #crate_ident::object::Watchable::watched_object(&#name);
+            },
+            CaptureKind::WeakAllowNone => quote! {
+                let #alias = #crate_ident::clone::Downgrade::downgrade(&#name);
+            },
+            CaptureKind::Strong => quote! {
+                let #alias = #name.clone();
+            },
+            CaptureKind::ToOwned => quote! {
+                let #alias = ::std::borrow::ToOwned::to_owned(&*#name);
+            },
+        }
+    }
+
+    fn outer_after_tokens(&self, crate_ident: &TokenStream, closure_ident: &Ident) -> TokenStream {
+        let name = &self.name;
+        match self.kind {
+            CaptureKind::Watch => quote! {
+                #crate_ident::object::Watchable::watch_closure(&#name, &#closure_ident);
+            },
+            _ => Default::default(),
+        }
+    }
+
+    fn inner_before_tokens(&self, crate_ident: &TokenStream) -> TokenStream {
+        let alias = self.alias();
+        match self.kind {
+            CaptureKind::Watch => {
+                quote! {
+                    let #alias = unsafe { #alias.borrow() };
+                    let #alias = ::core::convert::AsRef::as_ref(&#alias);
+                }
+            }
+            CaptureKind::WeakAllowNone => quote! {
+                let #alias = #crate_ident::clone::Upgrade::upgrade(&#alias);
+            },
+            _ => Default::default(),
+        }
+    }
+}
+
+impl syn::parse::Parse for CaptureKind {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![@]>()?;
+        let mut idents = TokenStream::new();
+        idents.append(input.call(syn::Ident::parse_any)?);
+        while input.peek(Token![-]) {
+            input.parse::<Token![-]>()?;
+            idents.append(input.call(syn::Ident::parse_any)?);
+        }
+        let keyword = idents
+            .clone()
+            .into_iter()
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("-");
+        match keyword.as_str() {
+            "strong" => Ok(CaptureKind::Strong),
+            "watch" => Ok(CaptureKind::Watch),
+            "weak-allow-none" => Ok(CaptureKind::WeakAllowNone),
+            "to-owned" => Ok(CaptureKind::ToOwned),
+            k => Err(syn::Error::new(
+                idents.span(),
+                format!("Unknown keyword `{}`, only `watch`, `weak-allow-none`, `to-owned` and `strong` are allowed",
+                k),
+            )),
+        }
+    }
+}
+
+impl syn::parse::Parse for Capture {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let start = input.span();
+        let kind = input.parse()?;
+        let mut name = TokenStream::new();
+        name.append(input.call(syn::Ident::parse_any)?);
+        while input.peek(Token![.]) {
+            input.parse::<Token![.]>()?;
+            name.append(proc_macro2::Punct::new('.', proc_macro2::Spacing::Alone));
+            name.append(input.call(syn::Ident::parse_any)?);
+        }
+        let alias = if input.peek(Token![as]) {
+            input.parse::<Token![as]>()?;
+            input.parse()?
+        } else {
+            None
+        };
+        if alias.is_none() {
+            if name.to_string() == "self" {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "Can't use `self` as variable name. Try storing it in a temporary variable or \
+                    rename it using `as`.",
+                ));
+            }
+            if name.to_string().contains('.') {
+                return Err(syn::Error::new(
+                    name.span(),
+                    format!(
+                        "`{}`: Field accesses are not allowed as is, you must rename it!",
+                        name
+                    ),
+                ));
+            }
+        }
+        Ok(Capture {
+            name,
+            alias,
+            kind,
+            start,
+        })
+    }
+}
+
+struct Closure {
+    captures: Vec<Capture>,
+    args: Vec<Ident>,
+    closure: syn::ExprClosure,
+    constructor: &'static str,
+}
+
+impl syn::parse::Parse for Closure {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut captures: Vec<Capture> = vec![];
+        if input.peek(Token![@]) {
+            loop {
+                let capture = input.parse::<Capture>()?;
+                if capture.kind == CaptureKind::Watch {
+                    if let Some(existing) = captures.iter().find(|c| c.kind == CaptureKind::Watch) {
+                        return Err(syn::Error::new(
+                            existing.start,
+                            "Only one `@watch` capture is allowed per closure",
+                        ));
+                    }
+                }
+                captures.push(capture);
+                if input.peek(Token![,]) {
+                    input.parse::<Token![,]>()?;
+                    if !input.peek(Token![@]) {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        if !captures.is_empty() {
+            input.parse::<Token![=>]>()?;
+        }
+        let mut closure = input.parse::<syn::ExprClosure>()?;
+        if closure.asyncness.is_some() {
+            return Err(syn::Error::new_spanned(
+                closure,
+                "Async closure not allowed",
+            ));
+        }
+        if !captures.is_empty() && closure.capture.is_none() {
+            return Err(syn::Error::new_spanned(
+                closure,
+                "Closure with captures needs to be \"moved\" so please add `move` before closure",
+            ));
+        }
+        let args = closure
+            .inputs
+            .iter()
+            .enumerate()
+            .map(|(i, _)| Ident::new(&format!("____value{i}"), Span::call_site()))
+            .collect();
+        closure.capture = None;
+        Ok(Closure {
+            captures,
+            args,
+            closure,
+            constructor: "new",
+        })
+    }
+}
+
+impl ToTokens for Closure {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let closure_ident = Ident::new("____closure", Span::call_site());
+        let values_ident = Ident::new("____values", Span::call_site());
+        let crate_ident = crate_ident_new();
+
+        let outer_before = self
+            .captures
+            .iter()
+            .map(|c| c.outer_before_tokens(&crate_ident));
+        let inner_before = self
+            .captures
+            .iter()
+            .map(|c| c.inner_before_tokens(&crate_ident));
+        let outer_after = self
+            .captures
+            .iter()
+            .map(|c| c.outer_after_tokens(&crate_ident, &closure_ident));
+
+        let arg_values = self.args.iter().enumerate().map(|(index, arg)| {
+            let err_msg = format!("Wrong type for argument {index}: {{:?}}");
+            quote! {
+                let #arg = ::core::result::Result::unwrap_or_else(
+                    #crate_ident::Value::get(&#values_ident[#index]),
+                    |e| panic!(#err_msg, e),
+                );
+            }
+        });
+        let arg_names = &self.args;
+        let args_len = self.args.len();
+        let closure = &self.closure;
+        let constructor = Ident::new(self.constructor, Span::call_site());
+
+        let deprecated = if self.constructor == "new" {
+            quote! {
+                {
+                    #[deprecated = "Using old-style closure! syntax"]
+                    macro_rules! closure { () => {}; }
+                    closure!();
+                }
+            }
+        } else {
+            quote! {
+                {
+                    #[deprecated = "Using old-style closure_local! syntax"]
+                    macro_rules! closure_local { () => {}; }
+                    closure_local!();
+                }
+            }
+        };
+
+        tokens.extend(quote! {
+            {
+                let #closure_ident = {
+                    #deprecated
+                    #(#outer_before)*
+                    #crate_ident::closure::RustClosure::#constructor(move |#values_ident| {
+                        assert_eq!(
+                            #values_ident.len(),
+                            #args_len,
+                            "Expected {} arguments but got {}",
+                            #args_len,
+                            #values_ident.len(),
+                        );
+                        #(#inner_before)*
+                        #(#arg_values)*
+                        #crate_ident::closure::IntoClosureReturnValue::into_closure_return_value(
+                            (#closure)(#(#arg_names),*)
+                        )
+                    })
+                };
+                #(#outer_after)*
+                #closure_ident
+            }
+        });
+    }
+}
+
+pub(crate) fn closure_inner(
+    input: proc_macro::TokenStream,
+    constructor: &'static str,
+) -> proc_macro::TokenStream {
+    let mut closure = syn::parse_macro_input!(input as Closure);
+    closure.constructor = constructor;
+    closure.into_token_stream().into()
+}

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -2,7 +2,9 @@
 
 mod boxed_derive;
 mod clone;
+mod clone_old;
 mod closure;
+mod closure_old;
 mod derived_properties_attribute;
 mod downgrade_derive;
 mod enum_derive;
@@ -17,7 +19,7 @@ mod variant_derive;
 mod utils;
 
 use flags_attribute::AttrInput;
-use proc_macro::TokenStream;
+use proc_macro::{TokenStream, TokenTree};
 use proc_macro2::Span;
 use syn::{parse_macro_input, DeriveInput};
 use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
@@ -72,9 +74,12 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// use std::rc::Rc;
 ///
 /// let v = Rc::new(1);
-/// let closure = clone!(@strong v => move |x| {
-///     println!("v: {}, x: {}", v, x);
-/// });
+/// let closure = clone!(
+///     #[strong] v,
+///     move |x| {
+///         println!("v: {}, x: {}", v, x);
+///     },
+/// );
 ///
 /// closure(2);
 /// ```
@@ -87,9 +92,13 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// use std::rc::Rc;
 ///
 /// let u = Rc::new(2);
-/// let closure = clone!(@weak u => move |x| {
-///     println!("u: {}, x: {}", u, x);
-/// });
+/// let closure = clone!(
+///     #[weak]
+///     u,
+///     move |x| {
+///         println!("u: {}, x: {}", u, x);
+///     },
+/// );
 ///
 /// closure(3);
 /// ```
@@ -97,7 +106,7 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// #### Allowing a nullable weak reference
 ///
 /// In some cases, even if the weak references can't be retrieved, you might want to still have
-/// your closure called. In this case, you need to use `@weak-allow-none`:
+/// your closure called. In this case, you need to use `#[weak_allow_none]` instead of `#[weak]`:
 ///
 /// ```
 /// use glib;
@@ -108,11 +117,15 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 ///     // This `Rc` won't be available in the closure because it's dropped at the end of the
 ///     // current block
 ///     let u = Rc::new(2);
-///     clone!(@weak-allow-none u => @default-return false, move |x| {
-///         // We need to use a Debug print for `u` because it'll be an `Option`.
-///         println!("u: {:?}, x: {}", u, x);
-///         true
-///     })
+///     clone!(
+///         #[weak_allow_none]
+///         u,
+///         move |x| {
+///             // We need to use a Debug print for `u` because it'll be an `Option`.
+///             println!("u: {:?}, x: {}", u, x);
+///             true
+///         },
+///     )
 /// };
 ///
 /// assert_eq!(closure(3), true);
@@ -125,10 +138,13 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// use glib_macros::clone;
 ///
 /// let v = "123";
-/// let closure = clone!(@to-owned v => move |x| {
-///     // v is passed as `String` here
-///     println!("v: {}, x: {}", v, x);
-/// });
+/// let closure = clone!(
+///     #[to_owned] v,
+///     move |x| {
+///         // v is passed as `String` here
+///         println!("v: {}, x: {}", v, x);
+///     },
+/// );
 ///
 /// closure(2);
 /// ```
@@ -142,18 +158,28 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 ///
 /// let v = Rc::new(1);
 /// let u = Rc::new(2);
-/// let closure = clone!(@strong v as y, @weak u => move |x| {
-///     println!("v as y: {}, u: {}, x: {}", y, u, x);
-/// });
+/// let closure = clone!(
+///     #[strong(rename_to = y)]
+///     v,
+///     #[weak] u,
+///     move |x| {
+///         println!("v as y: {}, u: {}, x: {}", y, u, x);
+///     },
+/// );
 ///
 /// closure(3);
 /// ```
 ///
-/// ### Providing a default return value if upgrading a weak reference fails
+/// ### Providing a return value if upgrading a weak reference fails
 ///
-/// You can do it in two different ways:
+/// By default, `()` is returned if upgrading a weak reference fails. This behaviour can be
+/// adjusted in two different ways:
 ///
-/// Either by providing the value yourself using `@default-return`:
+/// Either by providing the value yourself using one of
+///
+///   * `#[upgrade_or]`: Requires an expression that returns a `Copy` value of the expected return type,
+///   * `#[upgrade_or_else]`: Requires a closure that returns a value of the expected return type,
+///   * `#[upgrade_or_default]`: Requires that the return type implements `Default` and returns that.
 ///
 /// ```
 /// use glib;
@@ -161,10 +187,15 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// use std::rc::Rc;
 ///
 /// let v = Rc::new(1);
-/// let closure = clone!(@weak v => @default-return false, move |x| {
-///     println!("v: {}, x: {}", v, x);
-///     true
-/// });
+/// let closure = clone!(
+///     #[weak] v,
+///     #[upgrade_or]
+///     false,
+///     move |x| {
+///         println!("v: {}, x: {}", v, x);
+///         true
+///     },
+/// );
 ///
 /// // Drop value so that the weak reference can't be upgraded.
 /// drop(v);
@@ -172,17 +203,21 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// assert_eq!(closure(2), false);
 /// ```
 ///
-/// Or by using `@default-panic` (if the value fails to get upgraded, it'll panic):
+/// Or by using `#[upgrade_or_panic]`: If the value fails to get upgraded, it'll panic.
 ///
 /// ```should_panic
 /// # use glib;
 /// # use glib_macros::clone;
 /// # use std::rc::Rc;
 /// # let v = Rc::new(1);
-/// let closure = clone!(@weak v => @default-panic, move |x| {
-///     println!("v: {}, x: {}", v, x);
-///     true
-/// });
+/// let closure = clone!(
+///     #[weak] v,
+///     #[upgrade_or_panic]
+///     move |x| {
+///         println!("v: {}, x: {}", v, x);
+///         true
+///     },
+/// );
 /// # drop(v);
 /// # assert_eq!(closure(2), false);
 /// ```
@@ -191,7 +226,7 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 ///
 /// Here is a list of errors you might encounter:
 ///
-/// **Missing `@weak` or `@strong`**:
+/// **Missing `#[weak]` or `#[strong]`**:
 ///
 /// ```compile_fail
 /// # use glib;
@@ -199,7 +234,10 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// # use std::rc::Rc;
 /// let v = Rc::new(1);
 ///
-/// let closure = clone!(v => move |x| println!("v: {}, x: {}", v, x));
+/// let closure = clone!(
+///     v,
+///     move |x| println!("v: {}, x: {}", v, x),
+/// );
 /// # drop(v);
 /// # closure(2);
 /// ```
@@ -215,9 +253,12 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 ///
 /// impl Foo {
 ///     fn foo(&self) {
-///         let closure = clone!(@strong self => move |x| {
-///             println!("self: {:?}", self);
-///         });
+///         let closure = clone!(
+///             #[strong] self,
+///             move |x| {
+///                 println!("self: {:?}", self);
+///             },
+///         );
 ///         # closure(2);
 ///     }
 /// }
@@ -234,9 +275,13 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 ///
 /// impl Foo {
 ///     fn foo(&self) {
-///         let closure = clone!(@strong self as this => move |x| {
-///             println!("self: {:?}", this);
-///         });
+///         let closure = clone!(
+///             #[strong(rename_to = this)]
+///             self,
+///             move |x| {
+///                 println!("self: {:?}", this);
+///             },
+///         );
 ///         # closure(2);
 ///     }
 /// }
@@ -255,9 +300,12 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 ///
 /// impl Foo {
 ///     fn foo(&self) {
-///         let closure = clone!(@strong self.v => move |x| {
-///             println!("self.v: {:?}", v);
-///         });
+///         let closure = clone!(
+///             #[strong] self.v,
+///             move |x| {
+///                 println!("self.v: {:?}", v);
+///             },
+///         );
 ///         # closure(2);
 ///     }
 /// }
@@ -274,16 +322,31 @@ use utils::{parse_nested_meta_items_from_stream, NestedMetaItem};
 /// # }
 /// impl Foo {
 ///     fn foo(&self) {
-///         let closure = clone!(@strong self.v as v => move |x| {
-///             println!("self.v: {}", v);
-///         });
+///         let closure = clone!(
+///             #[strong(rename_to = v)]
+///             self.v,
+///             move |x| {
+///                 println!("self.v: {}", v);
+///             },
+///         );
 ///         # closure(2);
 ///     }
 /// }
 /// ```
 #[proc_macro]
 pub fn clone(item: TokenStream) -> TokenStream {
-    clone::clone_inner(item)
+    // Check if this is an old-style clone macro invocation.
+    // These always start with an '@' punctuation.
+    let Some(first) = item.clone().into_iter().next() else {
+        return syn::Error::new(Span::call_site(), "expected a closure or async block")
+            .to_compile_error()
+            .into();
+    };
+
+    match first {
+        TokenTree::Punct(ref p) if p.to_string() == "@" => clone_old::clone_inner(item),
+        _ => clone::clone_inner(item),
+    }
 }
 
 /// Macro for creating a [`Closure`] object. This is a wrapper around [`Closure::new`] that
@@ -299,16 +362,20 @@ pub fn clone(item: TokenStream) -> TokenStream {
 ///
 /// Similarly to [`clone!`](crate::clone!), this macro can be useful in combination with signal
 /// handlers to reduce boilerplate when passing references. Unique to `Closure` objects is the
-/// ability to watch an object using a the `@watch` directive. Only an [`Object`] value can be
-/// passed to `@watch`, and only one object can be watched per closure. When an object is watched,
+/// ability to watch an object using a the `#[watch]` attribute. Only an [`Object`] value can be
+/// passed to `#[watch]`, and only one object can be watched per closure. When an object is watched,
 /// a weak reference to the object is held in the closure. When the object is destroyed, the
 /// closure will become invalidated: all signal handlers connected to the closure will become
 /// disconnected, and any calls to [`Closure::invoke`] on the closure will be silently ignored.
 /// Internally, this is accomplished using [`Object::watch_closure`] on the watched object.
 ///
-/// The `@weak-allow-none` and `@strong` captures are also supported and behave the same as in
-/// [`clone!`](crate::clone!), as is aliasing captures with the `as` keyword. Notably, these
-/// captures are able to reference `Rc` and `Arc` values in addition to `Object` values.
+/// The `#[weak]`, `#[weak_allow_none]`, `#[strong]`, `#[to_owned]` captures are also supported and
+/// behave the same as in [`clone!`](crate::clone!), as is aliasing captures via `rename_to`.
+/// Similarly, upgrade failure of weak references can be adjusted via `#[upgrade_or]`,
+/// `#[upgrade_or_else]`, `#[upgrade_or_default]` and `#[upgrade_or_panic]`.
+///
+/// Notably, these captures are able to reference `Rc` and `Arc` values in addition to `Object`
+/// values.
 ///
 /// [`Closure`]: ../glib/closure/struct.Closure.html
 /// [`Closure::new`]: ../glib/closure/struct.Closure.html#method.new
@@ -367,9 +434,12 @@ pub fn clone(item: TokenStream) -> TokenStream {
 ///
 /// let closure = {
 ///     let obj = glib::Object::new::<glib::Object>();
-///     let closure = closure_local!(@watch obj => move || {
-///         obj.type_().name()
-///     });
+///     let closure = closure_local!(
+///         #[watch] obj,
+///         move || {
+///             obj.type_().name()
+///         },
+///     );
 ///     assert_eq!(closure.invoke::<String>(&[]), "GObject");
 ///     closure
 /// };
@@ -377,7 +447,7 @@ pub fn clone(item: TokenStream) -> TokenStream {
 /// closure.invoke::<()>(&[]);
 /// ```
 ///
-/// `@watch` has special behavior when connected to a signal:
+/// `#[watch]` has special behavior when connected to a signal:
 ///
 /// ```
 /// use glib;
@@ -389,10 +459,15 @@ pub fn clone(item: TokenStream) -> TokenStream {
 ///     let other = glib::Object::new::<glib::Object>();
 ///     obj.connect_closure(
 ///         "notify", false,
-///         closure_local!(@watch other as b => move |a: glib::Object, pspec: glib::ParamSpec| {
-///             let value = a.property_value(pspec.name());
-///             b.set_property(pspec.name(), &value);
-///         }));
+///         closure_local!(
+///             #[watch(rename_to = b)]
+///             other,
+///             move |a: glib::Object, pspec: glib::ParamSpec| {
+///                 let value = a.property_value(pspec.name());
+///                 b.set_property(pspec.name(), &value);
+///             },
+///         ),
+///     );
 ///     // The signal handler will disconnect automatically at the end of this
 ///     // block when `other` is dropped.
 /// }
@@ -410,10 +485,17 @@ pub fn clone(item: TokenStream) -> TokenStream {
 ///     let a = Arc::new(String::from("Hello"));
 ///     let b = Arc::new(String::from("World"));
 ///     let c = "!";
-///     let closure = closure!(@strong a, @weak-allow-none b, @to-owned c => move || {
-///         // `a` is Arc<String>, `b` is Option<Arc<String>>, `c` is a `String`
-///         format!("{} {}{}", a, b.as_ref().map(|b| b.as_str()).unwrap_or_else(|| "Moon"), c)
-///     });
+///     let closure = closure!(
+///         #[strong] a,
+///         #[weak_allow_none]
+///         b,
+///         #[to_owned]
+///         c,
+///         move || {
+///             // `a` is Arc<String>, `b` is Option<Arc<String>>, `c` is a `String`
+///             format!("{} {}{}", a, b.as_ref().map(|b| b.as_str()).unwrap_or_else(|| "Moon"), c)
+///         },
+///     );
 ///     assert_eq!(closure.invoke::<String>(&[]), "Hello World!");
 ///     closure
 /// };
@@ -422,7 +504,18 @@ pub fn clone(item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro]
 pub fn closure(item: TokenStream) -> TokenStream {
-    closure::closure_inner(item, "new")
+    // Check if this is an old-style closure macro invocation.
+    // These always start with an '@' punctuation.
+    let Some(first) = item.clone().into_iter().next() else {
+        return syn::Error::new(Span::call_site(), "expected a closure")
+            .to_compile_error()
+            .into();
+    };
+
+    match first {
+        TokenTree::Punct(ref p) if p.to_string() == "@" => closure_old::closure_inner(item, "new"),
+        _ => closure::closure_inner(item, "new"),
+    }
 }
 
 /// The same as [`closure!`](crate::closure!) but uses [`Closure::new_local`] as a constructor.
@@ -432,7 +525,20 @@ pub fn closure(item: TokenStream) -> TokenStream {
 /// [`Closure::new_local`]: ../glib/closure/struct.Closure.html#method.new_local
 #[proc_macro]
 pub fn closure_local(item: TokenStream) -> TokenStream {
-    closure::closure_inner(item, "new_local")
+    // Check if this is an old-style closure macro invocation.
+    // These always start with an '@' punctuation.
+    let Some(first) = item.clone().into_iter().next() else {
+        return syn::Error::new(Span::call_site(), "expected a closure")
+            .to_compile_error()
+            .into();
+    };
+
+    match first {
+        TokenTree::Punct(ref p) if p.to_string() == "@" => {
+            closure_old::closure_inner(item, "new_local")
+        }
+        _ => closure::closure_inner(item, "new_local"),
+    }
 }
 
 /// Derive macro for register a Rust enum in the GLib type system and derive the
@@ -1042,7 +1148,13 @@ pub fn object_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// let fancy_label = FancyLabel::new("Look at me!");
 /// let button = gtk::ButtonBuilder::new().label("Click me!").build();
-/// button.connect_clicked(clone!(@weak fancy_label => move || fancy_label.flip()));
+/// button.connect_clicked(
+///     clone!(
+///         #[weak]
+///         fancy_label,
+///         move || fancy_label.flip(),
+///     ),
+/// );
 /// ```
 ///
 /// ## Generic New Type

--- a/glib-macros/tests/clone.rs
+++ b/glib-macros/tests/clone.rs
@@ -6,252 +6,320 @@ use glib::clone;
 
 #[test]
 fn clone() {
+    let _ = clone!(move || {});
+    let fut = clone!(async move {});
+    drop(fut);
+
+    let x = 1;
+    let _ = clone!(move || {
+        println!("foo {x}");
+        1
+    });
+
+    let x = 1;
+    let y = String::from("123");
     let v = Rc::new(1);
-    let _ = clone!(@strong v => @default-return None::<i32>, move || {println!("foo"); 1});
+    let _ = clone!(
+        #[strong]
+        v,
+        move || {
+            println!("foo {x} {y} {v}");
+            1
+        }
+    );
 
     let v = Rc::new(1);
-    let _ = clone!(@weak v => @default-return None::<i32>, move || {println!("foo"); Some(1)});
+    let _ = clone!(
+        #[strong(rename_to = y)]
+        v,
+        move || {
+            println!("foo {y}");
+            1
+        }
+    );
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[strong(rename_to = y)]
+        Rc::strong_count(&v),
+        move || {
+            println!("foo {y}");
+            1
+        }
+    );
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[strong]
+        v,
+        move |a: i32, b: &str| {
+            println!("foo {a} {b} {v}");
+            1
+        }
+    );
+
+    let x = 1;
+    let y = String::from("123");
+    let v = Rc::new(1);
+    let fut = clone!(
+        #[strong]
+        v,
+        async move {
+            println!("foo {x} {y} {v}");
+            1
+        }
+    );
+    drop(fut);
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[weak]
+        v,
+        move || {
+            println!("foo {v}");
+        }
+    );
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[weak]
+        v,
+        #[upgrade_or_else]
+        || None::<i32>,
+        move || {
+            println!("foo {v}");
+            Some(1)
+        }
+    );
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[weak]
+        v,
+        #[upgrade_or]
+        None::<i32>,
+        move || {
+            println!("foo {v}");
+            Some(1)
+        }
+    );
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[weak]
+        v,
+        #[upgrade_or_default]
+        move || {
+            println!("foo {v}");
+            Some(1)
+        }
+    );
+
+    let v = Rc::new(1);
+    let w = Rc::new(2);
+    let x = Rc::new(3);
+    let _ = clone!(
+        #[weak]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or_else]
+        || {
+            let x: Rc<i32> = x;
+            Some(*x)
+        },
+        move || {
+            println!("foo {v} {w}");
+            Some(1)
+        }
+    );
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[weak]
+        v,
+        #[upgrade_or_panic]
+        move || {
+            println!("foo {v}");
+            Some(1)
+        }
+    );
+
+    let v = Rc::new(1);
+    let _ = clone!(
+        #[weak_allow_none]
+        v,
+        move || {
+            println!("foo {}", v.unwrap());
+            Some(1)
+        }
+    );
 
     let v = "123";
-    let _ = clone!(@to-owned v => @default-return None::<i32>, move || {println!("foo"); 1});
+    let _ = clone!(
+        #[to_owned]
+        v,
+        move || {
+            println!("foo {v}");
+            1
+        }
+    );
 }
 
 const TESTS: &[(&str, &str)] = &[
+    ("clone!()", "expected a closure or async block"),
     (
-        "clone!( => move || {})",
-        "If you have nothing to clone, no need to use this macro!",
-    ),
-    (
-        "clone!(|| {})",
-        "If you have nothing to clone, no need to use this macro!",
-    ),
-    (
-        "clone!(|a, b| {})",
-        "If you have nothing to clone, no need to use this macro!",
-    ),
-    (
-        "clone!(@weak a, @weak b => |x| {})",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_3.rs:1:86
+        "clone!(#[weak] a, #[weak] b, |x| {})",
+        r#"error: closures need to capture variables by move. Please add the `move` keyword
+ --> test_1.rs:1:88
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a, @weak b => |x| {}); }
-  |                                                                                      ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[weak] a, #[weak] b, |x| {}); }
+  |                                                                                        ^^^^^^"#,
     ),
     (
-        "clone!(@weak a, @weak b => || {})",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_4.rs:1:86
+        "clone!(#[strong] self, move |x| {})",
+        r#"error: capture attribute for `self` requires usage of the `rename_to` attribute property
+ --> test_2.rs:1:66
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a, @weak b => || {}); }
-  |                                                                                      ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong] self, move |x| {}); }
+  |                                                                  ^^^^^^^^^"#,
     ),
     (
-        "clone!(@weak a, @weak b => |x| println!(\"a\"))",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_5.rs:1:86
+        "clone!(#[strong] self.v, move |x| {})",
+        r#"error: capture attribute for an expression requires usage of the `rename_to` attribute property
+ --> test_3.rs:1:66
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a, @weak b => |x| println!("a")); }
-  |                                                                                      ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong] self.v, move |x| {}); }
+  |                                                                  ^^^^^^^^^"#,
     ),
     (
-        "clone!(@weak a, @weak b => || println!(\"a\"))",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_6.rs:1:86
+        "clone!(#[strong(rename_to = x, rename_to = y)] self.v, move || {})",
+        r#"error: multiple `rename_to` properties are not allowed
+ --> test_4.rs:1:90
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a, @weak b => || println!("a")); }
-  |                                                                                      ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong(rename_to = x, rename_to = y)] self.v, move || {}); }
+  |                                                                                          ^^^^^^^^^^^^^"#,
     ),
     (
-        "clone!(@weak a => |x| {})",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_7.rs:1:77
+        "clone!(#[strong(stronk)] self.v, move || {})",
+        r#"error: unsupported capture attribute property `stronk`: only `rename_to` is supported
+ --> test_5.rs:1:75
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a => |x| {}); }
-  |                                                                             ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong(stronk)] self.v, move || {}); }
+  |                                                                           ^^^^^^"#,
     ),
     (
-        "clone!(@weak a => || {})",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_8.rs:1:77
+        "clone!(#[strong(rename_to = \"a\")] self.v, move || {})",
+        r#"error: expected identifier
+ --> test_6.rs:1:87
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a => || {}); }
-  |                                                                             ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong(rename_to = "a")] self.v, move || {}); }
+  |                                                                                       ^^^"#,
     ),
     (
-        "clone!(@weak a => |x| println!(\"a\"))",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_9.rs:1:77
+        "clone!(#[weak] v, #[upgrade_or_else] false, move || {})",
+        r#"error: expected `|`
+ --> test_7.rs:1:96
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a => |x| println!("a")); }
-  |                                                                             ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[weak] v, #[upgrade_or_else] false, move || {}); }
+  |                                                                                                ^^^^^"#,
     ),
     (
-        "clone!(@weak a => || println!(\"a\"))",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_10.rs:1:77
+        "clone!(#[weak] v, #[upgrade_or(abort)] move || {})",
+        r#"error: unexpected token in attribute
+ --> test_8.rs:1:89
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak a => || println!("a")); }
-  |                                                                             ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[weak] v, #[upgrade_or(abort)] move || {}); }
+  |                                                                                         ^"#,
     ),
     (
-        "clone!(@strong self => move |x| {})",
-        r#"error: Can't use `self` as variable name. Try storing it in a temporary variable or rename it using `as`.
- --> test_11.rs:1:74
+        "clone!(#[yolo] v, move || {})",
+        r#"error: unsupported attribute `yolo`: only `strong`, `weak`, `weak_allow_none`, `to_owned`, `upgrade_or`, `upgrade_or_else`, `upgrade_or_default` and `upgrade_or_panic` are supported
+ --> test_9.rs:1:66
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong self => move |x| {}); }
-  |                                                                          ^^^^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[yolo] v, move || {}); }
+  |                                                                  ^^^^^^^"#,
     ),
     (
-        "clone!(@strong self.v => move |x| {})",
-        r#"error: `self.v`: Field accesses are not allowed as is, you must rename it!
- --> test_12.rs:1:79
+        "clone!(#[watch] v, move || {})",
+        r#"error: watch variable captures are not supported
+ --> test_10.rs:1:66
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong self.v => move |x| {}); }
-  |                                                                               ^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[watch] v, move || {}); }
+  |                                                                  ^^^^^^^^"#,
     ),
     (
-        "clone!(@weak v => @default-return false, || {})",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_13.rs:1:100
+        "clone!(#[strong]#[strong] v, move || {})",
+        r#"error: variable capture attributes must be followed by an identifier
+ --> test_11.rs:1:75
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak v => @default-return false, || {}); }
-  |                                                                                                    ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong]#[strong] v, move || {}); }
+  |                                                                           ^^^^^^^^^"#,
     ),
     (
-        "clone!(@weak v => @default-return false, || println!(\"a\"))",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_14.rs:1:100
+        "clone!(v, move || {})",
+        r#"error: only closures and async blocks are supported
+ --> test_12.rs:1:66
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak v => @default-return false, || println!("a")); }
-  |                                                                                                    ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(v, move || {}); }
+  |                                                                  ^"#,
     ),
     (
-        "clone!(@weak v => @default-return false, |bla| {})",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_15.rs:1:100
+        "clone!(#[upgrade_or_else] || lol, #[strong] v, move || {println!(\"foo\");})",
+        r#"error: upgrade failure attribute must not be followed by any other attributes. Found 1 more attribute
+ --> test_13.rs:1:93
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak v => @default-return false, |bla| {}); }
-  |                                                                                                    ^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[upgrade_or_else] || lol, #[strong] v, move || {println!("foo");}); }
+  |                                                                                             ^^^^^^^^^"#,
     ),
     (
-        "clone!(@weak v => @default-return false, |bla| println!(\"a\"))",
-        r#"error: Closure needs to be "moved" so please add `move` before closure
- --> test_16.rs:1:100
+        "clone!(#[upgrade_or_else] |x| lol, #[strong] v, move || {println!(\"foo\");})",
+        r#"error: `upgrade_or_else` closure must not have any parameters
+ --> test_14.rs:1:85
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak v => @default-return false, |bla| println!("a")); }
-  |                                                                                                    ^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[upgrade_or_else] |x| lol, #[strong] v, move || {println!("foo");}); }
+  |                                                                                     ^^^^^^^"#,
     ),
     (
-        "clone!(@weak v => default-return false, move || {})",
-        r#"error: Missing `@` before `default-return`
- --> test_17.rs:1:77
+        "clone!(#[upgrade_or_else] async || lol, #[strong] v, move || {println!(\"foo\");})",
+        r#"error: `upgrade_or_else` closure needs to be a non-async closure
+ --> test_15.rs:1:85
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak v => default-return false, move || {}); }
-  |                                                                             ^^^^^^^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[upgrade_or_else] async || lol, #[strong] v, move || {println!("foo");}...
+  |                                                                                     ^^^^^^^^^^^^"#,
     ),
     (
-        "clone!(@weak v => @default-return false move || {})",
-        r#"error: Expected `,` after `@default-return false`, found `move`
- --> test_18.rs:1:99
+        "clone!(#[upgrade_or_panic] #[strong] v, move || {println!(\"foo\");})",
+        r#"error: upgrade failure attribute must not be followed by any other attributes. Found 1 more attribute
+ --> test_16.rs:1:86
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@weak v => @default-return false move || {}); }
-  |                                                                                                   ^^^^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[upgrade_or_panic] #[strong] v, move || {println!("foo");}); }
+  |                                                                                      ^^^^^^^^^"#,
     ),
     (
-        "clone!(@yolo v => move || {})",
-        r#"error: Unknown keyword `yolo`, only `weak`, `weak-allow-none`, `to-owned` and `strong` are allowed
- --> test_19.rs:1:67
+        "clone!(#[strong] v, #[upgrade_or_panic] move || {println!(\"foo\");})",
+        r#"error: upgrade failure attribute can only be used together with weak variable captures
+ --> test_17.rs:1:79
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@yolo v => move || {}); }
-  |                                                                   ^^^^
-"#,
-    ),
-    (
-        "clone!(v => move || {})",
-        r#"error: Unexpected ident `v`: you need to specify if this is a weak or a strong clone.
- --> test_20.rs:1:66
-  |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(v => move || {}); }
-  |                                                                  ^
-"#,
-    ),
-    (
-        "clone!(@strong v => {println!(\"foo\");})",
-        r#"error: Missing `move` and closure declaration
- --> test_21.rs:1:79
-  |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong v => {println!("foo");}); }
-  |                                                                               ^^^^^^^^^^^^^^^^^^
-"#,
-    ),
-    (
-        "clone!(@strong v, @default-return lol => move || {println!(\"foo\");})",
-        r#"error: `@default-return` should be after `=>`
- --> test_22.rs:1:78
-  |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong v, @default-return lol => move || {println!("foo");}); }
-  |                                                                              ^^^^^^^
-"#,
-    ),
-    (
-        "clone!(@default-return lol, @strong v => move || {println!(\"foo\");})",
-        r#"error: `@default-return` should be after `=>`
- --> test_23.rs:1:67
-  |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@default-return lol, @strong v => move || {println!("foo");}); }
-  |                                                                   ^^^^^^^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong] v, #[upgrade_or_panic] move || {println!("foo");}); }
+  |                                                                               ^"#,
     ),
     // The async part!
     (
-        "clone!(@strong v => async || {println!(\"foo\");})",
-        r#"error: Expected `move` after `async`, found `|`
- --> test_24.rs:1:85
+        "clone!(#[strong] v, async {println!(\"foo\");})",
+        r#"error: async blocks need to capture variables by move. Please add the `move` keyword
+ --> test_18.rs:1:79
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong v => async || {println!("foo");}); }
-  |                                                                                     ^"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong] v, async {println!("foo");}); }
+  |                                                                               ^^^^^^^^^^^^^^^^^^^^^^^^"#,
     ),
     (
-        "clone!(@strong v => async {println!(\"foo\");})",
-        r#"error: Expected `move` after `async`, found `{`
- --> test_25.rs:1:85
+        "clone!(#[strong] v, {println!(\"foo\");})",
+        r#"error: only closures and async blocks are supported
+ --> test_19.rs:1:79
   |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong v => async {println!("foo");}); }
-  |                                                                                     ^^^^^^^^^^^^^^^^^^
-"#,
-    ),
-    (
-        "clone!(@strong v => move || async {println!(\"foo\");})",
-        r#"error: Expected `move` after `async`, found `{`
- --> test_26.rs:1:93
-  |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong v => move || async {println!("foo");}); }
-  |                                                                                             ^^^^^^^^^^^^^^^^^^
-"#,
-    ),
-    (
-        "clone!(@strong v => move || async println!(\"foo\");)",
-        r#"error: Expected `move` after `async`, found `println`
- --> test_27.rs:1:93
-  |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong v => move || async println!("foo");); }
-  |                                                                                             ^^^^^^^
-"#,
-    ),
-    (
-        "clone!(@strong v => move || async move println!(\"foo\");)",
-        r#"error: Expected block after `| async move`
- --> test_28.rs:1:98
-  |
-1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(@strong v => move || async move println!("foo");); }
-  |                                                                                                  ^^^^^^^
-"#,
+1 | fn main() { use glib::clone; let v = std::rc::Rc::new(1); clone!(#[strong] v, {println!("foo");}); }
+  |                                                                               ^^^^^^^^^^^^^^^^^^"#,
     ),
 ];
 
@@ -269,13 +337,14 @@ fn clone_failures() {
 }
 
 const NO_WARNING: &[&str] = &[
-    "clone!(@weak v => @default-return (), move || println!(\"{}\", v);)",
-    "clone!(@weak v => @default-return (()), move || println!(\"{}\", v);)",
-    "clone!(@weak v => @default-return ( () ), move || println!(\"{}\", v);)",
-    "clone!(@weak v => @default-return (  ), move || println!(\"{}\", v);)",
+    "let _ = clone!(#[weak] v, #[upgrade_or] (), move || println!(\"{}\", v))",
+    "let _ = clone!(#[weak] v, #[upgrade_or_else] || (), move || println!(\"{}\", v))",
+    "let _ = clone!(#[weak] v, #[upgrade_or_else] || (()), move || println!(\"{}\", v))",
+    "let _ = clone!(#[weak] v, #[upgrade_or_else] || ( () ), move || println!(\"{}\", v))",
+    "let _ = clone!(#[weak] v, #[upgrade_or_else] || (  ), move || println!(\"{}\", v))",
 ];
 
-// Ensures that no warning are emitted if the default-return is a unit tuple.
+// Ensures that no warning are emitted if the return value is a unit tuple.
 #[test]
 fn clone_unit_tuple_return() {
     let t = trybuild2::TestCases::new();

--- a/glib-macros/tests/closure.rs
+++ b/glib-macros/tests/closure.rs
@@ -1,0 +1,170 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+const TESTS: &[(&str, &str)] = &[
+    ("closure!()", "expected a closure"),
+    (
+        "closure!(#[weak] a, #[weak] b, |x| {})",
+        r#"error: closures need to capture variables by move. Please add the `move` keyword
+ --> test_1.rs:1:92
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[weak] a, #[weak] b, |x| {}); }
+  |                                                                                            ^^^^^^"#,
+    ),
+    (
+        "closure!(#[strong] self, move |x| {})",
+        r#"error: capture attribute for `self` requires usage of the `rename_to` attribute property
+ --> test_2.rs:1:70
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong] self, move |x| {}); }
+  |                                                                      ^^^^^^^^^"#,
+    ),
+    (
+        "closure!(#[strong] self.v, move |x| {})",
+        r#"error: capture attribute for an expression requires usage of the `rename_to` attribute property
+ --> test_3.rs:1:70
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong] self.v, move |x| {}); }
+  |                                                                      ^^^^^^^^^"#,
+    ),
+    (
+        "closure!(#[strong(rename_to = x, rename_to = y)] self.v, move || {})",
+        r#"error: multiple `rename_to` properties are not allowed
+ --> test_4.rs:1:94
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong(rename_to = x, rename_to = y)] self.v, move || {}); }
+  |                                                                                              ^^^^^^^^^^^^^"#,
+    ),
+    (
+        "closure!(#[strong(stronk)] self.v, move || {})",
+        r#"error: unsupported capture attribute property `stronk`: only `rename_to` is supported
+ --> test_5.rs:1:79
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong(stronk)] self.v, move || {}); }
+  |                                                                               ^^^^^^"#,
+    ),
+    (
+        "closure!(#[strong(rename_to = \"a\")] self.v, move || {})",
+        r#"error: expected identifier
+ --> test_6.rs:1:91
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong(rename_to = "a")] self.v, move || {}); }
+  |                                                                                           ^^^"#,
+    ),
+    (
+        "closure!(#[weak] v, #[upgrade_or_else] false, move || {})",
+        r#"error: expected `|`
+ --> test_7.rs:1:100
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[weak] v, #[upgrade_or_else] false, move || {}); }
+  |                                                                                                    ^^^^^"#,
+    ),
+    (
+        "closure!(#[weak] v, #[upgrade_or(abort)] move || {})",
+        r#"error: unexpected token in attribute
+ --> test_8.rs:1:93
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[weak] v, #[upgrade_or(abort)] move || {}); }
+  |                                                                                             ^"#,
+    ),
+    (
+        "closure!(#[yolo] v, move || {})",
+        r#"error: unsupported attribute `yolo`: only `watch`, `strong`, `weak`, `weak_allow_none`, `to_owned`, `upgrade_or`, `upgrade_or_else`, `upgrade_or_default` and `upgrade_or_panic` are supported
+ --> test_9.rs:1:70
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[yolo] v, move || {}); }
+  |                                                                      ^^^^^^^"#,
+    ),
+    (
+        "closure!(#[watch] v, #[watch] v, move || {})",
+        r#"error: only one `watch` capture is allowed per closure
+ --> test_10.rs:1:82
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[watch] v, #[watch] v, move || {}); }
+  |                                                                                  ^^^^^^^^"#,
+    ),
+    (
+        "closure!(#[strong]#[strong] v, move || {})",
+        r#"error: variable capture attributes must be followed by an identifier
+ --> test_11.rs:1:79
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong]#[strong] v, move || {}); }
+  |                                                                               ^^^^^^^^^"#,
+    ),
+    (
+        "closure!(v, move || {})",
+        r#"error: expected `|`
+ --> test_12.rs:1:70
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(v, move || {}); }
+  |                                                                      ^"#,
+    ),
+    (
+        "closure!(#[upgrade_or_else] || lol, #[strong] v, move || {println!(\"foo\");})",
+        r#"error: upgrade failure attribute must not be followed by any other attributes. Found 1 more attribute
+ --> test_13.rs:1:97
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[upgrade_or_else] || lol, #[strong] v, move || {println!("foo");}); }
+  |                                                                                                 ^^^^^^^^^"#,
+    ),
+    (
+        "closure!(#[upgrade_or_else] |x| lol, #[strong] v, move || {println!(\"foo\");})",
+        r#"error: `upgrade_or_else` closure must not have any parameters
+ --> test_14.rs:1:89
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[upgrade_or_else] |x| lol, #[strong] v, move || {println!("foo");}); }
+  |                                                                                         ^^^^^^^"#,
+    ),
+    (
+        "closure!(#[upgrade_or_else] async || lol, #[strong] v, move || {println!(\"foo\");})",
+        r#"error: `upgrade_or_else` closure needs to be a non-async closure
+ --> test_15.rs:1:89
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[upgrade_or_else] async || lol, #[strong] v, move || {println!("foo...
+  |                                                                                         ^^^^^^^^^^^^"#,
+    ),
+    (
+        "closure!(#[upgrade_or_panic] #[strong] v, move || {println!(\"foo\");})",
+        r#"error: upgrade failure attribute must not be followed by any other attributes. Found 1 more attribute
+ --> test_16.rs:1:90
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[upgrade_or_panic] #[strong] v, move || {println!("foo");}); }
+  |                                                                                          ^^^^^^^^^"#,
+    ),
+    (
+        "closure!(#[strong] v, async {println!(\"foo\");})",
+        r#"error: expected `|`
+ --> test_17.rs:1:89
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong] v, async {println!("foo");}); }
+  |                                                                                         ^"#,
+    ),
+    (
+        "closure!(#[strong] v, {println!(\"foo\");})",
+        r#"error: expected `|`
+ --> test_18.rs:1:83
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong] v, {println!("foo");}); }
+  |                                                                                   ^"#,
+    ),
+    (
+        "closure!(#[strong] v, #[upgrade_or_panic] move || {println!(\"foo\");})",
+        r#"error: upgrade failure attribute can only be used together with weak variable captures
+ --> test_19.rs:1:83
+  |
+1 | fn main() { use glib::closure; let v = std::rc::Rc::new(1); closure!(#[strong] v, #[upgrade_or_panic] move || {println!("foo");}); }
+  |                                                                                   ^"#,
+    ),
+];
+
+#[test]
+fn closure_failures() {
+    let t = trybuild2::TestCases::new();
+
+    for (index, (expr, err)) in TESTS.iter().enumerate() {
+        let prefix = "fn main() { use glib::closure; let v = std::rc::Rc::new(1); ";
+        let suffix = "; }";
+        let output = format!("{prefix}{expr}{suffix}");
+
+        t.compile_fail_inline_check_sub(&format!("test_{index}"), &output, err);
+    }
+}

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -545,7 +545,11 @@ fn closure() {
         let obj = glib::Object::new::<glib::Object>();
 
         assert_eq!(obj.ref_count(), 1);
-        let weak_test = glib::closure_local!(@watch obj => move || obj.ref_count());
+        let weak_test = glib::closure_local!(
+            #[watch]
+            obj,
+            move || obj.ref_count()
+        );
         assert_eq!(obj.ref_count(), 1);
         assert_eq!(weak_test.invoke::<u32>(&[]), 2);
         assert_eq!(obj.ref_count(), 1);
@@ -561,7 +565,11 @@ fn closure() {
 
         impl TestExt for glib::Object {
             fn ref_count_in_closure(&self) -> u32 {
-                let closure = glib::closure_local!(@watch self as obj => move || obj.ref_count());
+                let closure = glib::closure_local!(
+                    #[watch(rename_to = obj)]
+                    self,
+                    move || obj.ref_count()
+                );
                 closure.invoke::<u32>(&[])
             }
         }
@@ -577,8 +585,11 @@ fn closure() {
 
         impl A {
             fn ref_count_in_closure(&self) -> u32 {
-                let closure =
-                    glib::closure_local!(@watch self.obj as obj => move || obj.ref_count());
+                let closure = glib::closure_local!(
+                    #[watch(rename_to = obj)]
+                    self.obj,
+                    move || obj.ref_count()
+                );
                 closure.invoke::<u32>(&[])
             }
         }
@@ -592,7 +603,11 @@ fn closure() {
     let strong_test = {
         let obj = glib::Object::new::<glib::Object>();
 
-        let strong_test = glib::closure_local!(@strong obj => move || obj.ref_count());
+        let strong_test = glib::closure_local!(
+            #[strong]
+            obj,
+            move || obj.ref_count()
+        );
         assert_eq!(strong_test.invoke::<u32>(&[]), 2);
 
         strong_test
@@ -602,14 +617,63 @@ fn closure() {
     let weak_none_test = {
         let obj = glib::Object::new::<glib::Object>();
 
-        let weak_none_test = glib::closure_local!(@weak-allow-none obj => move || {
-            obj.map(|o| o.ref_count()).unwrap_or_default()
-        });
+        let weak_none_test = glib::closure_local!(
+            #[weak_allow_none]
+            obj,
+            move || { obj.map(|o| o.ref_count()).unwrap_or_default() }
+        );
         assert_eq!(weak_none_test.invoke::<u32>(&[]), 2);
 
         weak_none_test
     };
     assert_eq!(weak_none_test.invoke::<u32>(&[]), 0);
+
+    let weak_test_or_else = {
+        let obj = glib::Object::new::<glib::Object>();
+
+        let weak_test = glib::closure_local!(
+            #[weak]
+            obj,
+            #[upgrade_or_else]
+            || 0,
+            move || obj.ref_count()
+        );
+        assert_eq!(weak_test.invoke::<u32>(&[]), 2);
+
+        weak_test
+    };
+    assert_eq!(weak_test_or_else.invoke::<u32>(&[]), 0);
+
+    let weak_test_or = {
+        let obj = glib::Object::new::<glib::Object>();
+
+        let weak_test = glib::closure_local!(
+            #[weak]
+            obj,
+            #[upgrade_or]
+            0,
+            move || obj.ref_count()
+        );
+        assert_eq!(weak_test.invoke::<u32>(&[]), 2);
+
+        weak_test
+    };
+    assert_eq!(weak_test_or.invoke::<u32>(&[]), 0);
+
+    let weak_test_or_default = {
+        let obj = glib::Object::new::<glib::Object>();
+
+        let weak_test = glib::closure_local!(
+            #[weak]
+            obj,
+            #[upgrade_or_default]
+            move || obj.ref_count()
+        );
+        assert_eq!(weak_test.invoke::<u32>(&[]), 2);
+
+        weak_test
+    };
+    assert_eq!(weak_test_or_default.invoke::<u32>(&[]), 0);
 
     {
         let obj1 = glib::Object::new::<glib::Object>();
@@ -620,9 +684,13 @@ fn closure() {
         let rc = obj_arg_test.invoke::<u32>(&[&obj1, &obj2]);
         assert_eq!(rc, 6);
 
-        let alias_test = glib::closure_local!(@strong obj1 as a, @strong obj2 => move || {
-            a.ref_count() + obj2.ref_count()
-        });
+        let alias_test = glib::closure_local!(
+            #[strong(rename_to = a)]
+            obj1,
+            #[strong]
+            obj2,
+            move || { a.ref_count() + obj2.ref_count() }
+        );
         assert_eq!(alias_test.invoke::<u32>(&[]), 4);
     }
 
@@ -633,9 +701,11 @@ fn closure() {
 
         let a = glib::Object::new::<glib::Object>();
         let a_struct = A { a };
-        let struct_test = glib::closure_local!(@strong a_struct.a as a => move || {
-            a.ref_count()
-        });
+        let struct_test = glib::closure_local!(
+            #[strong(rename_to = a)]
+            a_struct.a,
+            move || { a.ref_count() }
+        );
         assert_eq!(struct_test.invoke::<u32>(&[]), 2);
     }
 
@@ -667,13 +737,21 @@ fn closure() {
             let f = glib::Object::new::<Foo>();
 
             assert_eq!(f.my_ref_count(), 1);
-            let cast_test = glib::closure_local!(@watch f => move || f.my_ref_count());
+            let cast_test = glib::closure_local!(
+                #[watch]
+                f,
+                move || f.my_ref_count()
+            );
             assert_eq!(f.my_ref_count(), 1);
             assert_eq!(cast_test.invoke::<u32>(&[]), 2);
             assert_eq!(f.my_ref_count(), 1);
 
             let f_ref = &f;
-            let _ = glib::closure_local!(@watch f_ref => move || f_ref.my_ref_count());
+            let _ = glib::closure_local!(
+                #[watch]
+                f_ref,
+                move || f_ref.my_ref_count()
+            );
 
             cast_test
         };
@@ -711,11 +789,15 @@ fn closure() {
         let inc_by = {
             let obj = glib::Object::new::<SendObject>();
             let obj = obj.imp().obj();
-            let inc_by = glib::closure!(@watch obj => move |x: i32| {
-                let old = obj.value();
-                obj.set_value(x + old);
-                old
-            });
+            let inc_by = glib::closure!(
+                #[watch]
+                obj,
+                move |x: i32| {
+                    let old = obj.value();
+                    obj.set_value(x + old);
+                    old
+                }
+            );
             obj.set_value(42);
             assert_eq!(obj.value(), 42);
             assert_eq!(inc_by.invoke::<i32>(&[&24i32]), 42);

--- a/glib/src/gobject/signal_group.rs
+++ b/glib/src/gobject/signal_group.rs
@@ -223,18 +223,28 @@ mod tests {
         group.connect_closure(
             "sig-with-args",
             false,
-            glib::closure_local!(@watch obj, @strong store => move |o: &SignalObject, a: u32, b: &str| {
-                assert_eq!(o, obj);
-                store.replace(format!("a {a} b {b}"));
-            })
+            glib::closure_local!(
+                #[watch]
+                obj,
+                #[strong]
+                store,
+                move |o: &SignalObject, a: u32, b: &str| {
+                    assert_eq!(o, obj);
+                    store.replace(format!("a {a} b {b}"));
+                }
+            ),
         );
         group.connect_closure(
             "sig-with-ret",
             false,
-            glib::closure_local!(@watch obj => move |o: &SignalObject| -> &'static crate::GStr {
-                assert_eq!(o, obj);
-                crate::gstr!("Hello")
-            }),
+            glib::closure_local!(
+                #[watch]
+                obj,
+                move |o: &SignalObject| -> &'static crate::GStr {
+                    assert_eq!(o, obj);
+                    crate::gstr!("Hello")
+                }
+            ),
         );
         group.set_target(Some(&obj));
         obj.emit_by_name::<()>("sig-with-args", &[&5u32, &"World"]);

--- a/glib/tests/clone.rs
+++ b/glib/tests/clone.rs
@@ -1,3 +1,6 @@
+// All the tests have their arguments used so they produce unused variable compiler warnings
+#![allow(unused_variables)]
+
 use std::{
     cell::RefCell,
     panic,
@@ -30,9 +33,13 @@ fn clone_and_references() {
     assert!(!ref_state.borrow().started);
 
     let closure = {
-        clone!(@weak ref_state => move || {
-            ref_state.borrow_mut().started = true;
-        })
+        clone!(
+            #[weak]
+            ref_state,
+            move || {
+                ref_state.borrow_mut().started = true;
+            }
+        )
     };
 
     closure();
@@ -49,10 +56,16 @@ fn subfields_renaming() {
         fn foo(&self) {
             let state = Rc::new(RefCell::new(State::new()));
 
-            let closure = clone!(@strong self.v as v, @weak state as hello => move |_| {
-                println!("v: {v}");
-                hello.borrow_mut().started = true;
-            });
+            let closure = clone!(
+                #[strong(rename_to = v)]
+                self.v,
+                #[weak(rename_to = hello)]
+                state,
+                move |_| {
+                    println!("v: {v}");
+                    hello.borrow_mut().started = true;
+                }
+            );
             closure(2);
         }
     }
@@ -66,9 +79,13 @@ fn renaming() {
     assert!(!state.borrow().started);
 
     let closure = {
-        clone!(@weak state as hello => move || {
-            hello.borrow_mut().started = true;
-        })
+        clone!(
+            #[weak(rename_to = hello)]
+            state,
+            move || {
+                hello.borrow_mut().started = true;
+            }
+        )
     };
 
     closure();
@@ -81,9 +98,13 @@ fn clone_closure() {
     assert!(!state.borrow().started);
 
     let closure = {
-        clone!(@weak state => move || {
-            state.borrow_mut().started = true;
-        })
+        clone!(
+            #[weak]
+            state,
+            move || {
+                state.borrow_mut().started = true;
+            }
+        )
     };
 
     closure();
@@ -95,11 +116,17 @@ fn clone_closure() {
         let state2 = Rc::new(RefCell::new(State::new()));
         assert!(state.borrow().started);
 
-        clone!(@weak state, @strong state2 => move || {
-            state.borrow_mut().count += 1;
-            state.borrow_mut().started = true;
-            state2.borrow_mut().started = true;
-        })
+        clone!(
+            #[weak]
+            state,
+            #[strong]
+            state2,
+            move || {
+                state.borrow_mut().count += 1;
+                state.borrow_mut().started = true;
+                state2.borrow_mut().started = true;
+            }
+        )
     };
 
     closure();
@@ -112,10 +139,16 @@ fn clone_closure() {
 fn clone_default_value() {
     let closure = {
         let state = Rc::new(RefCell::new(State::new()));
-        clone!(@weak state => @default-return 42, move |_| {
-            state.borrow_mut().started = true;
-            10
-        })
+        clone!(
+            #[weak]
+            state,
+            #[upgrade_or]
+            42,
+            move |_| {
+                state.borrow_mut().started = true;
+                10
+            }
+        )
     };
 
     assert_eq!(42, closure(50));
@@ -128,11 +161,19 @@ fn clone_panic() {
 
     let closure = {
         let state2 = Arc::new(Mutex::new(State::new()));
-        clone!(@weak state2, @strong state => @default-return panic!(), move |_| {
-            state.lock().expect("Failed to lock state mutex").count = 21;
-            state2.lock().expect("Failed to lock state2 mutex").started = true;
-            10
-        })
+        clone!(
+            #[weak]
+            state2,
+            #[strong]
+            state,
+            #[upgrade_or_else]
+            || panic!(),
+            move |_| {
+                state.lock().expect("Failed to lock state mutex").count = 21;
+                state2.lock().expect("Failed to lock state2 mutex").started = true;
+                10
+            }
+        )
     };
 
     let result = panic::catch_unwind(|| {
@@ -164,9 +205,9 @@ mod import_rename {
         let n = 2;
 
         let closure: Box<dyn Fn(u32, u32)> = Box::new(clone_g!(
-            @strong n
-            => move |_, _|
-            println!("The clone! macro does support renaming")
+            #[strong]
+            n,
+            move |_, _| println!("The clone! macro does support renaming")
         ));
 
         closure(0, 0);
@@ -183,37 +224,47 @@ fn test_clone_macro_self_rename() {
     impl Foo {
         #[allow(dead_code)]
         fn foo(&self) {
-            let closure = clone!(@strong self as this => move |_x| {
-                println!("v: {this:?}");
-            });
+            let closure = clone!(
+                #[strong(rename_to = this)]
+                self,
+                move |_x| {
+                    println!("v: {this:?}");
+                }
+            );
             closure(0i8); // to prevent compiler error for unknown `x` type.
-            let _ = clone!(@strong self as this => move || {
-                println!("v: {this:?}");
-            });
-            let closure = clone!(@strong self as this => move |_x| println!("v: {this:?}"));
+            let _ = clone!(
+                #[strong(rename_to = this)]
+                self,
+                move || {
+                    println!("v: {this:?}");
+                }
+            );
+            let closure = clone!(
+                #[strong(rename_to = this)]
+                self,
+                move |_x| println!("v: {this:?}")
+            );
             closure(0i8); // to prevent compiler error for unknown `x` type.
-            let _ = clone!(@strong self as this => move || println!("v: {this:?}"));
+            let _ = clone!(
+                #[strong(rename_to = this)]
+                self,
+                move || println!("v: {this:?}")
+            );
 
             // Fields now!
-            let closure = clone!(@strong self.v as v => move |_x| {
-                println!("v: {v:?}");
-            });
+            let closure = clone!(
+                #[strong(rename_to = v)]
+                self.v,
+                move |_x| {
+                    println!("v: {v:?}");
+                }
+            );
             closure(0i8); // to prevent compiler error for unknown `x` type.
-            let _ = clone!(@strong self.v as v => move || println!("v: {v:?}"));
-
-            // With @default-panic
-            let closure = clone!(@strong self.v as v => @default-panic, move |_x| {
-                println!("v: {v:?}");
-            });
-            closure(0i8); // to prevent compiler error for unknown `x` type.
-            let _ = clone!(@strong self.v as v => @default-panic, move || println!("v: {v:?}"));
-
-            // With @default-return
-            let closure = clone!(@strong self.v as _v => @default-return true, move |_x| {
-                false
-            });
-            closure(0i8); // to prevent compiler error for unknown `x` type.
-            let _ = clone!(@strong self.v as _v => @default-return true, move || false);
+            let _ = clone!(
+                #[strong(rename_to = v)]
+                self.v,
+                move || println!("v: {v:?}")
+            );
         }
     }
 }
@@ -222,78 +273,182 @@ fn test_clone_macro_self_rename() {
 fn test_clone_macro_rename() {
     let v = Rc::new(1);
 
-    let closure = clone!(@weak v as y => @default-panic, move |_x| {
-        println!("v: {y}");
-    });
+    let closure = clone!(
+        #[weak(rename_to = y)]
+        v,
+        #[upgrade_or_panic]
+        move |_x| {
+            println!("v: {y}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v as y => @default-panic, move || println!("v: {y}"));
+    let _ = clone!(
+        #[weak(rename_to = y)]
+        v,
+        #[upgrade_or_panic]
+        move || println!("v: {y}")
+    );
 
-    let closure = clone!(@strong v as y => @default-panic, move |_x| {
-        println!("v: {y}");
-    });
+    let closure = clone!(
+        #[strong(rename_to = y)]
+        v,
+        move |_x| {
+            println!("v: {y}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v as y => @default-panic, move || println!("v: {y}"));
+    let _ = clone!(
+        #[strong(rename_to = y)]
+        v,
+        move || println!("v: {y}")
+    );
 
-    let closure = clone!(@weak v as y => move |_x| {
-        println!("v: {y}");
-    });
+    let closure = clone!(
+        #[weak(rename_to = y)]
+        v,
+        move |_x| {
+            println!("v: {y}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v as y => move || println!("v: {y}"));
+    let _ = clone!(
+        #[weak(rename_to = y)]
+        v,
+        move || println!("v: {y}")
+    );
 
-    let closure = clone!(@strong v as y => move |_x| {
-        println!("v: {y}");
-    });
+    let closure = clone!(
+        #[strong(rename_to = y)]
+        v,
+        move |_x| {
+            println!("v: {y}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v as y => move || println!("v: {y}"));
+    let _ = clone!(
+        #[strong(rename_to = y)]
+        v,
+        move || println!("v: {y}")
+    );
 
-    let closure = clone!(@weak v as _y => @default-return true, move |_x| {
-        false
-    });
+    let closure = clone!(
+        #[weak(rename_to = y)]
+        v,
+        #[upgrade_or]
+        true,
+        move |_x| false
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v as _y => @default-return true, move || false);
+    let _ = clone!(
+        #[weak(rename_to = y)]
+        v,
+        #[upgrade_or_else]
+        || true,
+        move || false
+    );
 
-    let closure = clone!(@strong v as _y => @default-return true, move |_x| false);
+    let closure = clone!(
+        #[strong(rename_to = y)]
+        v,
+        move |_x| false
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v as _y => @default-return true, move || false);
+    let _ = clone!(
+        #[strong(rename_to = y)]
+        v,
+        move || false
+    );
 }
 
 #[test]
 fn test_clone_macro_simple() {
     let v = Rc::new(1);
 
-    let closure = clone!(@weak v => @default-panic, move |_x| {
-        println!("v: {v}");
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[upgrade_or_panic]
+        move |_x| {
+            println!("v: {v}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v => @default-panic, move || println!("v: {v}"));
+    let _ = clone!(
+        #[weak]
+        v,
+        #[upgrade_or_panic]
+        move || println!("v: {v}")
+    );
 
-    let closure = clone!(@strong v => @default-panic, move |_x| {
-        println!("v: {v}");
-    });
+    let closure = clone!(
+        #[strong]
+        v,
+        move |_x| {
+            println!("v: {v}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v => @default-panic, move || println!("v: {v}"));
+    let _ = clone!(
+        #[strong]
+        v,
+        move || println!("v: {v}")
+    );
 
-    let closure = clone!(@weak v => move |_x| {
-        println!("v: {v}");
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        move |_x| {
+            println!("v: {v}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v => move || println!("v: {v}"));
+    let _ = clone!(
+        #[weak]
+        v,
+        move || println!("v: {v}")
+    );
 
-    let closure = clone!(@strong v => move |_x| {
-        println!("v: {v}");
-    });
+    let closure = clone!(
+        #[strong]
+        v,
+        move |_x| {
+            println!("v: {v}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v => move || println!("v: {v}"));
+    let _ = clone!(
+        #[strong]
+        v,
+        move || println!("v: {v}")
+    );
 
-    let closure = clone!(@weak v => @default-return true, move |_x| {
-        false
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[upgrade_or]
+        true,
+        move |_x| false
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v => @default-return true, move || false);
+    let _ = clone!(
+        #[weak]
+        v,
+        #[upgrade_or_else]
+        || true,
+        move || false
+    );
 
-    let closure = clone!(@strong v => @default-return true, move |_x| false);
+    let closure = clone!(
+        #[strong]
+        v,
+        move |_x| false
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v => @default-return true, move || false);
+    let _ = clone!(
+        #[strong]
+        v,
+        move || false
+    );
 }
 
 #[test]
@@ -301,39 +456,115 @@ fn test_clone_macro_double_simple() {
     let v = Rc::new(1);
     let w = Rc::new(2);
 
-    let closure = clone!(@weak v, @weak w => @default-panic, move |_x| {
-        println!("v: {v}, w: {w}");
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or_panic]
+        move |_x| {
+            println!("v: {v}, w: {w}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v, @weak w => @default-panic, move || println!("v: {v}, w: {w}"));
+    let _ = clone!(
+        #[weak]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or_panic]
+        move || println!("v: {v}, w: {w}")
+    );
 
-    let closure = clone!(@strong v, @strong w => @default-panic, move |_x| {
-        println!("v: {v}, w: {w}");
-    });
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong]
+        w,
+        move |_x| {
+            println!("v: {v}, w: {w}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v, @strong w => @default-panic, move || println!("v: {v}, w: {w}"));
+    let _ = clone!(
+        #[strong]
+        v,
+        #[strong]
+        w,
+        move || println!("v: {v}, w: {w}")
+    );
 
-    let closure = clone!(@weak v, @weak w => move |_x| {
-        println!("v: {v}, w: {w}");
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak]
+        w,
+        move |_x| {
+            println!("v: {v}, w: {w}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v, @weak w => move || println!("v: {v}, w: {w}"));
+    let _ = clone!(
+        #[weak]
+        v,
+        #[weak]
+        w,
+        move || println!("v: {v}, w: {w}")
+    );
 
-    let closure = clone!(@strong v, @strong w => move |_x| {
-        println!("v: {v}, w: {w}");
-    });
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong]
+        w,
+        move |_x| {
+            println!("v: {v}, w: {w}");
+        }
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v, @strong w => move || println!("v: {v}, w: {w}"));
+    let _ = clone!(
+        #[strong]
+        v,
+        #[strong]
+        w,
+        move || println!("v: {v}, w: {w}")
+    );
 
-    let closure = clone!(@weak v, @weak w => @default-return true, move |_x| {
-        false
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or]
+        true,
+        move |_x| false
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@weak v, @weak w => @default-return true, move || false);
+    let _ = clone!(
+        #[weak]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or_else]
+        || true,
+        move || false
+    );
 
-    let closure = clone!(@strong v, @strong w => @default-return true, move |_x| false);
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong]
+        w,
+        move |_x| false
+    );
     closure(0i8); // to prevent compiler error for unknown `x` type.
-    let _ = clone!(@strong v, @strong w => @default-return true, move || false);
+    let _ = clone!(
+        #[strong]
+        v,
+        #[strong]
+        w,
+        move || false
+    );
 }
 
 #[test]
@@ -342,104 +573,253 @@ fn test_clone_macro_double_rename() {
     let w = Rc::new(2);
     let done = Rc::new(RefCell::new(0));
 
-    let closure = clone!(@weak v as x, @weak w => @default-panic, move |z| {
-        z + *x + *w
-    });
+    let closure = clone!(
+        #[weak(rename_to = x)]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or_panic]
+        move |z| z + *x + *w
+    );
     assert_eq!(closure(1i8), 4i8);
-    let closure = clone!(@weak v as x, @weak w => @default-panic, move || 1);
+    let closure = clone!(
+        #[weak(rename_to = x)]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or_panic]
+        move || 1
+    );
     assert_eq!(closure(), 1);
 
-    let closure = clone!(@weak v, @weak w as x => @default-panic, move |z| {
-        z + *v + *x
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        #[upgrade_or_panic]
+        move |z| z + *v + *x
+    );
     assert_eq!(closure(10i8), 13i8);
-    let closure = clone!(@weak v, @weak w as x => @default-panic, move || 2 + *x);
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        #[upgrade_or_panic]
+        move || 2 + *x
+    );
     assert_eq!(closure(), 4);
 
-    let closure = clone!(@strong v as x, @strong w => @default-panic, move |z| {
-        z + *x + *w
-    });
+    let closure = clone!(
+        #[strong(rename_to = x)]
+        v,
+        #[strong]
+        w,
+        move |z| z + *x + *w
+    );
     assert_eq!(closure(3i8), 6i8);
-    let closure = clone!(@strong v as x, @strong w => @default-panic, move || 4 + *w);
+    let closure = clone!(
+        #[strong(rename_to = x)]
+        v,
+        #[strong]
+        w,
+        move || 4 + *w
+    );
     assert_eq!(closure(), 6);
 
-    let closure = clone!(@strong v, @strong w as x => @default-panic, move |z| {
-        z + *v + *x
-    });
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong(rename_to = x)]
+        w,
+        move |z| z + *v + *x
+    );
     assert_eq!(closure(0i8), 3i8);
-    let closure = clone!(@strong v, @strong w as x => @default-panic, move || 5);
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong(rename_to = x)]
+        w,
+        move || 5
+    );
     assert_eq!(closure(), 5);
 
     let t_done = done.clone();
-    let closure = clone!(@weak v as x, @weak w => move |z| {
-        *t_done.borrow_mut() = z + *x + *w;
-    });
+    let closure = clone!(
+        #[weak(rename_to = x)]
+        v,
+        #[weak]
+        w,
+        move |z| {
+            *t_done.borrow_mut() = z + *x + *w;
+        }
+    );
     closure(4i8);
     assert_eq!(*done.borrow(), 7);
     let t_done = done.clone();
-    let closure = clone!(@weak v as x, @weak w => move || *t_done.borrow_mut() = *x + *w);
+    let closure = clone!(
+        #[weak(rename_to = x)]
+        v,
+        #[weak]
+        w,
+        move || *t_done.borrow_mut() = *x + *w
+    );
     closure();
     assert_eq!(*done.borrow(), 3);
 
     let t_done = done.clone();
-    let closure = clone!(@weak v, @weak w as x => move |z| {
-        *t_done.borrow_mut() = z + *v + *x;
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        move |z| {
+            *t_done.borrow_mut() = z + *v + *x;
+        }
+    );
     closure(8i8);
     assert_eq!(*done.borrow(), 11i8);
     let t_done = done.clone();
-    let closure = clone!(@weak v, @weak w as x => move || *t_done.borrow_mut() = *v * *x);
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        move || *t_done.borrow_mut() = *v * *x
+    );
     closure();
     assert_eq!(*done.borrow(), 2);
 
     let t_done = done.clone();
-    let closure = clone!(@strong v as x, @strong w => move |z| {
-        *t_done.borrow_mut() = z + *x + *w;
-    });
+    let closure = clone!(
+        #[strong(rename_to = x)]
+        v,
+        #[strong]
+        w,
+        move |z| {
+            *t_done.borrow_mut() = z + *x + *w;
+        }
+    );
     closure(9i8);
     assert_eq!(*done.borrow(), 12i8);
     let t_done = done.clone();
-    let closure = clone!(@strong v as x, @strong w => move || *t_done.borrow_mut() = *x - *w);
+    let closure = clone!(
+        #[strong(rename_to = x)]
+        v,
+        #[strong]
+        w,
+        move || *t_done.borrow_mut() = *x - *w
+    );
     closure();
     assert_eq!(*done.borrow(), -1);
 
     let t_done = done.clone();
-    let closure = clone!(@strong v, @strong w as x => move |z| {
-        *t_done.borrow_mut() = *v + *x * z;
-    });
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong(rename_to = x)]
+        w,
+        move |z| {
+            *t_done.borrow_mut() = *v + *x * z;
+        }
+    );
     closure(2i8);
     assert_eq!(*done.borrow(), 5);
     let t_done = done.clone();
-    let closure = clone!(@strong v, @strong w as x => move || *t_done.borrow_mut() = *x - *v);
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong(rename_to = x)]
+        w,
+        move || *t_done.borrow_mut() = *x - *v
+    );
     closure();
     assert_eq!(*done.borrow(), 1);
 
-    let closure = clone!(@weak v as _x, @weak w => @default-return true, move |_| {
-        false
-    });
+    let closure = clone!(
+        #[weak(rename_to = x)]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or]
+        true,
+        move |_| false
+    );
     assert!(!closure(0u8));
-    let closure = clone!(@weak v as _x, @weak w => @default-return true, move || false);
+    let closure = clone!(
+        #[weak(rename_to = x)]
+        v,
+        #[weak]
+        w,
+        #[upgrade_or_else]
+        || true,
+        move || false
+    );
     assert!(!closure());
 
-    let closure = clone!(@weak v, @weak w as _x => @default-return true, move |_| {
-        false
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        #[upgrade_or]
+        true,
+        move |_| false
+    );
     assert!(!closure("a"));
-    let closure = clone!(@weak v, @weak w as _x => @default-return true, move || false);
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        #[upgrade_or_else]
+        || true,
+        move || false
+    );
     assert!(!closure());
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        #[upgrade_or_default]
+        move || true
+    );
+    assert!(closure());
 
-    let closure = clone!(@strong v as _x, @strong w => @default-return true, move |_| {
-        false
-    });
+    let closure = clone!(
+        #[strong(rename_to = x)]
+        v,
+        #[strong]
+        w,
+        move |_| false
+    );
     assert!(!closure('a'));
-    let closure = clone!(@strong v as _x, @strong w => @default-return true, move || false);
+    let closure = clone!(
+        #[strong(rename_to = x)]
+        v,
+        #[strong]
+        w,
+        move || false
+    );
     assert!(!closure());
 
-    let closure = clone!(@strong v, @strong w as _x => @default-return true, move |_| {
-        false
-    });
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong(rename_to = x)]
+        w,
+        move |_| false
+    );
     assert!(!closure(12.));
-    let closure = clone!(@strong v, @strong w as _x => @default-return true, move || false);
+    let closure = clone!(
+        #[strong]
+        v,
+        #[strong(rename_to = x)]
+        w,
+        move || false
+    );
     assert!(!closure());
 }
 
@@ -452,21 +832,39 @@ fn test_clone_macro_typed_args() {
             let v = Arc::new(Mutex::new(1));
             let w = Arc::new(Mutex::new(1));
 
-            let closure = clone!(@$kind v as x, @$kind w, @weak check => @default-panic, move |arg: i8| {
-                *x.lock().unwrap() += arg;
-                *w.lock().unwrap() += arg;
-                *check.lock().unwrap() += 1;
-            });
+            let closure = clone!(
+                #[$kind(rename_to = x)]
+                v,
+                #[$kind]
+                w,
+                #[weak]
+                check,
+                #[upgrade_or_panic]
+                move |arg: i8| {
+                    *x.lock().unwrap() += arg;
+                    *w.lock().unwrap() += arg;
+                    *check.lock().unwrap() += 1;
+                }
+            );
             closure(1);
             assert_eq!(2, *v.lock().unwrap());
             assert_eq!(2, *w.lock().unwrap());
             assert_eq!(1, *check.lock().unwrap());
 
-            let closure2 = clone!(@$kind v, @$kind w as x, @weak check => @default-panic, move |arg: i8| {
-                *v.lock().unwrap() += arg;
-                *x.lock().unwrap() += arg;
-                *check.lock().unwrap() += 1;
-            });
+            let closure2 = clone!(
+                #[$kind]
+                v,
+                #[$kind(rename_to = x)]
+                w,
+                #[weak]
+                check,
+                #[upgrade_or_panic]
+                move |arg: i8| {
+                    *v.lock().unwrap() += arg;
+                    *x.lock().unwrap() += arg;
+                    *check.lock().unwrap() += 1;
+                }
+            );
             closure2(1);
             assert_eq!(3, *v.lock().unwrap());
             assert_eq!(3, *w.lock().unwrap());
@@ -482,13 +880,17 @@ fn test_clone_macro_typed_args() {
                     // We use the threads to ensure that the closure panics as expected.
                     assert!(thread::spawn(move || {
                         closure(1);
-                    }).join().is_err());
+                    })
+                    .join()
+                    .is_err());
                     assert_eq!(2, *check.lock().unwrap());
                     assert!(thread::spawn(move || {
                         closure2(1);
-                    }).join().is_err());
+                    })
+                    .join()
+                    .is_err());
                     assert_eq!(2, *check.lock().unwrap());
-                }}
+                }};
             }
 
             inner!($kind);
@@ -498,21 +900,37 @@ fn test_clone_macro_typed_args() {
             let v = Rc::new(RefCell::new(1));
             let w = Rc::new(RefCell::new(1));
 
-            let closure = clone!(@$kind v as x, @$kind w, @weak check => move |arg: i8| {
-                *x.borrow_mut() += arg;
-                *w.borrow_mut() += arg;
-                *check.borrow_mut() += 1;
-            });
+            let closure = clone!(
+                #[$kind(rename_to = x)]
+                v,
+                #[$kind]
+                w,
+                #[weak]
+                check,
+                move |arg: i8| {
+                    *x.borrow_mut() += arg;
+                    *w.borrow_mut() += arg;
+                    *check.borrow_mut() += 1;
+                }
+            );
             closure(1);
             assert_eq!(2, *v.borrow());
             assert_eq!(2, *w.borrow());
             assert_eq!(1, *check.borrow());
 
-            let closure2 = clone!(@$kind v, @$kind w as x, @weak check => move |arg: i8| {
-                *v.borrow_mut() += arg;
-                *x.borrow_mut() += arg;
-                *check.borrow_mut() += 1;
-            });
+            let closure2 = clone!(
+                #[$kind]
+                v,
+                #[$kind(rename_to = x)]
+                w,
+                #[weak]
+                check,
+                move |arg: i8| {
+                    *v.borrow_mut() += arg;
+                    *x.borrow_mut() += arg;
+                    *check.borrow_mut() += 1;
+                }
+            );
             closure2(1);
             assert_eq!(3, *v.borrow());
             assert_eq!(3, *w.borrow());
@@ -529,7 +947,7 @@ fn test_clone_macro_typed_args() {
                     assert_eq!(2, *check.borrow());
                     closure2(1);
                     assert_eq!(2, *check.borrow());
-                }}
+                }};
             }
 
             inner!($kind);
@@ -544,11 +962,19 @@ fn test_clone_macro_typed_args() {
     let check = Rc::new(RefCell::new(0));
     let v = Rc::new(RefCell::new(1));
     let w = Rc::new(RefCell::new(1));
-    let closure = clone!(@weak v, @weak w as x, @weak check => move |arg: i8, arg2| {
-        *v.borrow_mut() = arg;
-        *x.borrow_mut() = arg2;
-        *check.borrow_mut() += 1;
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        #[weak(rename_to = x)]
+        w,
+        #[weak]
+        check,
+        move |arg: i8, arg2| {
+            *v.borrow_mut() = arg;
+            *x.borrow_mut() = arg2;
+            *check.borrow_mut() += 1;
+        }
+    );
     closure(0, 9);
     assert_eq!(0, *v.borrow());
     assert_eq!(9, *w.borrow());
@@ -562,11 +988,11 @@ fn test_clone_macro_typed_args() {
 #[test]
 #[allow(clippy::bool_assert_comparison)]
 #[allow(clippy::nonminimal_bool)]
-fn test_clone_macro_default_return() {
+fn test_clone_macro_upgrade_failure() {
     macro_rules! test_default {
         ($ret:expr, $($closure_body:tt)*) => {{
             let v = Rc::new(1);
-            let tmp = clone!(@weak v => @default-return $ret, move || $($closure_body)*);
+            let tmp = clone!(#[weak] v, #[upgrade_or_else] || $ret, move || $($closure_body)*);
             assert_eq!(tmp(), $($closure_body)*, "shouldn't use default-return value!");
             ::std::mem::drop(v);
             assert_eq!(tmp(), $ret, "should use default-return value!");
@@ -609,14 +1035,20 @@ fn test_clone_macro_default_return() {
 fn test_clone_macro_body() {
     let v = Arc::new(Mutex::new(0));
 
-    let closure = clone!(@weak v => move || {
-        std::thread::spawn(move || {
-            let mut lock = v.lock().expect("failed to lock");
-            for _ in 1..=10 {
-                *lock += 1;
-            }
-        }).join().expect("thread::spawn failed");
-    });
+    let closure = clone!(
+        #[weak]
+        v,
+        move || {
+            std::thread::spawn(move || {
+                let mut lock = v.lock().expect("failed to lock");
+                for _ in 1..=10 {
+                    *lock += 1;
+                }
+            })
+            .join()
+            .expect("thread::spawn failed");
+        }
+    );
     closure();
     assert_eq!(10, *v.lock().expect("failed to lock"));
 }
@@ -625,11 +1057,12 @@ fn test_clone_macro_body() {
 fn test_clone_macro_async_kinds() {
     let v = Rc::new(RefCell::new(1));
 
-    // This one is still a rust unstable feature.
-    // let _closure = clone!(@weak v => async move || 0);
-    let closure = clone!(@weak v => move || async move { *v.borrow_mut() += 1; });
-    block_on(closure());
+    block_on(clone!(
+        #[weak]
+        v,
+        async move {
+            *v.borrow_mut() += 1;
+        }
+    ));
     assert_eq!(*v.borrow(), 2);
-    block_on(clone!(@weak v => async move { *v.borrow_mut() += 1; }));
-    assert_eq!(*v.borrow(), 3);
 }

--- a/glib/tests/log.rs
+++ b/glib/tests/log.rs
@@ -36,16 +36,30 @@ fn check_log_handlers() {
     // log_set_default_handler check part
     //
     let count = Arc::new(Mutex::new(Counters::default()));
-    log_set_default_handler(clone!(@weak count => move |_, level, _| {
-        match level {
-            LogLevel::Critical => { count.lock().expect("failed to lock 3").criticals += 1; }
-            LogLevel::Warning => { count.lock().expect("failed to lock 4").warnings += 1; }
-            LogLevel::Message => { count.lock().expect("failed to lock 5").messages += 1; }
-            LogLevel::Info => { count.lock().expect("failed to lock 6").infos += 1; }
-            LogLevel::Debug => { count.lock().expect("failed to lock 7").debugs += 1; }
-            _ => unreachable!(),
+    log_set_default_handler(clone!(
+        #[weak]
+        count,
+        move |_, level, _| {
+            match level {
+                LogLevel::Critical => {
+                    count.lock().expect("failed to lock 3").criticals += 1;
+                }
+                LogLevel::Warning => {
+                    count.lock().expect("failed to lock 4").warnings += 1;
+                }
+                LogLevel::Message => {
+                    count.lock().expect("failed to lock 5").messages += 1;
+                }
+                LogLevel::Info => {
+                    count.lock().expect("failed to lock 6").infos += 1;
+                }
+                LogLevel::Debug => {
+                    count.lock().expect("failed to lock 7").debugs += 1;
+                }
+                _ => unreachable!(),
+            }
         }
-    }));
+    ));
     assert_counts(&count, 0, 0, 0, 0, 0);
     g_warning!(Some("domain"), "hello");
     assert_counts(&count, 0, 1, 0, 0, 0);
@@ -74,13 +88,21 @@ fn check_log_handlers() {
         LogLevels::LEVEL_WARNING | LogLevels::LEVEL_DEBUG,
         false,
         false,
-        clone!(@weak count => move |_, level, _| {
-            match level {
-                LogLevel::Warning => { count.lock().expect("failed to lock 4").warnings += 1; }
-                LogLevel::Debug => { count.lock().expect("failed to lock 7").debugs += 1; }
-                _ => unreachable!(),
+        clone!(
+            #[weak]
+            count,
+            move |_, level, _| {
+                match level {
+                    LogLevel::Warning => {
+                        count.lock().expect("failed to lock 4").warnings += 1;
+                    }
+                    LogLevel::Debug => {
+                        count.lock().expect("failed to lock 7").debugs += 1;
+                    }
+                    _ => unreachable!(),
+                }
             }
-        }),
+        ),
     );
     assert_counts(&count, 0, 0, 0, 0, 0);
     g_warning!(Some("domain"), "hello");

--- a/glib/tests/print.rs
+++ b/glib/tests/print.rs
@@ -11,10 +11,14 @@ fn check_print_handler() {
     // g_print check part
     //
     let count = Arc::new(Mutex::new(0));
-    set_print_handler(clone!(@weak count => move |_| {
-        // we don't care about the message in here!
-        *count.lock().expect("failed to lock 1") += 1;
-    }));
+    set_print_handler(clone!(
+        #[weak]
+        count,
+        move |_| {
+            // we don't care about the message in here!
+            *count.lock().expect("failed to lock 1") += 1;
+        }
+    ));
     g_print!("test");
     assert_eq!(*count.lock().expect("failed to lock 2"), 1);
     g_printerr!("one");
@@ -31,10 +35,14 @@ fn check_print_handler() {
     // g_printerr check part
     //
     let count = Arc::new(Mutex::new(0));
-    set_printerr_handler(clone!(@weak count => move |_| {
-        // we don't care about the message in here!
-        *count.lock().expect("failed to lock a") += 1;
-    }));
+    set_printerr_handler(clone!(
+        #[weak]
+        count,
+        move |_| {
+            // we don't care about the message in here!
+            *count.lock().expect("failed to lock a") += 1;
+        }
+    ));
     g_printerr!("test");
     assert_eq!(*count.lock().expect("failed to lock b"), 1);
     g_print!("one");


### PR DESCRIPTION
This works correctly with rustfmt now, and thanks to using syn correctly also gives much better user experience with rust-analyzer.

Also the `closure!` macro now supports plain weak references too.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1394