### PR TITLE
glib: Make `<Variant as HasParamSpec>::BuilderFn` generic over lifetimes

### DIFF
--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -93,6 +93,8 @@ mod foo {
             string_vec: RefCell<Vec<String>>,
             #[property(get, set, builder(glib::VariantTy::DOUBLE))]
             variant: RefCell<Option<glib::Variant>>,
+            #[property(get, set, builder(&<Option<i32>>::static_variant_type()))]
+            variant2: RefCell<Option<glib::Variant>>,
             #[property(get = |_| 42.0, set)]
             infer_inline_type: RefCell<f64>,
             // The following property doesn't store any data. The value of the property is calculated

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -2307,8 +2307,7 @@ has_simple_spec!(bool, ParamSpecBoolean, ParamSpecBooleanBuilder);
 impl HasParamSpec for crate::Variant {
     type ParamSpec = ParamSpecVariant;
     type SetValue = Self;
-    type BuilderFn =
-        fn(&'static str, ty: &'static crate::VariantTy) -> ParamSpecVariantBuilder<'static>;
+    type BuilderFn = for<'a> fn(&'a str, ty: &'a crate::VariantTy) -> ParamSpecVariantBuilder<'a>;
 
     fn param_spec_builder() -> Self::BuilderFn {
         Self::ParamSpec::builder


### PR DESCRIPTION
This makes it possible to pass a non-`'static` `&VariantTy` to [`ParamSpecVariant::builder`](https://gtk-rs.org/gtk-rs-core/stable/0.20/docs/glib/struct.ParamSpecVariant.html#method.builder) in `#[derive(Properties)]`. Example:

```rust
#[derive(Properties)]
#[properties(wrapper_type = super::Foo)]
pub struct Foo {
    #[property(get, set, builder(&<Option<i32>>::static_variant_type()))]
    variant: RefCell<Option<glib::Variant>>,
}
```

