### PR TITLE
cairo/src/xcb.rs: use crate::Borrowed when not using glib

### DIFF
--- a/cairo/src/xcb.rs
+++ b/cairo/src/xcb.rs
@@ -7,6 +7,9 @@ use std::{ops::Deref, ptr};
 #[cfg(feature = "use_glib")]
 use glib::translate::*;
 
+#[cfg(not(feature = "use_glib"))]
+use crate::Borrowed;
+
 use crate::{ffi, Error, Surface, SurfaceType};
 
 #[derive(Debug)]


### PR DESCRIPTION
cairo currently does not compile when using xcb and not using glib, because crate::Borrowed is not imported but is used. This fixes that.

```
> cd cairo/
> cargo c --no-default-features --features=xcb
error[E0412]: cannot find type `Borrowed` in this scope
  --> cairo/src/xcb.rs:49:71
   |
49 |     pub unsafe fn from_raw_borrow(ptr: *mut ffi::xcb_connection_t) -> Borrowed<XCBConnection> {
   |                                                                       ^^^^^^^^ not found in this scope
   |
help: consider importing this struct through its public re-export
   |
5  + use crate::Borrowed;
   |
<same error about 10 other times>
```