### PR TITLE
glib: Ensure NULL terminator is present after creating allocation in `{StrV,PtrSlice}::reserve`

### DIFF
--- a/glib/src/collections/ptr_slice.rs
+++ b/glib/src/collections/ptr_slice.rs
@@ -718,6 +718,12 @@ impl<T: TransparentPtrType> PtrSlice<T> {
             let new_ptr =
                 ffi::g_realloc(ptr, mem::size_of::<T>().checked_mul(new_capacity).unwrap())
                     as *mut <T as GlibPtrDefault>::GlibType;
+            if self.capacity == 0 {
+                ptr::write(
+                    new_ptr,
+                    Ptr::from(ptr::null_mut::<<T as GlibPtrDefault>::GlibType>()),
+                );
+            }
             self.ptr = ptr::NonNull::new_unchecked(new_ptr);
             self.capacity = new_capacity;
         }

--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -714,6 +714,9 @@ impl StrV {
                     .checked_mul(new_capacity)
                     .unwrap(),
             ) as *mut *mut c_char;
+            if self.capacity == 0 {
+                *new_ptr = ptr::null_mut();
+            }
             self.ptr = ptr::NonNull::new_unchecked(new_ptr);
             self.capacity = new_capacity;
         }


### PR DESCRIPTION
After creating a new memory allocation, [`StrV::reserve`](https://gtk-rs.org/gtk-rs-core/stable/0.20/docs/glib/collections/strv/struct.StrV.html#method.reserve) didn't properly null-terminate the underlying array. This could cause an undefined behavior in `g_strfreev` if the `StrV` was immediately dropped.