### PR TITLE
glib-macros: Do not emit import of `Property{Get,Set}` in `Properties` derive macro

### DIFF
--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -758,8 +758,6 @@ pub fn impl_derive_props(input: PropsMacroInput) -> TokenStream {
     };
 
     let expanded = quote! {
-        use #crate_ident::property::{PropertyGet, PropertySet};
-
         #properties_enum
 
         impl #crate_ident::subclass::object::DerivedObjectProperties for #struct_ident {

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -182,6 +182,19 @@ mod foo {
                     .expect("Setter to be only called once");
             }
         }
+
+        /// Checks that `Properties` does not pollute the scope with
+        /// trait imports, as it did in older versions.
+        #[test]
+        fn no_import_leaks() {
+            // `vec.get` can match these methods (in order of precedence):
+            // (1) `<Vec<String> as PropertyGet>::get`
+            // (2) `<[String]>::get` through deref of `Vec<String>`
+            // Had the macro introduced `PropertyGet` into the scope, it would
+            // resolve to (1), which we do not want.
+            let vec: Vec<String> = vec![String::new(); 2];
+            assert_eq!(vec.get(1), Some(&String::new()));
+        }
     }
 
     glib::wrapper! {


### PR DESCRIPTION
Fixes #1501