### PR TITLE
Use rust 1.79 implied supertraits to simplify trait bounds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.70.0"
+          - "1.80.0"
         conf:
           - { name: "cairo", features: "png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface", nightly: "--features 'png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface'", test_sys: true }
           - { name: "gdk-pixbuf", features: "v2_42", nightly: "--all-features", test_sys: true }
@@ -104,7 +104,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.70.0"
+          - "1.80.0"
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,9 @@ authors = ["The gtk-rs Project Developers"]
 version = "0.21.0"
 repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
-exclude = [
-    "gir-files/*",
-]
+exclude = ["gir-files/*"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.80"
 
 [workspace.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ information about each crate, please refer to their `README.md` file in their di
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Documentation
 

--- a/cairo/README.md
+++ b/cairo/README.md
@@ -8,7 +8,7 @@ Cairo __1.14__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Default-on features
 

--- a/examples/virtual_methods/cat.rs
+++ b/examples/virtual_methods/cat.rs
@@ -96,19 +96,7 @@ impl Default for Cat {
 ///
 /// By convention we still create an empty `CatImpl` trait, this allows us to add
 /// 'protected' cat methods only available to be called by other Cats later.
-pub trait CatImpl: PetImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Pet>,
-    <Self as ObjectSubclass>::Type: IsA<Cat>,
-{
-}
+pub trait CatImpl: PetImpl + ObjectSubclass<Type: IsA<Cat>> {}
 
 /// To make this class subclassable we need to implement IsSubclassable
-unsafe impl<Obj: CatImpl + PetImpl> IsSubclassable<Obj> for Cat
-where
-    <Obj as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Obj as ObjectSubclass>::Type: IsA<Pet>,
-    <Obj as ObjectSubclass>::Type: IsA<Cat>,
-{
-}
+unsafe impl<Obj: CatImpl + PetImpl> IsSubclassable<Obj> for Cat {}

--- a/examples/virtual_methods/pet.rs
+++ b/examples/virtual_methods/pet.rs
@@ -125,11 +125,7 @@ pub trait PetExt: IsA<Pet> {
 impl<T: IsA<Pet>> PetExt for T {}
 
 /// The `PetImpl` trait contains overridable virtual function definitions for [`Pet`] objects.
-pub trait PetImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Pet>,
-{
+pub trait PetImpl: ObjectImpl + ObjectSubclass<Type: IsA<Pet>> {
     /// Default implementation of a virtual method.
     ///
     /// This always calls into the implementation of the parent class so that if
@@ -152,11 +148,7 @@ where
 /// The `PetImplExt` trait contains non-overridable methods for subclasses to use.
 ///
 /// These are supposed to be called only from inside implementations of `Pet` subclasses.
-pub trait PetImplExt: PetImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Pet>,
-{
+pub trait PetImplExt: PetImpl {
     /// Chains up to the parent implementation of [`PetImpl::pet`]
     fn parent_pet(&self) -> bool {
         let data = Self::type_data();
@@ -177,19 +169,10 @@ where
 }
 
 /// The `PetImplExt` trait is implemented for all subclasses that have [`Pet`] in the class hierarchy
-impl<T: PetImpl> PetImplExt for T
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Pet>,
-{
-}
+impl<T: PetImpl> PetImplExt for T {}
 
 /// To make this class subclassable we need to implement IsSubclassable
-unsafe impl<Obj: PetImpl> IsSubclassable<Obj> for Pet
-where
-    <Obj as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Obj as ObjectSubclass>::Type: IsA<Pet>,
-{
+unsafe impl<Obj: PetImpl> IsSubclassable<Obj> for Pet {
     /// Override the virtual method function pointers in subclasses to call directly into the
     /// `PetImpl` of the subclass.
     ///

--- a/examples/virtual_methods/purrable.rs
+++ b/examples/virtual_methods/purrable.rs
@@ -82,11 +82,7 @@ pub trait PurrableExt: IsA<Purrable> {
 impl<T: IsA<Purrable>> PurrableExt for T {}
 
 /// The `PurrableImpl` trait contains virtual function definitions for [`Purrable`] objects.
-pub trait PurrableImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Purrable>,
-{
+pub trait PurrableImpl: ObjectImpl + ObjectSubclass<Type: IsA<Purrable>> {
     /// Return the current purring status.
     ///
     /// The default implementation chains up to the parent implementation,
@@ -100,11 +96,7 @@ where
 /// The `PurrableImplExt` trait contains non-overridable methods for subclasses to use.
 ///
 /// These are supposed to be called only from inside implementations of `Pet` subclasses.
-pub trait PurrableImplExt: PurrableImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Purrable>,
-{
+pub trait PurrableImplExt: PurrableImpl {
     /// Chains up to the parent implementation of [`PurrableExt::is_purring`]
     fn parent_is_purring(&self) -> bool {
         let data = Self::type_data();
@@ -117,19 +109,10 @@ where
 }
 
 /// The `PurrableImplExt` trait is implemented for all classes that implement [`Purrable`].
-impl<T: PurrableImpl> PurrableImplExt for T
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Purrable>,
-{
-}
+impl<T: PurrableImpl> PurrableImplExt for T {}
 
 /// To make this interface implementable we need to implement [`IsImplementable`]
-unsafe impl<Obj: PurrableImpl> IsImplementable<Obj> for Purrable
-where
-    <Obj as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Obj as ObjectSubclass>::Type: IsA<Purrable>,
-{
+unsafe impl<Obj: PurrableImpl> IsImplementable<Obj> for Purrable {
     fn interface_init(iface: &mut glib::Interface<Self>) {
         let klass = iface.as_mut();
 

--- a/gdk-pixbuf/README.md
+++ b/gdk-pixbuf/README.md
@@ -6,7 +6,7 @@ GDK-PixBuf __2.36.8__ is the lowest supported version for the underlying library
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Documentation
 

--- a/gdk-pixbuf/src/subclass/pixbuf_animation.rs
+++ b/gdk-pixbuf/src/subclass/pixbuf_animation.rs
@@ -13,11 +13,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*};
 
 use crate::{ffi, Pixbuf, PixbufAnimation, PixbufAnimationIter};
 
-pub trait PixbufAnimationImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
+pub trait PixbufAnimationImpl: ObjectImpl + ObjectSubclass<Type: IsA<PixbufAnimation>> {
     fn is_static_image(&self) -> bool {
         self.parent_is_static_image()
     }
@@ -35,11 +31,7 @@ where
     }
 }
 
-pub trait PixbufAnimationImplExt: ObjectSubclass + PixbufAnimationImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
+pub trait PixbufAnimationImplExt: PixbufAnimationImpl {
     fn parent_is_static_image(&self) -> bool {
         unsafe {
             let data = Self::type_data();
@@ -119,18 +111,9 @@ where
     }
 }
 
-impl<T: PixbufAnimationImpl> PixbufAnimationImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
-}
+impl<T: PixbufAnimationImpl> PixbufAnimationImplExt for T {}
 
-unsafe impl<T: PixbufAnimationImpl> IsSubclassable<T> for PixbufAnimation
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
+unsafe impl<T: PixbufAnimationImpl> IsSubclassable<T> for PixbufAnimation {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -144,11 +127,7 @@ where
 
 unsafe extern "C" fn animation_is_static_image<T: PixbufAnimationImpl>(
     ptr: *mut ffi::GdkPixbufAnimation,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -159,10 +138,7 @@ unsafe extern "C" fn animation_get_size<T: PixbufAnimationImpl>(
     ptr: *mut ffi::GdkPixbufAnimation,
     width_ptr: *mut libc::c_int,
     height_ptr: *mut libc::c_int,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
+) {
     if width_ptr.is_null() && height_ptr.is_null() {
         return;
     }
@@ -181,11 +157,7 @@ unsafe extern "C" fn animation_get_size<T: PixbufAnimationImpl>(
 
 unsafe extern "C" fn animation_get_static_image<T: PixbufAnimationImpl>(
     ptr: *mut ffi::GdkPixbufAnimation,
-) -> *mut ffi::GdkPixbuf
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
+) -> *mut ffi::GdkPixbuf {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -215,11 +187,7 @@ where
 unsafe extern "C" fn animation_get_iter<T: PixbufAnimationImpl>(
     ptr: *mut ffi::GdkPixbufAnimation,
     start_time_ptr: *const glib::ffi::GTimeVal,
-) -> *mut ffi::GdkPixbufAnimationIter
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimation>,
-{
+) -> *mut ffi::GdkPixbufAnimationIter {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gdk-pixbuf/src/subclass/pixbuf_animation_iter.rs
+++ b/gdk-pixbuf/src/subclass/pixbuf_animation_iter.rs
@@ -12,10 +12,8 @@ use glib::{prelude::*, subclass::prelude::*, translate::*};
 
 use crate::{ffi, Pixbuf, PixbufAnimationIter};
 
-pub trait PixbufAnimationIterImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
+pub trait PixbufAnimationIterImpl:
+    ObjectImpl + ObjectSubclass<Type: IsA<PixbufAnimationIter>>
 {
     // rustdoc-stripper-ignore-next
     /// Time in milliseconds, returning `None` implies showing the same pixbuf forever.
@@ -36,11 +34,7 @@ where
     }
 }
 
-pub trait PixbufAnimationIterImplExt: ObjectSubclass + PixbufAnimationIterImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
-{
+pub trait PixbufAnimationIterImplExt: PixbufAnimationIterImpl {
     fn parent_delay_time(&self) -> Option<Duration> {
         unsafe {
             let data = Self::type_data();
@@ -124,18 +118,9 @@ where
     }
 }
 
-impl<T: PixbufAnimationIterImpl> PixbufAnimationIterImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
-{
-}
+impl<T: PixbufAnimationIterImpl> PixbufAnimationIterImplExt for T {}
 
-unsafe impl<T: PixbufAnimationIterImpl> IsSubclassable<T> for PixbufAnimationIter
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
-{
+unsafe impl<T: PixbufAnimationIterImpl> IsSubclassable<T> for PixbufAnimationIter {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -149,11 +134,7 @@ where
 
 unsafe extern "C" fn animation_iter_get_delay_time<T: PixbufAnimationIterImpl>(
     ptr: *mut ffi::GdkPixbufAnimationIter,
-) -> i32
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
-{
+) -> i32 {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -162,11 +143,7 @@ where
 
 unsafe extern "C" fn animation_iter_get_pixbuf<T: PixbufAnimationIterImpl>(
     ptr: *mut ffi::GdkPixbufAnimationIter,
-) -> *mut ffi::GdkPixbuf
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
-{
+) -> *mut ffi::GdkPixbuf {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -182,11 +159,7 @@ where
 
 unsafe extern "C" fn animation_iter_on_currently_loading_frame<T: PixbufAnimationIterImpl>(
     ptr: *mut ffi::GdkPixbufAnimationIter,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -196,11 +169,7 @@ where
 unsafe extern "C" fn animation_iter_advance<T: PixbufAnimationIterImpl>(
     ptr: *mut ffi::GdkPixbufAnimationIter,
     current_time_ptr: *const glib::ffi::GTimeVal,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufAnimationIter>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gdk-pixbuf/src/subclass/pixbuf_loader.rs
+++ b/gdk-pixbuf/src/subclass/pixbuf_loader.rs
@@ -7,11 +7,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*};
 
 use crate::{ffi, PixbufLoader};
 
-pub trait PixbufLoaderImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
+pub trait PixbufLoaderImpl: ObjectImpl + ObjectSubclass<Type: IsA<PixbufLoader>> {
     fn size_prepared(&self, width: i32, height: i32) {
         self.parent_size_prepared(width, height)
     }
@@ -29,11 +25,7 @@ where
     }
 }
 
-pub trait PixbufLoaderImplExt: ObjectSubclass + PixbufLoaderImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
+pub trait PixbufLoaderImplExt: PixbufLoaderImpl {
     fn parent_size_prepared(&self, width: i32, height: i32) {
         unsafe {
             let data = Self::type_data();
@@ -99,18 +91,9 @@ where
     }
 }
 
-impl<T: PixbufLoaderImpl> PixbufLoaderImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
-}
+impl<T: PixbufLoaderImpl> PixbufLoaderImplExt for T {}
 
-unsafe impl<T: PixbufLoaderImpl> IsSubclassable<T> for PixbufLoader
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
+unsafe impl<T: PixbufLoaderImpl> IsSubclassable<T> for PixbufLoader {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -126,21 +109,14 @@ unsafe extern "C" fn loader_size_prepared<T: PixbufLoaderImpl>(
     ptr: *mut ffi::GdkPixbufLoader,
     width: i32,
     height: i32,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
+) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
     imp.size_prepared(width, height)
 }
 
-unsafe extern "C" fn loader_area_prepared<T: PixbufLoaderImpl>(ptr: *mut ffi::GdkPixbufLoader)
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
+unsafe extern "C" fn loader_area_prepared<T: PixbufLoaderImpl>(ptr: *mut ffi::GdkPixbufLoader) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -153,21 +129,14 @@ unsafe extern "C" fn loader_area_updated<T: PixbufLoaderImpl>(
     y: i32,
     width: i32,
     height: i32,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
+) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
     imp.area_updated(x, y, width, height)
 }
 
-unsafe extern "C" fn loader_closed<T: PixbufLoaderImpl>(ptr: *mut ffi::GdkPixbufLoader)
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<PixbufLoader>,
-{
+unsafe extern "C" fn loader_closed<T: PixbufLoaderImpl>(ptr: *mut ffi::GdkPixbufLoader) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gio/README.md
+++ b/gio/README.md
@@ -6,7 +6,7 @@ GIO __2.56__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Documentation
 

--- a/gio/src/subclass/action_group.rs
+++ b/gio/src/subclass/action_group.rs
@@ -6,11 +6,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*, GString, Quark, Varia
 
 use crate::{ffi, ActionGroup};
 
-pub trait ActionGroupImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+pub trait ActionGroupImpl: ObjectImpl + ObjectSubclass<Type: IsA<ActionGroup>> {
     fn action_added(&self, action_name: &str) {
         self.parent_action_added(action_name);
     }
@@ -77,11 +73,7 @@ where
     )>;
 }
 
-pub trait ActionGroupImplExt: ObjectSubclass + ActionGroupImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+pub trait ActionGroupImplExt: ActionGroupImpl {
     fn parent_action_added(&self, action_name: &str) {
         unsafe {
             let type_data = Self::type_data();
@@ -344,18 +336,9 @@ where
     }
 }
 
-impl<T: ActionGroupImpl> ActionGroupImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
-}
+impl<T: ActionGroupImpl> ActionGroupImplExt for T {}
 
-unsafe impl<T: ActionGroupImpl> IsImplementable<T> for ActionGroup
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+unsafe impl<T: ActionGroupImpl> IsImplementable<T> for ActionGroup {
     fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
@@ -379,11 +362,7 @@ where
 unsafe extern "C" fn action_group_has_action<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(action_group as *mut T::Instance);
     let action_name = GString::from_glib_borrow(action_nameptr);
     let imp = instance.imp();
@@ -394,11 +373,7 @@ where
 unsafe extern "C" fn action_group_get_action_enabled<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -419,11 +394,7 @@ impl<T, F: Fn(*mut T) + 'static> Drop for PtrHolder<T, F> {
 unsafe extern "C" fn action_group_get_action_parameter_type<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) -> *const glib::ffi::GVariantType
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> *const glib::ffi::GVariantType {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -452,11 +423,7 @@ where
 unsafe extern "C" fn action_group_get_action_state_type<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) -> *const glib::ffi::GVariantType
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> *const glib::ffi::GVariantType {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -485,11 +452,7 @@ where
 unsafe extern "C" fn action_group_get_action_state_hint<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) -> *mut glib::ffi::GVariant
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> *mut glib::ffi::GVariant {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -517,11 +480,7 @@ where
 unsafe extern "C" fn action_group_get_action_state<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) -> *mut glib::ffi::GVariant
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> *mut glib::ffi::GVariant {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -548,10 +507,7 @@ unsafe extern "C" fn action_group_change_action_state<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
     stateptr: *mut glib::ffi::GVariant,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -564,10 +520,7 @@ unsafe extern "C" fn action_group_activate_action<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
     parameterptr: *mut glib::ffi::GVariant,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -579,10 +532,7 @@ unsafe extern "C" fn action_group_activate_action<T: ActionGroupImpl>(
 unsafe extern "C" fn action_group_action_added<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -593,10 +543,7 @@ unsafe extern "C" fn action_group_action_added<T: ActionGroupImpl>(
 unsafe extern "C" fn action_group_action_removed<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -608,10 +555,7 @@ unsafe extern "C" fn action_group_action_enabled_changed<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
     enabled: glib::ffi::gboolean,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -623,10 +567,7 @@ unsafe extern "C" fn action_group_action_state_changed<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
     action_nameptr: *const libc::c_char,
     stateptr: *mut glib::ffi::GVariant,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);
@@ -637,11 +578,7 @@ unsafe extern "C" fn action_group_action_state_changed<T: ActionGroupImpl>(
 
 unsafe extern "C" fn action_group_list_actions<T: ActionGroupImpl>(
     action_group: *mut ffi::GActionGroup,
-) -> *mut *mut libc::c_char
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> *mut *mut libc::c_char {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
 
@@ -667,11 +604,7 @@ unsafe extern "C" fn action_group_query_action<T: ActionGroupImpl>(
     state_type: *mut *const glib::ffi::GVariantType,
     state_hint: *mut *mut glib::ffi::GVariant,
     state: *mut *mut glib::ffi::GVariant,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionGroup>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(action_group as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);

--- a/gio/src/subclass/action_map.rs
+++ b/gio/src/subclass/action_map.rs
@@ -6,21 +6,13 @@ use glib::{prelude::*, subclass::prelude::*, translate::*, GString, Quark};
 
 use crate::{ffi, Action, ActionMap};
 
-pub trait ActionMapImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<ActionMap>,
-{
+pub trait ActionMapImpl: ObjectImpl + ObjectSubclass<Type: IsA<ActionMap>> {
     fn lookup_action(&self, action_name: &str) -> Option<Action>;
     fn add_action(&self, action: &Action);
     fn remove_action(&self, action_name: &str);
 }
 
-pub trait ActionMapImplExt: ObjectSubclass + ActionMapImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<ActionMap>,
-{
+pub trait ActionMapImplExt: ActionMapImpl {
     fn parent_lookup_action(&self, name: &str) -> Option<Action> {
         unsafe {
             let type_data = Self::type_data();
@@ -71,18 +63,9 @@ where
     }
 }
 
-impl<T: ActionMapImpl> ActionMapImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionMap>,
-{
-}
+impl<T: ActionMapImpl> ActionMapImplExt for T {}
 
-unsafe impl<T: ActionMapImpl> IsImplementable<T> for ActionMap
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionMap>,
-{
+unsafe impl<T: ActionMapImpl> IsImplementable<T> for ActionMap {
     fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
@@ -95,11 +78,7 @@ where
 unsafe extern "C" fn action_map_lookup_action<T: ActionMapImpl>(
     action_map: *mut ffi::GActionMap,
     action_nameptr: *const libc::c_char,
-) -> *mut ffi::GAction
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionMap>,
-{
+) -> *mut ffi::GAction {
     let instance = &*(action_map as *mut T::Instance);
     let action_name = GString::from_glib_borrow(action_nameptr);
     let imp = instance.imp();
@@ -129,10 +108,7 @@ where
 unsafe extern "C" fn action_map_add_action<T: ActionMapImpl>(
     action_map: *mut ffi::GActionMap,
     actionptr: *mut ffi::GAction,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionMap>,
-{
+) {
     let instance = &*(action_map as *mut T::Instance);
     let imp = instance.imp();
     let action: Borrowed<Action> = from_glib_borrow(actionptr);
@@ -143,10 +119,7 @@ unsafe extern "C" fn action_map_add_action<T: ActionMapImpl>(
 unsafe extern "C" fn action_map_remove_action<T: ActionMapImpl>(
     action_map: *mut ffi::GActionMap,
     action_nameptr: *const libc::c_char,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ActionMap>,
-{
+) {
     let instance = &*(action_map as *mut T::Instance);
     let imp = instance.imp();
     let action_name = GString::from_glib_borrow(action_nameptr);

--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -64,11 +64,7 @@ impl From<ArgumentList> for Vec<OsString> {
     }
 }
 
-pub trait ApplicationImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Application>,
-{
+pub trait ApplicationImpl: ObjectImpl + ObjectSubclass<Type: IsA<Application>> {
     fn activate(&self) {
         self.parent_activate()
     }
@@ -114,11 +110,7 @@ where
     }
 }
 
-pub trait ApplicationImplExt: ObjectSubclass + ApplicationImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Application>,
-{
+pub trait ApplicationImplExt: ApplicationImpl {
     fn parent_activate(&self) {
         unsafe {
             let data = Self::type_data();
@@ -274,18 +266,9 @@ where
     }
 }
 
-impl<T: ApplicationImpl> ApplicationImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
-}
+impl<T: ApplicationImpl> ApplicationImplExt for T {}
 
-unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -304,11 +287,7 @@ where
     }
 }
 
-unsafe extern "C" fn application_activate<T: ApplicationImpl>(ptr: *mut ffi::GApplication)
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+unsafe extern "C" fn application_activate<T: ApplicationImpl>(ptr: *mut ffi::GApplication) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -318,10 +297,7 @@ where
 unsafe extern "C" fn application_after_emit<T: ApplicationImpl>(
     ptr: *mut ffi::GApplication,
     platform_data: *mut glib::ffi::GVariant,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -330,10 +306,7 @@ unsafe extern "C" fn application_after_emit<T: ApplicationImpl>(
 unsafe extern "C" fn application_before_emit<T: ApplicationImpl>(
     ptr: *mut ffi::GApplication,
     platform_data: *mut glib::ffi::GVariant,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -342,11 +315,7 @@ unsafe extern "C" fn application_before_emit<T: ApplicationImpl>(
 unsafe extern "C" fn application_command_line<T: ApplicationImpl>(
     ptr: *mut ffi::GApplication,
     command_line: *mut ffi::GApplicationCommandLine,
-) -> i32
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+) -> i32 {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -356,11 +325,7 @@ unsafe extern "C" fn application_local_command_line<T: ApplicationImpl>(
     ptr: *mut ffi::GApplication,
     arguments: *mut *mut *mut c_char,
     exit_status: *mut i32,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -381,51 +346,32 @@ unsafe extern "C" fn application_open<T: ApplicationImpl>(
     files: *mut *mut ffi::GFile,
     num_files: i32,
     hint: *const c_char,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
     let files: Vec<crate::File> = FromGlibContainer::from_glib_none_num(files, num_files as usize);
     imp.open(files.as_slice(), &glib::GString::from_glib_borrow(hint))
 }
-unsafe extern "C" fn application_quit_mainloop<T: ApplicationImpl>(ptr: *mut ffi::GApplication)
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+unsafe extern "C" fn application_quit_mainloop<T: ApplicationImpl>(ptr: *mut ffi::GApplication) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
     imp.quit_mainloop()
 }
-unsafe extern "C" fn application_run_mainloop<T: ApplicationImpl>(ptr: *mut ffi::GApplication)
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+unsafe extern "C" fn application_run_mainloop<T: ApplicationImpl>(ptr: *mut ffi::GApplication) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
     imp.run_mainloop()
 }
-unsafe extern "C" fn application_shutdown<T: ApplicationImpl>(ptr: *mut ffi::GApplication)
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+unsafe extern "C" fn application_shutdown<T: ApplicationImpl>(ptr: *mut ffi::GApplication) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
     imp.shutdown()
 }
-unsafe extern "C" fn application_startup<T: ApplicationImpl>(ptr: *mut ffi::GApplication)
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+unsafe extern "C" fn application_startup<T: ApplicationImpl>(ptr: *mut ffi::GApplication) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -435,11 +381,7 @@ where
 unsafe extern "C" fn application_handle_local_options<T: ApplicationImpl>(
     ptr: *mut ffi::GApplication,
     options: *mut glib::ffi::GVariantDict,
-) -> c_int
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Application>,
-{
+) -> c_int {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gio/src/subclass/initable.rs
+++ b/gio/src/subclass/initable.rs
@@ -6,21 +6,13 @@ use glib::{prelude::*, subclass::prelude::*, translate::*, Error};
 
 use crate::{ffi, Cancellable, Initable};
 
-pub trait InitableImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Initable>,
-{
+pub trait InitableImpl: ObjectImpl + ObjectSubclass<Type: IsA<Initable>> {
     fn init(&self, cancellable: Option<&Cancellable>) -> Result<(), Error> {
         self.parent_init(cancellable)
     }
 }
 
-pub trait InitableImplExt: ObjectSubclass + InitableImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Initable>,
-{
+pub trait InitableImplExt: InitableImpl {
     fn parent_init(&self, cancellable: Option<&Cancellable>) -> Result<(), Error> {
         unsafe {
             let type_data = Self::type_data();
@@ -47,18 +39,9 @@ where
     }
 }
 
-impl<T: InitableImpl> InitableImplExt for T
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Initable>,
-{
-}
+impl<T: InitableImpl> InitableImplExt for T {}
 
-unsafe impl<T: InitableImpl> IsImplementable<T> for Initable
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Initable>,
-{
+unsafe impl<T: InitableImpl> IsImplementable<T> for Initable {
     fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
         iface.init = Some(initable_init::<T>);
@@ -69,11 +52,7 @@ unsafe extern "C" fn initable_init<T: InitableImpl>(
     initable: *mut ffi::GInitable,
     cancellable: *mut ffi::GCancellable,
     error: *mut *mut glib::ffi::GError,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Initable>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(initable as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gio/src/subclass/input_stream.rs
+++ b/gio/src/subclass/input_stream.rs
@@ -6,11 +6,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*, Error};
 
 use crate::{ffi, Cancellable, InputStream};
 
-pub trait InputStreamImpl: ObjectImpl + Send
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<InputStream>,
-{
+pub trait InputStreamImpl: Send + ObjectImpl + ObjectSubclass<Type: IsA<InputStream>> {
     fn read(&self, buffer: &mut [u8], cancellable: Option<&Cancellable>) -> Result<usize, Error> {
         self.parent_read(buffer, cancellable)
     }
@@ -24,11 +20,7 @@ where
     }
 }
 
-pub trait InputStreamImplExt: ObjectSubclass + InputStreamImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<InputStream>,
-{
+pub trait InputStreamImplExt: InputStreamImpl {
     fn parent_read(
         &self,
         buffer: &mut [u8],
@@ -106,18 +98,9 @@ where
     }
 }
 
-impl<T: InputStreamImpl> InputStreamImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<InputStream>,
-{
-}
+impl<T: InputStreamImpl> InputStreamImplExt for T {}
 
-unsafe impl<T: InputStreamImpl> IsSubclassable<T> for InputStream
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<InputStream>,
-{
+unsafe impl<T: InputStreamImpl> IsSubclassable<T> for InputStream {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -134,11 +117,7 @@ unsafe extern "C" fn stream_read<T: InputStreamImpl>(
     count: usize,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> isize
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<InputStream>,
-{
+) -> isize {
     debug_assert!(count <= isize::MAX as usize);
 
     let instance = &*(ptr as *mut T::Instance);
@@ -172,11 +151,7 @@ unsafe extern "C" fn stream_close<T: InputStreamImpl>(
     ptr: *mut ffi::GInputStream,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<InputStream>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -200,11 +175,7 @@ unsafe extern "C" fn stream_skip<T: InputStreamImpl>(
     count: usize,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> isize
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<InputStream>,
-{
+) -> isize {
     debug_assert!(count <= isize::MAX as usize);
 
     let instance = &*(ptr as *mut T::Instance);

--- a/gio/src/subclass/io_stream.rs
+++ b/gio/src/subclass/io_stream.rs
@@ -6,11 +6,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*, Error};
 
 use crate::{ffi, Cancellable, IOStream, InputStream, OutputStream};
 
-pub trait IOStreamImpl: ObjectImpl + Send
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<IOStream>,
-{
+pub trait IOStreamImpl: Send + ObjectImpl + ObjectSubclass<Type: IsA<IOStream>> {
     fn input_stream(&self) -> InputStream {
         self.parent_input_stream()
     }
@@ -24,11 +20,7 @@ where
     }
 }
 
-pub trait IOStreamImplExt: ObjectSubclass + IOStreamImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<IOStream>,
-{
+pub trait IOStreamImplExt: IOStreamImpl {
     fn parent_input_stream(&self) -> InputStream {
         unsafe {
             let data = Self::type_data();
@@ -73,18 +65,9 @@ where
     }
 }
 
-impl<T: IOStreamImpl> IOStreamImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<IOStream>,
-{
-}
+impl<T: IOStreamImpl> IOStreamImplExt for T {}
 
-unsafe impl<T: IOStreamImpl> IsSubclassable<T> for IOStream
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<IOStream>,
-{
+unsafe impl<T: IOStreamImpl> IsSubclassable<T> for IOStream {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -97,11 +80,7 @@ where
 
 unsafe extern "C" fn stream_get_input_stream<T: IOStreamImpl>(
     ptr: *mut ffi::GIOStream,
-) -> *mut ffi::GInputStream
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<IOStream>,
-{
+) -> *mut ffi::GInputStream {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -128,11 +107,7 @@ where
 
 unsafe extern "C" fn stream_get_output_stream<T: IOStreamImpl>(
     ptr: *mut ffi::GIOStream,
-) -> *mut ffi::GOutputStream
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<IOStream>,
-{
+) -> *mut ffi::GOutputStream {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -161,11 +136,7 @@ unsafe extern "C" fn stream_close<T: IOStreamImpl>(
     ptr: *mut ffi::GIOStream,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<IOStream>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gio/src/subclass/list_model.rs
+++ b/gio/src/subclass/list_model.rs
@@ -6,11 +6,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*};
 
 use crate::{ffi, ListModel};
 
-pub trait ListModelImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<ListModel>,
-{
+pub trait ListModelImpl: ObjectImpl + ObjectSubclass<Type: IsA<ListModel>> {
     #[doc(alias = "get_item_type")]
     fn item_type(&self) -> glib::Type;
     #[doc(alias = "get_n_items")]
@@ -19,11 +15,7 @@ where
     fn item(&self, position: u32) -> Option<glib::Object>;
 }
 
-pub trait ListModelImplExt: ObjectSubclass + ListModelImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<ListModel>,
-{
+pub trait ListModelImplExt: ListModelImpl {
     fn parent_item_type(&self) -> glib::Type {
         unsafe {
             let type_data = Self::type_data();
@@ -69,18 +61,9 @@ where
     }
 }
 
-impl<T: ListModelImpl> ListModelImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ListModel>,
-{
-}
+impl<T: ListModelImpl> ListModelImplExt for T {}
 
-unsafe impl<T: ListModelImpl> IsImplementable<T> for ListModel
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ListModel>,
-{
+unsafe impl<T: ListModelImpl> IsImplementable<T> for ListModel {
     fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
@@ -92,11 +75,7 @@ where
 
 unsafe extern "C" fn list_model_get_item_type<T: ListModelImpl>(
     list_model: *mut ffi::GListModel,
-) -> glib::ffi::GType
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ListModel>,
-{
+) -> glib::ffi::GType {
     let instance = &*(list_model as *mut T::Instance);
     let imp = instance.imp();
 
@@ -125,11 +104,7 @@ where
 
 unsafe extern "C" fn list_model_get_n_items<T: ListModelImpl>(
     list_model: *mut ffi::GListModel,
-) -> u32
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ListModel>,
-{
+) -> u32 {
     let instance = &*(list_model as *mut T::Instance);
     let imp = instance.imp();
 
@@ -139,11 +114,7 @@ where
 unsafe extern "C" fn list_model_get_item<T: ListModelImpl>(
     list_model: *mut ffi::GListModel,
     position: u32,
-) -> *mut glib::gobject_ffi::GObject
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<ListModel>,
-{
+) -> *mut glib::gobject_ffi::GObject {
     let instance = &*(list_model as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gio/src/subclass/output_stream.rs
+++ b/gio/src/subclass/output_stream.rs
@@ -6,11 +6,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*, Error};
 
 use crate::{ffi, Cancellable, InputStream, OutputStream, OutputStreamSpliceFlags};
 
-pub trait OutputStreamImpl: ObjectImpl + Send
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<OutputStream>,
-{
+pub trait OutputStreamImpl: Send + ObjectImpl + ObjectSubclass<Type: IsA<OutputStream>> {
     fn write(&self, buffer: &[u8], cancellable: Option<&Cancellable>) -> Result<usize, Error> {
         self.parent_write(buffer, cancellable)
     }
@@ -33,11 +29,7 @@ where
     }
 }
 
-pub trait OutputStreamImplExt: ObjectSubclass + OutputStreamImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<OutputStream>,
-{
+pub trait OutputStreamImplExt: OutputStreamImpl {
     fn parent_write(
         &self,
         buffer: &[u8],
@@ -153,18 +145,9 @@ where
     }
 }
 
-impl<T: OutputStreamImpl> OutputStreamImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<OutputStream>,
-{
-}
+impl<T: OutputStreamImpl> OutputStreamImplExt for T {}
 
-unsafe impl<T: OutputStreamImpl> IsSubclassable<T> for OutputStream
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<OutputStream>,
-{
+unsafe impl<T: OutputStreamImpl> IsSubclassable<T> for OutputStream {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -182,11 +165,7 @@ unsafe extern "C" fn stream_write<T: OutputStreamImpl>(
     count: usize,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> isize
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<OutputStream>,
-{
+) -> isize {
     debug_assert!(count <= isize::MAX as usize);
 
     let instance = &*(ptr as *mut T::Instance);
@@ -220,11 +199,7 @@ unsafe extern "C" fn stream_close<T: OutputStreamImpl>(
     ptr: *mut ffi::GOutputStream,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<OutputStream>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -247,11 +222,7 @@ unsafe extern "C" fn stream_flush<T: OutputStreamImpl>(
     ptr: *mut ffi::GOutputStream,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<OutputStream>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -276,11 +247,7 @@ unsafe extern "C" fn stream_splice<T: OutputStreamImpl>(
     flags: ffi::GOutputStreamSpliceFlags,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> isize
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<OutputStream>,
-{
+) -> isize {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gio/src/subclass/seekable.rs
+++ b/gio/src/subclass/seekable.rs
@@ -6,11 +6,7 @@ use glib::{prelude::*, subclass::prelude::*, translate::*, Error, SeekType};
 
 use crate::{ffi, Cancellable, Seekable};
 
-pub trait SeekableImpl: ObjectImpl + Send
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Seekable>,
-{
+pub trait SeekableImpl: Send + ObjectImpl + ObjectSubclass<Type: IsA<Seekable>> {
     fn tell(&self) -> i64;
     fn can_seek(&self) -> bool;
     fn seek(
@@ -23,11 +19,7 @@ where
     fn truncate(&self, offset: i64, cancellable: Option<&Cancellable>) -> Result<(), Error>;
 }
 
-pub trait SeekableImplExt: ObjectSubclass + SeekableImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<Seekable>,
-{
+pub trait SeekableImplExt: SeekableImpl {
     fn parent_tell(&self) -> i64 {
         unsafe {
             let type_data = Self::type_data();
@@ -128,18 +120,9 @@ where
     }
 }
 
-impl<T: SeekableImpl> SeekableImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Seekable>,
-{
-}
+impl<T: SeekableImpl> SeekableImplExt for T {}
 
-unsafe impl<T: SeekableImpl> IsImplementable<T> for Seekable
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Seekable>,
-{
+unsafe impl<T: SeekableImpl> IsImplementable<T> for Seekable {
     fn interface_init(iface: &mut glib::Interface<Self>) {
         let iface = iface.as_mut();
 
@@ -151,11 +134,7 @@ where
     }
 }
 
-unsafe extern "C" fn seekable_tell<T: SeekableImpl>(seekable: *mut ffi::GSeekable) -> i64
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Seekable>,
-{
+unsafe extern "C" fn seekable_tell<T: SeekableImpl>(seekable: *mut ffi::GSeekable) -> i64 {
     let instance = &*(seekable as *mut T::Instance);
     let imp = instance.imp();
 
@@ -164,11 +143,7 @@ where
 
 unsafe extern "C" fn seekable_can_seek<T: SeekableImpl>(
     seekable: *mut ffi::GSeekable,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Seekable>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(seekable as *mut T::Instance);
     let imp = instance.imp();
 
@@ -181,11 +156,7 @@ unsafe extern "C" fn seekable_seek<T: SeekableImpl>(
     type_: glib::ffi::GSeekType,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Seekable>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(seekable as *mut T::Instance);
     let imp = instance.imp();
 
@@ -208,11 +179,7 @@ where
 
 unsafe extern "C" fn seekable_can_truncate<T: SeekableImpl>(
     seekable: *mut ffi::GSeekable,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Seekable>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(seekable as *mut T::Instance);
     let imp = instance.imp();
 
@@ -224,11 +191,7 @@ unsafe extern "C" fn seekable_truncate<T: SeekableImpl>(
     offset: i64,
     cancellable: *mut ffi::GCancellable,
     err: *mut *mut glib::ffi::GError,
-) -> glib::ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<Seekable>,
-{
+) -> glib::ffi::gboolean {
     let instance = &*(seekable as *mut T::Instance);
     let imp = instance.imp();
 

--- a/gio/src/subclass/socket_control_message.rs
+++ b/gio/src/subclass/socket_control_message.rs
@@ -4,10 +4,8 @@ use glib::{prelude::*, subclass::prelude::*, translate::*};
 
 use crate::{ffi, SocketControlMessage};
 
-pub trait SocketControlMessageImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<SocketControlMessage>,
+pub trait SocketControlMessageImpl:
+    ObjectImpl + ObjectSubclass<Type: IsA<SocketControlMessage>>
 {
     fn level(&self) -> i32 {
         self.parent_level()
@@ -30,11 +28,7 @@ where
     }
 }
 
-pub trait SocketControlMessageImplExt: ObjectSubclass + SocketControlMessageImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-    <Self as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
+pub trait SocketControlMessageImplExt: SocketControlMessageImpl {
     fn parent_level(&self) -> i32 {
         unsafe {
             let data = Self::type_data();
@@ -116,18 +110,9 @@ where
     }
 }
 
-impl<T: SocketControlMessageImpl> SocketControlMessageImplExt for T
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
-}
+impl<T: SocketControlMessageImpl> SocketControlMessageImplExt for T {}
 
-unsafe impl<T: SocketControlMessageImpl> IsSubclassable<T> for SocketControlMessage
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
+unsafe impl<T: SocketControlMessageImpl> IsSubclassable<T> for SocketControlMessage {
     fn class_init(class: &mut ::glib::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -142,11 +127,7 @@ where
 
 unsafe extern "C" fn socket_control_message_get_level<T: SocketControlMessageImpl>(
     ptr: *mut ffi::GSocketControlMessage,
-) -> i32
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
+) -> i32 {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -155,11 +136,7 @@ where
 
 unsafe extern "C" fn socket_control_message_get_type<T: SocketControlMessageImpl>(
     ptr: *mut ffi::GSocketControlMessage,
-) -> i32
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
+) -> i32 {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -168,11 +145,7 @@ where
 
 unsafe extern "C" fn socket_control_message_get_size<T: SocketControlMessageImpl>(
     ptr: *mut ffi::GSocketControlMessage,
-) -> usize
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
+) -> usize {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -182,10 +155,7 @@ where
 unsafe extern "C" fn socket_control_message_serialize<T: SocketControlMessageImpl>(
     ptr: *mut ffi::GSocketControlMessage,
     data: glib::ffi::gpointer,
-) where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
+) {
     let instance = &*(ptr as *mut T::Instance);
     let imp = instance.imp();
 
@@ -199,11 +169,7 @@ unsafe extern "C" fn socket_control_message_deserialize<T: SocketControlMessageI
     type_: i32,
     size: usize,
     data: glib::ffi::gpointer,
-) -> *mut ffi::GSocketControlMessage
-where
-    <T as ObjectSubclass>::Type: IsA<glib::Object>,
-    <T as ObjectSubclass>::Type: IsA<SocketControlMessage>,
-{
+) -> *mut ffi::GSocketControlMessage {
     let data = std::slice::from_raw_parts(data as *mut u8, size);
 
     T::deserialize(level, type_, data).into_glib_ptr()

--- a/glib-build-tools/README.md
+++ b/glib-build-tools/README.md
@@ -4,7 +4,7 @@ Crate containing helpers for building GIO-based applications.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Documentation
 

--- a/glib-macros/tests/object_subclass_dynamic.rs
+++ b/glib-macros/tests/object_subclass_dynamic.rs
@@ -28,10 +28,8 @@ mod static_ {
             type Interface = MyStaticInterfaceClass;
         }
 
-        pub trait MyStaticInterfaceImpl: ObjectImpl + ObjectSubclass
-        where
-            <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-            <Self as ObjectSubclass>::Type: IsA<super::MyStaticInterface>,
+        pub trait MyStaticInterfaceImpl:
+            ObjectImpl + ObjectSubclass<Type: IsA<super::MyStaticInterface>>
         {
         }
 
@@ -50,10 +48,8 @@ mod static_ {
 
         impl MyStaticInterfaceImpl for MyStaticType {}
 
-        pub trait MyStaticTypeImpl: ObjectImpl + ObjectSubclass
-        where
-            <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-            <Self as ObjectSubclass>::Type: IsA<super::MyStaticType>,
+        pub trait MyStaticTypeImpl:
+            ObjectImpl + ObjectSubclass<Type: IsA<super::MyStaticType>>
         {
         }
     }
@@ -63,24 +59,14 @@ mod static_ {
         pub struct MyStaticInterface(ObjectInterface<imp::MyStaticInterface>);
     }
 
-    unsafe impl<T: imp::MyStaticInterfaceImpl> IsImplementable<T> for MyStaticInterface
-    where
-        <T as ObjectSubclass>::Type: IsA<glib::Object>,
-        <T as ObjectSubclass>::Type: IsA<MyStaticInterface>,
-    {
-    }
+    unsafe impl<T: imp::MyStaticInterfaceImpl> IsImplementable<T> for MyStaticInterface {}
 
     // an object subclass to register as a static type and that implements `MyStaticInterface`.
     glib::wrapper! {
         pub struct MyStaticType(ObjectSubclass<imp::MyStaticType>) @implements MyStaticInterface;
     }
 
-    unsafe impl<T: imp::MyStaticTypeImpl> IsSubclassable<T> for MyStaticType
-    where
-        <T as ObjectSubclass>::Type: IsA<glib::Object>,
-        <T as ObjectSubclass>::Type: IsA<MyStaticType>,
-    {
-    }
+    unsafe impl<T: imp::MyStaticTypeImpl> IsSubclassable<T> for MyStaticType {}
 }
 
 use static_::{
@@ -115,9 +101,8 @@ mod module {
             type Interface = MyModuleInterfaceClass;
         }
 
-        pub trait MyModuleInterfaceImpl: ObjectImpl + ObjectSubclass
-        where
-            <Self as ObjectSubclass>::Type: IsA<glib::Object>,
+        pub trait MyModuleInterfaceImpl:
+            ObjectImpl + ObjectSubclass<Type: IsA<super::MyModuleInterface>>
         {
         }
 
@@ -163,10 +148,8 @@ mod module {
             type Interface = MyModuleInterfaceLazyClass;
         }
 
-        pub trait MyModuleInterfaceLazyImpl: ObjectImpl + ObjectSubclass
-        where
-            <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-            <Self as ObjectSubclass>::Type: IsA<super::MyModuleInterfaceLazy>,
+        pub trait MyModuleInterfaceLazyImpl:
+            ObjectImpl + ObjectSubclass<Type: IsA<super::MyModuleInterfaceLazy>>
         {
         }
 
@@ -235,12 +218,7 @@ mod module {
         pub struct MyModuleInterface(ObjectInterface<imp::MyModuleInterface>) @requires MyStaticInterface;
     }
 
-    unsafe impl<T: imp::MyModuleInterfaceImpl> IsImplementable<T> for MyModuleInterface
-    where
-        <T as ObjectSubclass>::Type: IsA<glib::Object>,
-        <T as ObjectSubclass>::Type: IsA<MyModuleInterface>,
-    {
-    }
+    unsafe impl<T: imp::MyModuleInterfaceImpl> IsImplementable<T> for MyModuleInterface {}
 
     // an object subclass to register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyModuleInterface`.
     glib::wrapper! {
@@ -252,12 +230,7 @@ mod module {
         pub struct MyModuleInterfaceLazy(ObjectInterface<imp::MyModuleInterfaceLazy>) @requires MyStaticInterface;
     }
 
-    unsafe impl<T: imp::MyModuleInterfaceLazyImpl> IsImplementable<T> for MyModuleInterfaceLazy
-    where
-        <T as ObjectSubclass>::Type: IsA<glib::Object>,
-        <T as ObjectSubclass>::Type: IsA<MyModuleInterfaceLazy>,
-    {
-    }
+    unsafe impl<T: imp::MyModuleInterfaceLazyImpl> IsImplementable<T> for MyModuleInterfaceLazy {}
 
     // an object subclass to lazy register as a dynamic type and that extends `MyStaticType` that implements `MyStaticInterface` and `MyModuleInterfaceLazy`.
     glib::wrapper! {
@@ -374,10 +347,8 @@ pub mod plugin {
             type Interface = MyPluginInterfaceClass;
         }
 
-        pub trait MyPluginInterfaceImpl: ObjectImpl + ObjectSubclass
-        where
-            <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-            <Self as ObjectSubclass>::Type: IsA<super::MyPluginInterface>,
+        pub trait MyPluginInterfaceImpl:
+            ObjectImpl + ObjectSubclass<Type: IsA<super::MyPluginInterface>>
         {
         }
 
@@ -423,10 +394,8 @@ pub mod plugin {
             type Interface = MyPluginInterfaceLazyClass;
         }
 
-        pub trait MyPluginInterfaceLazyImpl: ObjectImpl + ObjectSubclass
-        where
-            <Self as ObjectSubclass>::Type: IsA<glib::Object>,
-            <Self as ObjectSubclass>::Type: IsA<super::MyPluginInterfaceLazy>,
+        pub trait MyPluginInterfaceLazyImpl:
+            ObjectImpl + ObjectSubclass<Type: IsA<super::MyPluginInterfaceLazy>>
         {
         }
 
@@ -449,10 +418,7 @@ pub mod plugin {
 
         impl MyStaticInterfaceImpl for MyPluginTypeLazy {}
 
-        impl MyPluginInterfaceLazyImpl for MyPluginTypeLazy where
-            <Self as ObjectSubclass>::Type: IsA<super::MyPluginInterfaceLazy>
-        {
-        }
+        impl MyPluginInterfaceLazyImpl for MyPluginTypeLazy {}
 
         // impl for a type plugin (must implement `glib::TypePlugin`).
         #[derive(Default)]
@@ -601,12 +567,7 @@ pub mod plugin {
         pub struct MyPluginInterface(ObjectInterface<imp::MyPluginInterface>) @requires MyStaticInterface;
     }
 
-    unsafe impl<T: imp::MyPluginInterfaceImpl> IsImplementable<T> for MyPluginInterface
-    where
-        <T as ObjectSubclass>::Type: IsA<glib::Object>,
-        <T as ObjectSubclass>::Type: IsA<MyPluginInterface>,
-    {
-    }
+    unsafe impl<T: imp::MyPluginInterfaceImpl> IsImplementable<T> for MyPluginInterface {}
 
     // an object subclass to register as a dynamic type and that extends `MyStaticType` and that implements `MyStaticInterface` and `MyPluginInterface`.
     glib::wrapper! {
@@ -618,12 +579,7 @@ pub mod plugin {
         pub struct MyPluginInterfaceLazy(ObjectInterface<imp::MyPluginInterfaceLazy>) @requires MyStaticInterface;
     }
 
-    unsafe impl<T: imp::MyPluginInterfaceLazyImpl> IsImplementable<T> for MyPluginInterfaceLazy
-    where
-        <T as ObjectSubclass>::Type: IsA<glib::Object>,
-        <T as ObjectSubclass>::Type: IsA<MyPluginInterfaceLazy>,
-    {
-    }
+    unsafe impl<T: imp::MyPluginInterfaceLazyImpl> IsImplementable<T> for MyPluginInterfaceLazy {}
 
     // an object subclass to lazy register as a dynamic type and that extends `MyStaticType` that implements `MyStaticInterface` and `MyPluginInterfaceLazy`.
     glib::wrapper! {

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -42,10 +42,7 @@ mod base {
         pub struct Base(ObjectSubclass<imp::Base>);
     }
 
-    unsafe impl<T: ObjectImpl> IsSubclassable<T> for Base where
-        <T as ObjectSubclass>::Type: IsA<glib::Object>
-    {
-    }
+    unsafe impl<T: ObjectImpl> IsSubclassable<T> for Base {}
 }
 
 #[cfg(test)]

--- a/glib/README.md
+++ b/glib/README.md
@@ -16,7 +16,7 @@ crates.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Dynamic typing
 

--- a/glib/src/gobject/dynamic_object.rs
+++ b/glib/src/gobject/dynamic_object.rs
@@ -41,11 +41,9 @@ pub trait DynamicObjectRegisterExt: AsRef<TypePlugin> + sealed::Sealed + 'static
     ) -> crate::types::Type;
 }
 
-impl<O: IsA<TypePlugin> + ObjectSubclassIsExt> DynamicObjectRegisterExt for O
+impl<O: IsA<Object> + IsA<TypePlugin> + ObjectSubclassIsExt> DynamicObjectRegisterExt for O
 where
     O::Subclass: TypePluginRegisterImpl,
-    <O::Subclass as ObjectSubclass>::Type: IsA<Object>,
-    <O::Subclass as ObjectSubclass>::Type: IsA<TypePlugin>,
 {
     fn add_dynamic_interface(
         &self,

--- a/glib/src/subclass/object.rs
+++ b/glib/src/subclass/object.rs
@@ -19,10 +19,7 @@ use crate::{
 ///
 /// This allows overriding the virtual methods of `glib::Object`. Except for
 /// `finalize` as implementing `Drop` would allow the same behavior.
-pub trait ObjectImpl: ObjectSubclass
-where
-    <Self as ObjectSubclass>::Type: IsA<Object>,
-{
+pub trait ObjectImpl: ObjectSubclass<Type: IsA<Object>> {
     // rustdoc-stripper-ignore-next
     /// Properties installed for this type.
     fn properties() -> &'static [ParamSpec] {
@@ -95,9 +92,7 @@ unsafe extern "C" fn property<T: ObjectImpl>(
     id: u32,
     value: *mut gobject_ffi::GValue,
     pspec: *mut gobject_ffi::GParamSpec,
-) where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-{
+) {
     let instance = &*(obj as *mut T::Instance);
     let imp = instance.imp();
 
@@ -121,9 +116,7 @@ unsafe extern "C" fn set_property<T: ObjectImpl>(
     id: u32,
     value: *mut gobject_ffi::GValue,
     pspec: *mut gobject_ffi::GParamSpec,
-) where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-{
+) {
     let instance = &*(obj as *mut T::Instance);
     let imp = instance.imp();
     imp.set_property(
@@ -133,10 +126,7 @@ unsafe extern "C" fn set_property<T: ObjectImpl>(
     );
 }
 
-unsafe extern "C" fn constructed<T: ObjectImpl>(obj: *mut gobject_ffi::GObject)
-where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-{
+unsafe extern "C" fn constructed<T: ObjectImpl>(obj: *mut gobject_ffi::GObject) {
     let instance = &*(obj as *mut T::Instance);
     let imp = instance.imp();
 
@@ -146,9 +136,7 @@ where
 unsafe extern "C" fn notify<T: ObjectImpl>(
     obj: *mut gobject_ffi::GObject,
     pspec: *mut gobject_ffi::GParamSpec,
-) where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-{
+) {
     let instance = &*(obj as *mut T::Instance);
     let imp = instance.imp();
     imp.notify(&from_glib_borrow(pspec));
@@ -158,18 +146,13 @@ unsafe extern "C" fn dispatch_properties_changed<T: ObjectImpl>(
     obj: *mut gobject_ffi::GObject,
     n_pspecs: u32,
     pspecs: *mut *mut gobject_ffi::GParamSpec,
-) where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-{
+) {
     let instance = &*(obj as *mut T::Instance);
     let imp = instance.imp();
     imp.dispatch_properties_changed(Slice::from_glib_borrow_num(pspecs, n_pspecs as _));
 }
 
-unsafe extern "C" fn dispose<T: ObjectImpl>(obj: *mut gobject_ffi::GObject)
-where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-{
+unsafe extern "C" fn dispose<T: ObjectImpl>(obj: *mut gobject_ffi::GObject) {
     let instance = &*(obj as *mut T::Instance);
     let imp = instance.imp();
 
@@ -230,10 +213,7 @@ pub unsafe trait ObjectClassSubclassExt: Sized + 'static {
 
 unsafe impl ObjectClassSubclassExt for crate::Class<Object> {}
 
-unsafe impl<T: ObjectImpl> IsSubclassable<T> for Object
-where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-{
+unsafe impl<T: ObjectImpl> IsSubclassable<T> for Object {
     fn class_init(class: &mut crate::Class<Self>) {
         let klass = class.as_mut();
         klass.set_property = Some(set_property::<T>);
@@ -273,10 +253,7 @@ where
     fn instance_init(_instance: &mut super::InitializingObject<T>) {}
 }
 
-pub trait ObjectImplExt: ObjectSubclass + ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<Object>,
-{
+pub trait ObjectImplExt: ObjectImpl {
     // rustdoc-stripper-ignore-next
     /// Chain up to the parent class' implementation of `glib::Object::constructed()`.
     #[inline]
@@ -339,7 +316,7 @@ where
     }
 }
 
-impl<T: ObjectImpl> ObjectImplExt for T where <T as ObjectSubclass>::Type: IsA<Object> {}
+impl<T: ObjectImpl> ObjectImplExt for T {}
 
 #[cfg(test)]
 mod test {

--- a/glib/src/subclass/type_module.rs
+++ b/glib/src/subclass/type_module.rs
@@ -2,11 +2,7 @@
 
 use crate::{ffi, gobject_ffi, prelude::*, subclass::prelude::*, translate::*, Object, TypeModule};
 
-pub trait TypeModuleImpl: ObjectImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<Object>,
-    <Self as ObjectSubclass>::Type: IsA<TypeModule>,
-{
+pub trait TypeModuleImpl: ObjectImpl + ObjectSubclass<Type: IsA<Object> + IsA<TypeModule>> {
     // rustdoc-stripper-ignore-next
     /// Loads the module, registers one or more object subclasses using
     /// [`register_dynamic_type`] and registers one or more object interfaces
@@ -25,20 +21,12 @@ where
     fn unload(&self);
 }
 
-pub trait TypeModuleImplExt: ObjectSubclass + TypeModuleImpl
-where
-    <Self as ObjectSubclass>::Type: IsA<Object>,
-    <Self as ObjectSubclass>::Type: IsA<TypeModule>,
-{
+pub trait TypeModuleImplExt: TypeModuleImpl {
     fn parent_load(&self) -> bool;
     fn parent_unload(&self);
 }
 
-impl<T: TypeModuleImpl> TypeModuleImplExt for T
-where
-    <Self as ObjectSubclass>::Type: IsA<Object>,
-    <Self as ObjectSubclass>::Type: IsA<TypeModule>,
-{
+impl<T: TypeModuleImpl> TypeModuleImplExt for T {
     fn parent_load(&self) -> bool {
         unsafe {
             let data = T::type_data();
@@ -70,11 +58,7 @@ where
     }
 }
 
-unsafe impl<T: TypeModuleImpl> IsSubclassable<T> for TypeModule
-where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-    <T as ObjectSubclass>::Type: IsA<TypeModule>,
-{
+unsafe impl<T: TypeModuleImpl> IsSubclassable<T> for TypeModule {
     fn class_init(class: &mut crate::Class<Self>) {
         Self::parent_class_init::<T>(class);
 
@@ -86,11 +70,7 @@ where
 
 unsafe extern "C" fn load<T: TypeModuleImpl>(
     type_module: *mut gobject_ffi::GTypeModule,
-) -> ffi::gboolean
-where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-    <T as ObjectSubclass>::Type: IsA<TypeModule>,
-{
+) -> ffi::gboolean {
     let instance = &*(type_module as *mut T::Instance);
     let imp = instance.imp();
 
@@ -110,11 +90,7 @@ where
     res.into_glib()
 }
 
-unsafe extern "C" fn unload<T: TypeModuleImpl>(type_module: *mut gobject_ffi::GTypeModule)
-where
-    <T as ObjectSubclass>::Type: IsA<Object>,
-    <T as ObjectSubclass>::Type: IsA<TypeModule>,
-{
+unsafe extern "C" fn unload<T: TypeModuleImpl>(type_module: *mut gobject_ffi::GTypeModule) {
     let instance = &*(type_module as *mut T::Instance);
     let imp = instance.imp();
 

--- a/glib/tests/subclass_compiletest/04-auto-send-sync-with-send-sync-parent.rs
+++ b/glib/tests/subclass_compiletest/04-auto-send-sync-with-send-sync-parent.rs
@@ -19,16 +19,15 @@ glib::wrapper! {
     pub struct TestParent(ObjectSubclass<imp_parent::TestParent>);
 }
 
-pub trait TestParentImpl: glib::subclass::prelude::ObjectImpl + Send + Sync
-where
-    <Self as glib::subclass::prelude::ObjectSubclass>::Type: glib::prelude::IsA<glib::Object>,
+pub trait TestParentImpl:
+    Send
+    + Sync
+    + glib::subclass::prelude::ObjectImpl
+    + glib::subclass::prelude::ObjectSubclass<Type: glib::prelude::IsA<TestParent>>
 {
 }
 
-unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for TestParent where
-    <T as glib::subclass::prelude::ObjectSubclass>::Type: glib::prelude::IsA<glib::Object>
-{
-}
+unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for TestParent {}
 
 impl Default for TestParent {
     fn default() -> Self {

--- a/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs
+++ b/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs
@@ -20,16 +20,13 @@ glib::wrapper! {
     pub struct TestParent(ObjectSubclass<imp_parent::TestParent>);
 }
 
-pub trait TestParentImpl: glib::subclass::prelude::ObjectImpl
-where
-    <Self as glib::subclass::prelude::ObjectSubclass>::Type: glib::prelude::IsA<glib::Object>,
+pub trait TestParentImpl:
+    glib::subclass::prelude::ObjectImpl
+    + glib::subclass::prelude::ObjectSubclass<Type: glib::prelude::IsA<TestParent>>
 {
 }
 
-unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for TestParent where
-    <T as glib::subclass::prelude::ObjectSubclass>::Type: glib::prelude::IsA<glib::Object>
-{
-}
+unsafe impl<T: TestParentImpl> glib::subclass::prelude::IsSubclassable<T> for TestParent {}
 
 impl Default for TestParent {
     fn default() -> Self {

--- a/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.stderr
+++ b/glib/tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `RefCell<std::string::String>` cannot be shared between threads safely
-  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:73:11
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:70:11
    |
-73 |     check(&obj);
+70 |     check(&obj);
    |     ----- ^^^^ `RefCell<std::string::String>` cannot be shared between threads safely
    |     |
    |     required by a bound introduced by this call
@@ -21,12 +21,12 @@ note: required because it appears within the type `TestParent`
    |                ^^^^^^^^^^
    = note: required for `TypedObjectRef<imp_object::TestObject, TestParent>` to implement `Send`
 note: required because it appears within the type `TestObject`
-  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:60:16
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:57:16
    |
-60 |     pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends TestParent;
+57 |     pub struct TestObject(ObjectSubclass<imp_object::TestObject>) @extends TestParent;
    |                ^^^^^^^^^^
 note: required by a bound in `main::check`
-  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:70:17
+  --> tests/subclass_compiletest/05-no-auto-send-sync-with-non-send-sync-parent.rs:67:17
    |
-70 |     fn check<T: Send + Sync>(_obj: &T) {}
+67 |     fn check<T: Send + Sync>(_obj: &T) {}
    |                 ^^^^ required by this bound in `check`

--- a/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs
+++ b/glib/tests/subclass_compiletest/06-no-auto-send-sync-with-non-send-sync-ffi-parent.rs
@@ -7,14 +7,14 @@ glib::wrapper! {
     }
 }
 
-pub trait InitiallyUnownedImpl: glib::subclass::prelude::ObjectImpl
-where
-    <Self as glib::subclass::prelude::ObjectSubclass>::Type: glib::prelude::IsA<glib::Object>,
+pub trait InitiallyUnownedImpl:
+    glib::subclass::prelude::ObjectImpl
+    + glib::subclass::prelude::ObjectSubclass<Type: glib::prelude::IsA<InitiallyUnowned>>
 {
 }
 
-unsafe impl<T: InitiallyUnownedImpl> glib::subclass::prelude::IsSubclassable<T> for InitiallyUnowned where
-    <T as glib::subclass::prelude::ObjectSubclass>::Type: glib::prelude::IsA<glib::Object>
+unsafe impl<T: InitiallyUnownedImpl> glib::subclass::prelude::IsSubclassable<T>
+    for InitiallyUnowned
 {
 }
 

--- a/graphene/README.md
+++ b/graphene/README.md
@@ -6,7 +6,7 @@ Graphene __1.10__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Documentation
 

--- a/pango/README.md
+++ b/pango/README.md
@@ -6,7 +6,7 @@ Pango __1.40__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Documentation
 

--- a/pangocairo/README.md
+++ b/pangocairo/README.md
@@ -7,7 +7,7 @@ PangoCairo __1.40__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.70.0`.
+Currently, the minimum supported Rust version is `1.80.0`.
 
 ## Documentation
 

--- a/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
+++ b/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
@@ -6,7 +6,7 @@ description = "crate that depends on a glib-rs dependent crate for validation of
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.80"
 
 [dependencies]
 # Use `gstreamer` as a simulation of an identified crate re-exporting `glib`.

--- a/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
@@ -7,7 +7,7 @@ description = "gstreamer simulator as a glib dependent crate for validation of g
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.80"
 
 [dependencies]
 glib = { path = "../../../glib" }

--- a/tests/two-levels-glib-dependent/gtk/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gtk/Cargo.toml
@@ -7,7 +7,7 @@ description = "gtk simulator as a glib dependent crate for validation of glib re
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.80"
 
 [dependencies]
 glib = { path = "../../../glib" }


### PR DESCRIPTION
This removes a lot of the boilerplate introduced by #1519 by using supertraits instead of where clauses. Supertraits are allowed to imply their trait bounds since rust 1.79.

This bumps MSRV to 1.80.

IMO it's easier to review this against d8dfa3a26184e7c6010744233fe5cc516310438e than master, as it reverts most of what that's doing.