### PR TITLE
ci: bump gvsbuild

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       # git revision of gvsbuild we use for to build GLib and the other dependencies
-      gvsbuildref: 876d21a1ecd8db1398b1dba263efee1bc3befad8
+      gvsbuildref: bb1d2691d25c7bb1239118a907c8e21b1aa24e03
 
       # bump this number if you want to force a rebuild of gvsbuild with the same revision
       gvsbuildupdate: 1


### PR DESCRIPTION
I think we are still using a pre-release version of glib... Update to the latest version.