### PR TITLE
glib-macros: Remove &mut to static mut in object_subclass

### DIFF
--- a/glib-macros/src/object_impl_attributes/subclass.rs
+++ b/glib-macros/src/object_impl_attributes/subclass.rs
@@ -103,7 +103,7 @@ pub fn impl_object_subclass(input: super::Input) -> TokenStream {
             fn type_data() -> ::std::ptr::NonNull<#crate_ident::subclass::TypeData> {
                 static mut DATA: #crate_ident::subclass::TypeData =
                     #crate_ident::subclass::types::TypeData::new();
-                unsafe { ::std::ptr::NonNull::from(&mut DATA) }
+                unsafe { ::std::ptr::NonNull::new_unchecked(::std::ptr::addr_of_mut!(DATA)) }
             }
 
             #[inline]


### PR DESCRIPTION
Mutable references to mutable statics are not only discouraged, they will also be removed in rust 2024

I have grepped the code for more of these, but didn't find any.

Closes #1516 