### PR TITLE
glib: Add unimplemented diagnostic to IsA linking to the wrapper macro

### DIFF
--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -63,6 +63,11 @@ pub unsafe trait ObjectType:
 ///
 /// The trait can only be implemented if the appropriate `ToGlibPtr`
 /// implementations exist.
+#[diagnostic::on_unimplemented(
+    message = "the trait `glib::object::IsA<{T}>` is not implemented for `{Self}`",
+    label = "requires `{Self}` to be a GObject that can be statically cast to `{T}`",
+    note = "if this is your own object, use the `glib::wrapper!` macro to implement this trait: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.wrapper.html"
+)]
 pub unsafe trait IsA<T: ObjectType>:
     ObjectType + Into<T> + AsRef<T> + std::borrow::Borrow<T>
 {


### PR DESCRIPTION
Emits errors such as these:

```
error[E0277]: the trait `glib::object::IsA<purrable::Purrable>` is not implemented for `tabby_cat::TabbyCat`
  --> examples/virtual_methods/main.rs:38:30
   |
38 |     let purrable = tabby_cat.upcast_ref::<Purrable>();
   |                              ^^^^^^^^^^ requires `tabby_cat::TabbyCat` to be a GObject that can be cast as `purrable::Purrable`
   |
   = help: the trait `glib::object::IsA<purrable::Purrable>` is not implemented for `tabby_cat::TabbyCat`
   = note: if this is your own object, use the `glib::wrapper!` macro to implement this trait: https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/macro.wrapper.html
   = help: the following other types implement trait `glib::object::IsA<T>`:
             `tabby_cat::TabbyCat` implements `glib::object::IsA<Object>`
             `tabby_cat::TabbyCat` implements `glib::object::IsA<cat::Cat>`
             `tabby_cat::TabbyCat` implements `glib::object::IsA<tabby_cat::TabbyCat>`
note: required by a bound in `upcast_ref`
  --> /home/fina/Code/gtk-rs-core/glib/src/object.rs:118:5

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
warning: `gtk-rs-examples` (bin "virtual_methods") generated 1 warning
error: could not compile `gtk-rs-examples` (bin "virtual_methods") due to 9 previous errors; 1 warning emitted
```

Compared to

```
error[E0277]: the trait bound `tabby_cat::TabbyCat: glib::object::IsA<purrable::Purrable>` is not satisfied
   --> examples/virtual_methods/main.rs:38:30
    |
38  |     let purrable = tabby_cat.upcast_ref::<Purrable>();
    |                              ^^^^^^^^^^ the trait `glib::object::IsA<purrable::Purrable>` is not implemented for `tabby_cat::TabbyCat`
    |
    = help: the following other types implement trait `glib::object::IsA<T>`:
              `tabby_cat::TabbyCat` implements `glib::object::IsA<Object>`
              `tabby_cat::TabbyCat` implements `glib::object::IsA<cat::Cat>`
              `tabby_cat::TabbyCat` implements `glib::object::IsA<tabby_cat::TabbyCat>`
note: required by a bound in `upcast_ref`
   --> /home/fina/Code/gtk-rs-core/glib/src/object.rs:116:15
    |
114 |     fn upcast_ref<T: ObjectType>(&self) -> &T
    |        ---------- required by a bound in this associated function
115 |     where
116 |         Self: IsA<T>,
    |               ^^^^^^ required by this bound in `Cast::upcast_ref`

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
warning: `gtk-rs-examples` (bin "virtual_methods") generated 1 warning
error: could not compile `gtk-rs-examples` (bin "virtual_methods") due to 9 previous errors; 1 warning emitted
```

The most important part here being the link to the `glib::wrapper!` docs.

We could probably add a few more diagnostics to some of the core traits, but I am not sure where it makes sense.