### PR TITLE
gio: Only provide UNIX mount compat API on UNIX platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
  "shell-words",
  "system-deps",
  "tempfile",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/gio/sys/src/manual.rs
+++ b/gio/sys/src/manual.rs
@@ -174,6 +174,7 @@ mod windows_streams {
 }
 
 #[cfg(not(feature = "v2_84"))]
+#[cfg(target_family = "unix")]
 mod unix_mount_compat {
     #![allow(clippy::missing_safety_doc)]
 
@@ -284,4 +285,5 @@ mod unix_mount_compat {
 }
 
 #[cfg(not(feature = "v2_84"))]
+#[cfg(target_family = "unix")]
 pub use unix_mount_compat::*;


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/librsvg/-/issues/1126#note_2298554