### PR TITLE
gio: Add a method to get a stream of incoming connections to SocketListener

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -118,7 +118,6 @@ generate = [
     "Gio.SocketConnectable",
     "Gio.SocketConnection",
     "Gio.SocketFamily",
-    "Gio.SocketListener",
     "Gio.SocketListenerEvent",
     "Gio.SocketProtocol",
     "Gio.SocketService",
@@ -1332,6 +1331,11 @@ manual_traits = ["SocketControlMessageExtManual"]
     # writes to a void pointer
     manual = true
     doc_trait_name = "SocketControlMessageExtManual"
+
+[[object]]
+name = "Gio.SocketListener"
+status = "generate"
+manual_traits = ["SocketListenerExtManual"]
 
 [[object]]
 name = "Gio.Subprocess"

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -82,6 +82,7 @@ mod simple_proxy_resolver;
 mod socket;
 pub use socket::{InputMessage, InputVector, OutputMessage, OutputVector, SocketControlMessages};
 mod socket_control_message;
+mod socket_listener;
 mod socket_msg_flags;
 pub use socket_msg_flags::SocketMsgFlags;
 mod subprocess;

--- a/gio/src/prelude.rs
+++ b/gio/src/prelude.rs
@@ -41,5 +41,6 @@ pub use crate::{
     output_stream::OutputStreamExtManual, pollable_input_stream::PollableInputStreamExtManual,
     pollable_output_stream::PollableOutputStreamExtManual, settings::SettingsExtManual,
     simple_proxy_resolver::SimpleProxyResolverExtManual, socket::SocketExtManual,
-    socket_control_message::SocketControlMessageExtManual, tls_connection::TlsConnectionExtManual,
+    socket_control_message::SocketControlMessageExtManual,
+    socket_listener::SocketListenerExtManual, tls_connection::TlsConnectionExtManual,
 };

--- a/gio/src/socket_listener.rs
+++ b/gio/src/socket_listener.rs
@@ -1,0 +1,56 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use std::{pin::Pin, task::ready};
+
+use futures_core::{
+    stream::Stream,
+    task::{Context, Poll},
+    Future,
+};
+
+use crate::{prelude::SocketListenerExt, SocketConnection, SocketListener};
+use glib::{prelude::*, Error, Object};
+
+pub struct Incoming {
+    listener: SocketListener,
+    fut: Option<Pin<Box<dyn Future<Output = Result<(SocketConnection, Option<Object>), Error>>>>>,
+}
+
+impl Stream for Incoming {
+    type Item = Result<(SocketConnection, Option<Object>), Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.fut.is_none() {
+            self.fut = Some(self.listener.accept_future());
+        }
+
+        let fut = self.fut.as_mut().unwrap();
+        let res = ready!(Pin::new(fut).poll(ctx));
+        self.fut.take();
+
+        Poll::Ready(Some(res))
+    }
+}
+
+pub trait SocketListenerExtManual: SocketListenerExt {
+    // rustdoc-stripper-ignore-next
+    /// Returns a stream of incoming connections
+    ///
+    /// Iterating over this stream is equivalent to calling [`SocketListenerExt::accept_future`] in a
+    /// loop. The stream of connections is infinite, i.e awaiting the next
+    /// connection will never result in [`None`].
+    fn incoming(
+        &self,
+    ) -> Pin<Box<dyn Stream<Item = Result<(SocketConnection, Option<Object>), Error>>>>;
+}
+
+impl<O: IsA<SocketListener>> SocketListenerExtManual for O {
+    fn incoming(
+        &self,
+    ) -> Pin<Box<dyn Stream<Item = Result<(SocketConnection, Option<Object>), Error>>>> {
+        Box::pin(Incoming {
+            listener: self.as_ref().clone(),
+            fut: None,
+        })
+    }
+}


### PR DESCRIPTION
This object provides a `Stream` over which we can iterate in order to accept connections in an async environment.

This is analogous to the one provided by async-std's `TcpListener`.

This is an attempt at #1064. As I mention there, I think `SocketService` is the wrong abstraction to use in async so this is implemented for `SocketListener`, so that this `incoming()` is by itself an alternative to `SocketService`.

The type that we return here feels pretty awkward but it's what this returns. The pattern with the source object feels like another instance of something that makes sense without easy async but with async Rust you'd create multiple objects? But maybe I don't see other use-cases for it here.