### PR TITLE
gio: manually implement content_type_guess

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -249,9 +249,9 @@ status = "generate"
     ignore = true
     [[object.function]]
     name = "content_type_guess"
-        [[object.function.parameter]]
-        name = "filename"
-        string_type = "filename"
+    # implemented manually until gir generates nullable array parameters
+    # https://github.com/gtk-rs/gir/issues/1133
+    manual = true
 
 [[object]]
 name = "Gio.ActionGroup"

--- a/gio/src/auto/functions.rs
+++ b/gio/src/auto/functions.rs
@@ -178,24 +178,6 @@ pub fn content_type_get_symbolic_icon(type_: &str) -> Icon {
     }
 }
 
-#[doc(alias = "g_content_type_guess")]
-pub fn content_type_guess(
-    filename: Option<impl AsRef<std::path::Path>>,
-    data: &[u8],
-) -> (glib::GString, bool) {
-    let data_size = data.len() as _;
-    unsafe {
-        let mut result_uncertain = std::mem::MaybeUninit::uninit();
-        let ret = from_glib_full(ffi::g_content_type_guess(
-            filename.as_ref().map(|p| p.as_ref()).to_glib_none().0,
-            data.to_glib_none().0,
-            data_size,
-            result_uncertain.as_mut_ptr(),
-        ));
-        (ret, from_glib(result_uncertain.assume_init()))
-    }
-}
-
 #[doc(alias = "g_content_type_guess_for_tree")]
 pub fn content_type_guess_for_tree(root: &impl IsA<File>) -> Vec<glib::GString> {
     unsafe {

--- a/gio/src/content_type.rs
+++ b/gio/src/content_type.rs
@@ -1,0 +1,26 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use std::ptr;
+
+use glib::translate::*;
+
+use crate::ffi;
+
+#[doc(alias = "g_content_type_guess")]
+pub fn content_type_guess<'a>(
+    filename: Option<impl AsRef<std::path::Path>>,
+    data: impl Into<Option<&'a [u8]>>,
+) -> (glib::GString, bool) {
+    let data = data.into();
+    let data_size = data.map_or(0, |d| d.len());
+    unsafe {
+        let mut result_uncertain = std::mem::MaybeUninit::uninit();
+        let ret = from_glib_full(ffi::g_content_type_guess(
+            filename.as_ref().map(|p| p.as_ref()).to_glib_none().0,
+            data.map_or(ptr::null(), |d| d.to_glib_none().0),
+            data_size,
+            result_uncertain.as_mut_ptr(),
+        ));
+        (ret, from_glib(result_uncertain.assume_init()))
+    }
+}

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -21,6 +21,7 @@ mod async_initable;
 mod cancellable;
 mod cancellable_future;
 pub use crate::cancellable_future::{CancellableFuture, Cancelled};
+mod content_type;
 mod converter;
 mod credentials;
 mod data_input_stream;
@@ -115,6 +116,7 @@ pub mod builders {
 
 pub mod functions {
     pub use super::auto::functions::*;
+    pub use super::content_type::content_type_guess;
 }
 
 pub use crate::auto::*;

--- a/gio/tests/content_type.rs
+++ b/gio/tests/content_type.rs
@@ -1,0 +1,15 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+#[cfg(unix)]
+#[test]
+fn test_content_type_guess() {
+    // We only test for directory and file without extension here as we can't guarantee the
+    // CI runners will have any mimetypes installed.
+    let ret: (glib::GString, bool) =
+        gio::functions::content_type_guess(Some(std::path::Path::new("test/")), None);
+    assert_eq!(ret.0, "inode/directory");
+
+    let ret: (glib::GString, bool) =
+        gio::functions::content_type_guess(Some(std::path::Path::new("test")), None);
+    assert_eq!(ret.0, "application/octet-stream");
+}


### PR DESCRIPTION
Related: https://github.com/gtk-rs/gtk-rs-core/issues/1257

In C, `g_content_type_guess` supports passing NULL to the `data` parameter which makes it guess the content type based on the filename only.

So, add a manually written `content_type_guess` allowing `Option` for the `data` parameter. This is a stopgap until `gir` can generate the optional parameter for these cases.

This is an API break in some cases, but should continue to compile in most cases.