### PR TITLE
Copy docs to getter in Properties macro

### DIFF
--- a/examples/object_subclass/author.rs
+++ b/examples/object_subclass/author.rs
@@ -14,7 +14,12 @@ mod imp {
     #[derive(Properties, Default)]
     #[properties(wrapper_type = super::Author)]
     pub struct Author {
+        /// The name of the author
+        ///
+        /// Just their given name, not their surname.
         #[property(get, set)]
+        /// A helpful name-surname combination.
+        #[property(name = "name-surname", get = |author: &Self| format!("{} {}", author.name.borrow(), author.surname.borrow()))]
         name: RefCell<String>,
         #[property(get, set)]
         surname: RefCell<String>,

--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -1367,6 +1367,10 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 /// * `connect_$property_notify()`
 /// * `notify_$property()`
 ///
+/// # Documentation
+///
+/// Doc comments preceding a `#[property]` attribute will be copied to the generated getter method.
+///
 /// ## Extension trait
 /// You can choose to move the method definitions to a trait by using `#[properties(wrapper_type = super::MyType, ext_trait = MyTypePropertiesExt)]`.
 /// The trait name is optional, and defaults to `MyTypePropertiesExt`, where `MyType` is extracted from the wrapper type.
@@ -1430,7 +1434,9 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 ///     pub struct Foo {
 ///         #[property(get, set = Self::set_fizz)]
 ///         fizz: RefCell<String>,
+///         /// The author's name
 ///         #[property(name = "author-name", get, set, type = String, member = name)]
+///         /// The author's childhood nickname
 ///         #[property(name = "author-nick", get, set, type = String, member = nick)]
 ///         author: RefCell<Author>,
 ///         #[property(get, set, explicit_notify, lax_validation)]


### PR DESCRIPTION
Spurred by #1236 though there's probably more we can do here.

The change here is that we take anything that's a doc before a `#[property]` and consider that to be the docs for the getter, as it seems like the getter and the property would be the most likely to share doc comments.

There is of course an open question of what one could do to get docs for the setter that aren't a pain to write, but at least for the setter we can make something that, I think, makes intuitive sense.

The big issue here is that you wouldn't get docs copied over if you add a doc to the field but after the `#[property]`. This is probably something we could allow, but I don't know how important it would be.