### PR TITLE
glib-sys: Fix value of `G_VARIANT_TYPE_BYTE_STRING_ARRAY`

### DIFF
--- a/glib/sys/src/manual.rs
+++ b/glib/sys/src/manual.rs
@@ -69,7 +69,7 @@ pub const G_VARIANT_TYPE_DICTIONARY: &str = "a{?*}";
 pub const G_VARIANT_TYPE_STRING_ARRAY: &str = "as";
 pub const G_VARIANT_TYPE_OBJECT_PATH_ARRAY: &str = "ao";
 pub const G_VARIANT_TYPE_BYTE_STRING: &str = "ay";
-pub const G_VARIANT_TYPE_BYTE_STRING_ARRAY: &str = "ayy";
+pub const G_VARIANT_TYPE_BYTE_STRING_ARRAY: &str = "aay";
 pub const G_VARIANT_TYPE_VARDICT: &str = "a{sv}";
 
 #[cfg(target_family = "windows")]


### PR DESCRIPTION
`G_VARIANT_TYPE_BYTE_STRING_ARRAY` is `"aay"` (`[[u8]]`), not `"ayy"` (`[u8]` + stray string `"y"`).

https://gitlab.gnome.org/GNOME/glib/-/blob/593b88bf1f21ee5fd261b84bf639ef1fa17f7a35/glib/gvarianttype.h#L249-254