### PR TITLE
glib: Add `ObjectInterface::Instance` for symmetry with `ObjectSubcla…

### DIFF
--- a/examples/virtual_methods/purrable.rs
+++ b/examples/virtual_methods/purrable.rs
@@ -43,6 +43,7 @@ mod iface {
     impl ObjectInterface for Purrable {
         const NAME: &'static str = "Purrable";
 
+        type Instance = super::ffi::Instance;
         type Interface = super::ffi::Interface;
 
         /// Initialize the class struct with the default implementations of the

--- a/glib-macros/src/object_impl_attributes/interface.rs
+++ b/glib-macros/src/object_impl_attributes/interface.rs
@@ -32,11 +32,14 @@ pub fn impl_object_interface(input: super::Input) -> TokenStream {
     };
 
     let mut has_prerequisites = false;
+    let mut has_instance = false;
     for item in items.iter() {
         if let syn::ImplItem::Type(type_) = item {
             let name = type_.ident.to_string();
             if name == "Prerequisites" {
                 has_prerequisites = true;
+            } else if name == "Instance" {
+                has_instance = true;
             }
         }
     }
@@ -49,10 +52,19 @@ pub fn impl_object_interface(input: super::Input) -> TokenStream {
         ))
     };
 
+    let instance_opt = if has_instance {
+        None
+    } else {
+        Some(quote!(
+            type Instance = ::std::ffi::c_void;
+        ))
+    };
+
     quote! {
         #(#attrs)*
         #unsafety impl #generics #trait_path for #self_ty {
             #prerequisites_opt
+            #instance_opt
             #(#items)*
         }
 

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -1322,7 +1322,7 @@ macro_rules! glib_object_wrapper {
     (@object_interface [$($attr:meta)*] $visibility:vis $name:ident $(<$($generic:ident $(: $bound:tt $(+ $bound2:tt)*)?),+>)?, $iface:ty,
     @type_ $get_type_expr:expr, @requires [$($requires:tt)*]) => {
        $crate::glib_object_wrapper!(
-           @interface [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, $iface, std::os::raw::c_void,
+           @interface [$($attr)*] $visibility $name $(<$($generic $(: $bound $(+ $bound2)*)?),+>)?, $iface, <$iface as $crate::subclass::interface::ObjectInterface>::Instance,
            @ffi_class  <$iface as $crate::subclass::interface::ObjectInterface>::Interface,
            @type_ $get_type_expr, @requires [$($requires)*]
        );

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -212,6 +212,8 @@ unsafe extern "C" fn interface_init<T: ObjectInterface>(
 ///
 /// [`object_interface!`]: ../../macro.object_interface.html
 pub fn register_interface<T: ObjectInterface>() -> Type {
+    assert_eq!(mem::size_of::<T>(), 0);
+
     unsafe {
         use std::ffi::CString;
 
@@ -284,6 +286,8 @@ pub fn register_interface<T: ObjectInterface>() -> Type {
 pub fn register_dynamic_interface<P: DynamicObjectRegisterExt, T: ObjectInterface>(
     type_plugin: &P,
 ) -> Type {
+    assert_eq!(mem::size_of::<T>(), 0);
+
     unsafe {
         use std::ffi::CString;
 

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -110,6 +110,13 @@ pub trait ObjectInterface: ObjectInterfaceType + Sized + 'static {
     type Prerequisites: PrerequisiteList;
 
     // rustdoc-stripper-ignore-next
+    /// The C instance struct. This is usually either `std::ffi::c_void` or a newtype wrapper
+    /// around it.
+    ///
+    /// Optional
+    type Instance;
+
+    // rustdoc-stripper-ignore-next
     /// The C class struct.
     type Interface: InterfaceStruct<Type = Self>;
 


### PR DESCRIPTION
…ss::Instance`

This defaults to `std::ffi::c_void` but can be used to provide a newtype wrapper around it instead for additional type-safety in FFI code.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1485

----

CC @felinira 