### PR TITLE
glib: Add support for registering GTypes with name conflicts

### DIFF
--- a/gio/src/read_input_stream.rs
+++ b/gio/src/read_input_stream.rs
@@ -25,6 +25,7 @@ mod imp {
     #[glib::object_subclass]
     impl ObjectSubclass for ReadInputStream {
         const NAME: &'static str = "ReadInputStream";
+        const ALLOW_NAME_CONFLICT: bool = true;
         type Type = super::ReadInputStream;
         type ParentType = InputStream;
         type Interfaces = (crate::Seekable,);

--- a/gio/src/write_output_stream.rs
+++ b/gio/src/write_output_stream.rs
@@ -27,6 +27,7 @@ mod imp {
     #[glib::object_subclass]
     impl ObjectSubclass for WriteOutputStream {
         const NAME: &'static str = "WriteOutputStream";
+        const ALLOW_NAME_CONFLICT: bool = true;
         type Type = super::WriteOutputStream;
         type ParentType = OutputStream;
         type Interfaces = (crate::Seekable,);

--- a/glib/src/boxed_any_object.rs
+++ b/glib/src/boxed_any_object.rs
@@ -37,6 +37,7 @@ mod imp {
     #[glib::object_subclass]
     impl ObjectSubclass for BoxedAnyObject {
         const NAME: &'static str = "BoxedAnyObject";
+        const ALLOW_NAME_CONFLICT: bool = true;
         type Type = super::BoxedAnyObject;
     }
     impl Default for BoxedAnyObject {

--- a/glib/src/subclass/boxed.rs
+++ b/glib/src/subclass/boxed.rs
@@ -20,6 +20,21 @@ pub trait BoxedType: StaticType + Clone + Sized + 'static {
     ///
     /// This must be unique in the whole process.
     const NAME: &'static str;
+
+    // rustdoc-stripper-ignore-next
+    /// Allow name conflicts for this boxed type.
+    ///
+    /// By default, trying to register a type with a name that was registered before will panic. If
+    /// this is set to `true` then a new name will be selected by appending a counter.
+    ///
+    /// This is useful for defining new types in Rust library crates that might be linked multiple
+    /// times in the same process.
+    ///
+    /// A consequence of setting this to `true` is that it's not guaranteed that
+    /// `glib::Type::from_name(Self::NAME).unwrap() == Self::static_type()`.
+    ///
+    /// Optional.
+    const ALLOW_NAME_CONFLICT: bool = false;
 }
 
 // rustdoc-stripper-ignore-next
@@ -45,13 +60,32 @@ pub fn register_boxed_type<T: BoxedType>() -> crate::Type {
     unsafe {
         use std::ffi::CString;
 
-        let type_name = CString::new(T::NAME).unwrap();
-        assert_eq!(
-            gobject_ffi::g_type_from_name(type_name.as_ptr()),
-            gobject_ffi::G_TYPE_INVALID,
-            "Type {} has already been registered",
-            type_name.to_str().unwrap()
-        );
+        let type_name = if T::ALLOW_NAME_CONFLICT {
+            let mut i = 0;
+            loop {
+                let type_name = CString::new(if i == 0 {
+                    T::NAME.to_string()
+                } else {
+                    format!("{}-{}", T::NAME, i)
+                })
+                .unwrap();
+                if gobject_ffi::g_type_from_name(type_name.as_ptr()) == gobject_ffi::G_TYPE_INVALID
+                {
+                    break type_name;
+                }
+                i += 1;
+            }
+        } else {
+            let type_name = CString::new(T::NAME).unwrap();
+            assert_eq!(
+                gobject_ffi::g_type_from_name(type_name.as_ptr()),
+                gobject_ffi::G_TYPE_INVALID,
+                "Type {} has already been registered",
+                type_name.to_str().unwrap()
+            );
+
+            type_name
+        };
 
         let type_ = crate::Type::from_glib(gobject_ffi::g_boxed_type_register_static(
             type_name.as_ptr(),

--- a/glib/src/subclass/shared.rs
+++ b/glib/src/subclass/shared.rs
@@ -101,6 +101,21 @@ pub trait SharedType: StaticType + Clone + Sized + 'static {
     const NAME: &'static str;
 
     // rustdoc-stripper-ignore-next
+    /// Allow name conflicts for this boxed type.
+    ///
+    /// By default, trying to register a type with a name that was registered before will panic. If
+    /// this is set to `true` then a new name will be selected by appending a counter.
+    ///
+    /// This is useful for defining new types in Rust library crates that might be linked multiple
+    /// times in the same process.
+    ///
+    /// A consequence of setting this to `true` is that it's not guaranteed that
+    /// `glib::Type::from_name(Self::NAME).unwrap() == Self::static_type()`.
+    ///
+    /// Optional.
+    const ALLOW_NAME_CONFLICT: bool = false;
+
+    // rustdoc-stripper-ignore-next
     /// The inner refcounted type
     type RefCountedType: RefCounted;
 
@@ -135,13 +150,32 @@ pub fn register_shared_type<T: SharedType>() -> crate::Type {
             );
         }
 
-        let type_name = CString::new(T::NAME).unwrap();
-        assert_eq!(
-            gobject_ffi::g_type_from_name(type_name.as_ptr()),
-            gobject_ffi::G_TYPE_INVALID,
-            "Type {} has already been registered",
-            type_name.to_str().unwrap()
-        );
+        let type_name = if T::ALLOW_NAME_CONFLICT {
+            let mut i = 0;
+            loop {
+                let type_name = CString::new(if i == 0 {
+                    T::NAME.to_string()
+                } else {
+                    format!("{}-{}", T::NAME, i)
+                })
+                .unwrap();
+                if gobject_ffi::g_type_from_name(type_name.as_ptr()) == gobject_ffi::G_TYPE_INVALID
+                {
+                    break type_name;
+                }
+                i += 1;
+            }
+        } else {
+            let type_name = CString::new(T::NAME).unwrap();
+            assert_eq!(
+                gobject_ffi::g_type_from_name(type_name.as_ptr()),
+                gobject_ffi::G_TYPE_INVALID,
+                "Type {} has already been registered",
+                type_name.to_str().unwrap()
+            );
+
+            type_name
+        };
 
         let type_ = crate::Type::from_glib(gobject_ffi::g_boxed_type_register_static(
             type_name.as_ptr(),

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -617,6 +617,24 @@ pub trait ObjectSubclass: ObjectSubclassType + Sized + 'static {
     const ABSTRACT: bool = false;
 
     // rustdoc-stripper-ignore-next
+    /// Allow name conflicts for this class.
+    ///
+    /// By default, trying to register a type with a name that was registered before will panic. If
+    /// this is set to `true` then a new name will be selected by appending a counter.
+    ///
+    /// This is useful for defining new types in Rust library crates that might be linked multiple
+    /// times in the same process.
+    ///
+    /// A consequence of setting this to `true` is that it's not guaranteed that
+    /// `glib::Type::from_name(Self::NAME).unwrap() == Self::type_()`.
+    ///
+    /// Note that this is not allowed for dynamic types. If a dynamic type is registered and a type
+    /// with that name exists already, it is assumed that they're the same.
+    ///
+    /// Optional.
+    const ALLOW_NAME_CONFLICT: bool = false;
+
+    // rustdoc-stripper-ignore-next
     /// Wrapper around this subclass defined with `wrapper!`
     type Type: ObjectType
         + ObjectSubclassIs<Subclass = Self>
@@ -1013,13 +1031,32 @@ pub fn register_type<T: ObjectSubclass>() -> Type {
     unsafe {
         use std::ffi::CString;
 
-        let type_name = CString::new(T::NAME).unwrap();
-        assert_eq!(
-            gobject_ffi::g_type_from_name(type_name.as_ptr()),
-            gobject_ffi::G_TYPE_INVALID,
-            "Type {} has already been registered",
-            type_name.to_str().unwrap()
-        );
+        let type_name = if T::ALLOW_NAME_CONFLICT {
+            let mut i = 0;
+            loop {
+                let type_name = CString::new(if i == 0 {
+                    T::NAME.to_string()
+                } else {
+                    format!("{}-{}", T::NAME, i)
+                })
+                .unwrap();
+                if gobject_ffi::g_type_from_name(type_name.as_ptr()) == gobject_ffi::G_TYPE_INVALID
+                {
+                    break type_name;
+                }
+                i += 1;
+            }
+        } else {
+            let type_name = CString::new(T::NAME).unwrap();
+            assert_eq!(
+                gobject_ffi::g_type_from_name(type_name.as_ptr()),
+                gobject_ffi::G_TYPE_INVALID,
+                "Type {} has already been registered",
+                type_name.to_str().unwrap()
+            );
+
+            type_name
+        };
 
         let type_ = Type::from_glib(gobject_ffi::g_type_register_static_simple(
             <T::ParentType as StaticType>::static_type().into_glib(),


### PR DESCRIPTION
When explicitly allowed when defining the type, a GType name conflict wouldn't cause a panic anymore but instead a new name is found by appending a counter to the given name.

This is useful if multiple definitions of the same type can end up in the same process.

Also use this for `glib::BoxedAnyObject`, `gio::WriteOutputStream` and `gio::ReadInputStream`.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1430