### PR TITLE
glib-macros: Don't produce unnecessary braces in `clone!(async move {…

### DIFF
--- a/glib-macros/src/clone.rs
+++ b/glib-macros/src/clone.rs
@@ -524,6 +524,11 @@ impl ToTokens for Clone {
                     block,
                 } = a;
 
+                // Directly output the statements instead of the whole block including braces as we
+                // already produce a block with braces below and otherwise a compiler warning about
+                // unnecessary braces is wrongly emitted.
+                let stmts = &block.stmts;
+
                 quote! {
                     #(#attrs)*
                     #async_token
@@ -531,7 +536,7 @@ impl ToTokens for Clone {
                     {
                         #upgrade_failure_closure
                         #(#inner_before)*
-                        #block
+                        #(#stmts)*
                     }
                 }
             }


### PR DESCRIPTION
… x })`

This would wrongly suggest to remove the braces, which is invalid syntax, because the macro already adds another layer of braces around the body of the async block.

To avoid this, don't output the braces of the async block in the macro expansion and instead only use the braces added by the macro.