### PR TITLE
glib-macros: Derived boxed types are not TransparentPtrType but `TransparentType`

### DIFF
--- a/glib-macros/src/boxed_derive.rs
+++ b/glib-macros/src/boxed_derive.rs
@@ -192,7 +192,9 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> syn::Result<TokenStream> {
 
         #impl_from_value
 
-        unsafe impl #crate_ident::translate::TransparentPtrType for #name {}
+        unsafe impl #crate_ident::translate::TransparentType for #name {
+            type GlibType = #name;
+        }
 
         impl #crate_ident::translate::GlibPtrDefault for #name {
             type GlibType = *mut #name;

--- a/glib-macros/tests/test.rs
+++ b/glib-macros/tests/test.rs
@@ -1,7 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
 use glib::{
-    collections::PtrSlice,
+    collections::Slice,
     prelude::*,
     translate::{FromGlib, IntoGlib},
 };
@@ -185,19 +185,16 @@ fn derive_boxed_nullable() {
 }
 
 #[test]
-fn boxed_transparent_ptr() {
+fn boxed_transparent() {
     #[derive(Clone, Debug, PartialEq, Eq, glib::Boxed)]
     #[boxed_type(name = "MyBoxed")]
     struct MyBoxed(String);
 
     let vec = vec![MyBoxed(String::from("abc")), MyBoxed(String::from("dfg"))];
 
-    // PtrSlice requires TransparentPtrType trait
-    let ptr_slice = PtrSlice::from(vec);
-    assert_eq!(
-        ptr_slice.last(),
-        Some(MyBoxed(String::from("dfg"))).as_ref()
-    );
+    // Slice requires TransparentType trait
+    let slice = Slice::from(vec);
+    assert_eq!(slice.last(), Some(MyBoxed(String::from("dfg"))).as_ref());
 }
 
 #[test]

--- a/glib/src/collections/ptr_slice.rs
+++ b/glib/src/collections/ptr_slice.rs
@@ -601,6 +601,11 @@ impl<T: TransparentPtrType> PtrSlice<T> {
     /// Creates a new empty slice.
     #[inline]
     pub fn new() -> Self {
+        debug_assert_eq!(
+            mem::size_of::<T>(),
+            mem::size_of::<<T as GlibPtrDefault>::GlibType>()
+        );
+
         PtrSlice {
             ptr: ptr::NonNull::dangling(),
             len: 0,

--- a/glib/src/collections/slice.rs
+++ b/glib/src/collections/slice.rs
@@ -403,6 +403,7 @@ impl<T: TransparentType> Slice<T> {
     /// Borrows a C array.
     #[inline]
     pub unsafe fn from_glib_borrow_num<'a>(ptr: *const T::GlibType, len: usize) -> &'a [T] {
+        debug_assert_eq!(mem::size_of::<T>(), mem::size_of::<T::GlibType>());
         debug_assert!(!ptr.is_null() || len == 0);
 
         if len == 0 {
@@ -416,6 +417,7 @@ impl<T: TransparentType> Slice<T> {
     /// Borrows a mutable C array.
     #[inline]
     pub unsafe fn from_glib_borrow_num_mut<'a>(ptr: *mut T::GlibType, len: usize) -> &'a mut [T] {
+        debug_assert_eq!(mem::size_of::<T>(), mem::size_of::<T::GlibType>());
         debug_assert!(!ptr.is_null() || len == 0);
 
         if len == 0 {
@@ -432,6 +434,7 @@ impl<T: TransparentType> Slice<T> {
         ptr: *const *const T::GlibType,
         len: usize,
     ) -> &'a [&'a T] {
+        debug_assert_eq!(mem::size_of::<T>(), mem::size_of::<T::GlibType>());
         debug_assert!(!ptr.is_null() || len == 0);
 
         if len == 0 {
@@ -448,6 +451,7 @@ impl<T: TransparentType> Slice<T> {
         ptr: *mut *mut T::GlibType,
         len: usize,
     ) -> &'a mut [&'a mut T] {
+        debug_assert_eq!(mem::size_of::<T>(), mem::size_of::<T::GlibType>());
         debug_assert!(!ptr.is_null() || len == 0);
 
         if len == 0 {
@@ -522,6 +526,8 @@ impl<T: TransparentType> Slice<T> {
     /// Creates a new empty slice.
     #[inline]
     pub fn new() -> Self {
+        debug_assert_eq!(mem::size_of::<T>(), mem::size_of::<T::GlibType>());
+
         Slice {
             ptr: ptr::NonNull::dangling(),
             len: 0,


### PR DESCRIPTION
I.e. they're equal to their FFI representation, not equal to a pointer of their FFI representation.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1554

----

@pbor you introduced this in 84c951ef5a62. Sorry for not catching that. I'll backport this breaking change to the 0.20 branch and include it in the next bugfix release because this was simply wrong and could've only worked by chance (and usually involve memory corruption).