### PR TITLE
glib: Remove SendWeakRef::new() because implementation is unsound

### DIFF
--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -3583,18 +3583,13 @@ impl<T: ObjectType> PartialOrd for WeakRef<T> {
 /// where it was created on will panic but dropping or cloning can be done
 /// safely from any thread.
 #[derive(Debug)]
-pub struct SendWeakRef<T: ObjectType>(WeakRef<T>, Option<usize>);
+pub struct SendWeakRef<T: ObjectType>(WeakRef<T>, usize);
 
 impl<T: ObjectType> SendWeakRef<T> {
     #[inline]
-    pub fn new() -> SendWeakRef<T> {
-        SendWeakRef(WeakRef::new(), None)
-    }
-
-    #[inline]
     pub fn into_weak_ref(self) -> WeakRef<T> {
         assert!(
-            self.1.is_none() || self.1 == Some(thread_id()),
+            self.1 == thread_id(),
             "SendWeakRef dereferenced on a different thread",
         );
 
@@ -3608,7 +3603,7 @@ impl<T: ObjectType> ops::Deref for SendWeakRef<T> {
     #[inline]
     fn deref(&self) -> &WeakRef<T> {
         assert!(
-            self.1.is_none() || self.1 == Some(thread_id()),
+            self.1 == thread_id(),
             "SendWeakRef dereferenced on a different thread"
         );
 
@@ -3627,14 +3622,14 @@ impl<T: ObjectType> Clone for SendWeakRef<T> {
 impl<T: ObjectType> Default for SendWeakRef<T> {
     #[inline]
     fn default() -> Self {
-        Self::new()
+        Self::from(WeakRef::new())
     }
 }
 
 impl<T: ObjectType> From<WeakRef<T>> for SendWeakRef<T> {
     #[inline]
     fn from(v: WeakRef<T>) -> SendWeakRef<T> {
-        SendWeakRef(v, Some(thread_id()))
+        SendWeakRef(v, thread_id())
     }
 }
 


### PR DESCRIPTION
Fixes #1617

Not sure whether it would be better to remove the Default impl too, I've kept it for now.