### PR TITLE
gio: Export `RegistrationBuilder` from the crate root

### DIFF
--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -29,8 +29,8 @@ mod dbus;
 pub use self::dbus::*;
 mod dbus_connection;
 pub use self::dbus_connection::{
-    ActionGroupExportId, FilterId, MenuModelExportId, RegistrationId, SignalSubscriptionId,
-    WatcherId,
+    ActionGroupExportId, FilterId, MenuModelExportId, RegistrationBuilder, RegistrationId,
+    SignalSubscriptionId, WatcherId,
 };
 mod dbus_message;
 mod dbus_method_invocation;


### PR DESCRIPTION
It was not exported at all before.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1597