### PR TITLE
pango: Fix `LayoutLine::x_ranges()` bindings

### DIFF
--- a/pango/Gir.toml
+++ b/pango/Gir.toml
@@ -383,6 +383,9 @@ status = "generate"
     [[object.function]]
     name = "x_to_index"
     manual = true
+    [[object.function]]
+    name = "get_x_ranges"
+    manual = true
 
 [[object]]
 name = "Pango.Matrix"

--- a/pango/src/auto/layout_line.rs
+++ b/pango/src/auto/layout_line.rs
@@ -90,23 +90,6 @@ impl LayoutLine {
         unsafe { ffi::pango_layout_line_get_start_index(self.to_glib_none().0) }
     }
 
-    #[doc(alias = "pango_layout_line_get_x_ranges")]
-    #[doc(alias = "get_x_ranges")]
-    pub fn x_ranges(&self, start_index: i32, end_index: i32) -> Vec<i32> {
-        unsafe {
-            let mut ranges = std::ptr::null_mut();
-            let mut n_ranges = std::mem::MaybeUninit::uninit();
-            ffi::pango_layout_line_get_x_ranges(
-                self.to_glib_none().0,
-                start_index,
-                end_index,
-                &mut ranges,
-                n_ranges.as_mut_ptr(),
-            );
-            FromGlibContainer::from_glib_full_num(ranges, n_ranges.assume_init() as _)
-        }
-    }
-
     #[doc(alias = "pango_layout_line_index_to_x")]
     pub fn index_to_x(&self, index_: i32, trailing: bool) -> i32 {
         unsafe {

--- a/pango/src/layout.rs
+++ b/pango/src/layout.rs
@@ -90,4 +90,21 @@ impl LayoutLine {
             is_inside,
         }
     }
+
+    #[doc(alias = "pango_layout_line_get_x_ranges")]
+    #[doc(alias = "get_x_ranges")]
+    pub fn x_ranges(&self, start_index: i32, end_index: i32) -> Vec<i32> {
+        unsafe {
+            let mut ranges = std::ptr::null_mut();
+            let mut n_ranges = std::mem::MaybeUninit::uninit();
+            ffi::pango_layout_line_get_x_ranges(
+                self.to_glib_none().0,
+                start_index,
+                end_index,
+                &mut ranges,
+                n_ranges.as_mut_ptr(),
+            );
+            FromGlibContainer::from_glib_full_num(ranges, 2 * n_ranges.assume_init() as usize)
+        }
+    }
 }


### PR DESCRIPTION
The returned array has 2*n_ranges elements, not just n_ranges.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1563