### PR TITLE
examples: Add stricter impl trait bounds

### DIFF
--- a/examples/virtual_methods/cat.rs
+++ b/examples/virtual_methods/cat.rs
@@ -96,7 +96,19 @@ impl Default for Cat {
 ///
 /// By convention we still create an empty `CatImpl` trait, this allows us to add
 /// 'protected' cat methods only available to be called by other Cats later.
-pub trait CatImpl: PetImpl {}
+pub trait CatImpl: PetImpl
+where
+    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Self as ObjectSubclass>::Type: IsA<Pet>,
+    <Self as ObjectSubclass>::Type: IsA<Cat>,
+{
+}
 
 /// To make this class subclassable we need to implement IsSubclassable
-unsafe impl<Obj: CatImpl + PetImpl> IsSubclassable<Obj> for Cat {}
+unsafe impl<Obj: CatImpl + PetImpl> IsSubclassable<Obj> for Cat
+where
+    <Obj as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Obj as ObjectSubclass>::Type: IsA<Pet>,
+    <Obj as ObjectSubclass>::Type: IsA<Cat>,
+{
+}

--- a/examples/virtual_methods/pet.rs
+++ b/examples/virtual_methods/pet.rs
@@ -125,7 +125,11 @@ pub trait PetExt: IsA<Pet> {
 impl<T: IsA<Pet>> PetExt for T {}
 
 /// The `PetImpl` trait contains overridable virtual function definitions for [`Pet`] objects.
-pub trait PetImpl: ObjectImpl {
+pub trait PetImpl: ObjectImpl
+where
+    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Self as ObjectSubclass>::Type: IsA<Pet>,
+{
     /// Default implementation of a virtual method.
     ///
     /// This always calls into the implementation of the parent class so that if
@@ -148,7 +152,11 @@ pub trait PetImpl: ObjectImpl {
 /// The `PetImplExt` trait contains non-overridable methods for subclasses to use.
 ///
 /// These are supposed to be called only from inside implementations of `Pet` subclasses.
-pub trait PetImplExt: PetImpl {
+pub trait PetImplExt: PetImpl
+where
+    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Self as ObjectSubclass>::Type: IsA<Pet>,
+{
     /// Chains up to the parent implementation of [`PetImpl::pet`]
     fn parent_pet(&self) -> bool {
         let data = Self::type_data();
@@ -169,10 +177,19 @@ pub trait PetImplExt: PetImpl {
 }
 
 /// The `PetImplExt` trait is implemented for all subclasses that have [`Pet`] in the class hierarchy
-impl<T: PetImpl> PetImplExt for T {}
+impl<T: PetImpl> PetImplExt for T
+where
+    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Self as ObjectSubclass>::Type: IsA<Pet>,
+{
+}
 
 /// To make this class subclassable we need to implement IsSubclassable
-unsafe impl<Obj: PetImpl> IsSubclassable<Obj> for Pet {
+unsafe impl<Obj: PetImpl> IsSubclassable<Obj> for Pet
+where
+    <Obj as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Obj as ObjectSubclass>::Type: IsA<Pet>,
+{
     /// Override the virtual method function pointers in subclasses to call directly into the
     /// `PetImpl` of the subclass.
     ///

--- a/examples/virtual_methods/purrable.rs
+++ b/examples/virtual_methods/purrable.rs
@@ -82,7 +82,11 @@ pub trait PurrableExt: IsA<Purrable> {
 impl<T: IsA<Purrable>> PurrableExt for T {}
 
 /// The `PurrableImpl` trait contains virtual function definitions for [`Purrable`] objects.
-pub trait PurrableImpl: ObjectImpl {
+pub trait PurrableImpl: ObjectImpl
+where
+    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Self as ObjectSubclass>::Type: IsA<Purrable>,
+{
     /// Return the current purring status.
     ///
     /// The default implementation chains up to the parent implementation,
@@ -96,7 +100,11 @@ pub trait PurrableImpl: ObjectImpl {
 /// The `PurrableImplExt` trait contains non-overridable methods for subclasses to use.
 ///
 /// These are supposed to be called only from inside implementations of `Pet` subclasses.
-pub trait PurrableImplExt: PurrableImpl {
+pub trait PurrableImplExt: PurrableImpl
+where
+    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Self as ObjectSubclass>::Type: IsA<Purrable>,
+{
     /// Chains up to the parent implementation of [`PurrableExt::is_purring`]
     fn parent_is_purring(&self) -> bool {
         let data = Self::type_data();
@@ -109,10 +117,19 @@ pub trait PurrableImplExt: PurrableImpl {
 }
 
 /// The `PurrableImplExt` trait is implemented for all classes that implement [`Purrable`].
-impl<T: PurrableImpl> PurrableImplExt for T {}
+impl<T: PurrableImpl> PurrableImplExt for T
+where
+    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Self as ObjectSubclass>::Type: IsA<Purrable>,
+{
+}
 
 /// To make this interface implementable we need to implement [`IsImplementable`]
-unsafe impl<Obj: PurrableImpl> IsImplementable<Obj> for Purrable {
+unsafe impl<Obj: PurrableImpl> IsImplementable<Obj> for Purrable
+where
+    <Obj as ObjectSubclass>::Type: IsA<glib::Object>,
+    <Obj as ObjectSubclass>::Type: IsA<Purrable>,
+{
     fn interface_init(iface: &mut glib::Interface<Self>) {
         let klass = iface.as_mut();
 


### PR DESCRIPTION
Separates out the examples as those don't introduce breaking changes.

See #1515 