### PR TITLE
Expose dbus_register and dbus_unregister vfuncs

### DIFF
--- a/examples/gio_dbus_register_object/main.rs
+++ b/examples/gio_dbus_register_object/main.rs
@@ -1,126 +1,162 @@
-use gio::{prelude::*, IOErrorEnum};
-use std::{
-    sync::mpsc::{channel, Receiver, Sender},
-    time::Duration,
-};
+use gio::prelude::*;
 
-const EXAMPLE_XML: &str = r#"
-  <node>
-    <interface name='com.github.gtk_rs.examples.HelloWorld'>
-      <method name='Hello'>
-        <arg type='s' name='name' direction='in'/>
-        <arg type='s' name='greet' direction='out'/>
-      </method>
-      <method name='SlowHello'>
-        <arg type='s' name='name' direction='in'/>
-        <arg type='u' name='delay' direction='in'/>
-        <arg type='s' name='greet' direction='out'/>
-      </method>
-    </interface>
-  </node>
+glib::wrapper! {
+    pub struct SampleApplication(ObjectSubclass<imp::SampleApplication>)
+        @extends gio::Application,
+        @implements gio::ActionGroup, gio::ActionMap;
+}
+
+impl Default for SampleApplication {
+    fn default() -> Self {
+        glib::Object::builder()
+            .property(
+                "application-id",
+                "com.github.gtk-rs.examples.RegisterDBusObject",
+            )
+            .build()
+    }
+}
+
+mod imp {
+    use std::cell::RefCell;
+    use std::time::Duration;
+
+    use gio::prelude::*;
+    use gio::subclass::prelude::*;
+    use gio::{DBusConnection, IOErrorEnum};
+
+    const EXAMPLE_XML: &str = r#"
+<node>
+  <interface name='com.github.gtk_rs.examples.HelloWorld'>
+    <method name='Hello'>
+      <arg type='s' name='name' direction='in'/>
+      <arg type='s' name='greet' direction='out'/>
+    </method>
+    <method name='SlowHello'>
+      <arg type='s' name='name' direction='in'/>
+      <arg type='u' name='delay' direction='in'/>
+      <arg type='s' name='greet' direction='out'/>
+    </method>
+  </interface>
+</node>
 "#;
 
-#[derive(Debug, glib::Variant)]
-struct Hello {
-    name: String,
-}
-
-#[derive(Debug, glib::Variant)]
-struct SlowHello {
-    name: String,
-    delay: u32,
-}
-
-#[derive(Debug)]
-enum HelloMethod {
-    Hello(Hello),
-    SlowHello(SlowHello),
-}
-
-impl DBusMethodCall for HelloMethod {
-    fn parse_call(
-        _obj_path: &str,
-        _interface: Option<&str>,
-        method: &str,
-        params: glib::Variant,
-    ) -> Result<Self, glib::Error> {
-        match method {
-            "Hello" => Ok(params.get::<Hello>().map(Self::Hello)),
-            "SlowHello" => Ok(params.get::<SlowHello>().map(Self::SlowHello)),
-            _ => Err(glib::Error::new(IOErrorEnum::Failed, "No such method")),
-        }
-        .and_then(|p| p.ok_or_else(|| glib::Error::new(IOErrorEnum::Failed, "Invalid parameters")))
+    #[derive(Debug, glib::Variant)]
+    struct Hello {
+        name: String,
     }
-}
 
-fn on_startup(app: &gio::Application, tx: &Sender<gio::RegistrationId>) {
-    let connection = app.dbus_connection().expect("connection");
+    #[derive(Debug, glib::Variant)]
+    struct SlowHello {
+        name: String,
+        delay: u32,
+    }
 
-    let example = gio::DBusNodeInfo::for_xml(EXAMPLE_XML)
-        .ok()
-        .and_then(|e| e.lookup_interface("com.github.gtk_rs.examples.HelloWorld"))
-        .expect("Example interface");
+    #[derive(Debug)]
+    enum HelloMethod {
+        Hello(Hello),
+        SlowHello(SlowHello),
+    }
 
-    if let Ok(id) = connection
-        .register_object("/com/github/gtk_rs/examples/HelloWorld", &example)
-        .typed_method_call::<HelloMethod>()
-        .invoke_and_return_future_local(|_, sender, call| {
-            println!("Method call from {sender:?}");
-            async {
-                match call {
-                    HelloMethod::Hello(Hello { name }) => {
-                        let greet = format!("Hello {name}!");
-                        println!("{greet}");
-                        Ok(Some(greet.to_variant()))
+    impl DBusMethodCall for HelloMethod {
+        fn parse_call(
+            _obj_path: &str,
+            _interface: Option<&str>,
+            method: &str,
+            params: glib::Variant,
+        ) -> Result<Self, glib::Error> {
+            match method {
+                "Hello" => Ok(params.get::<Hello>().map(Self::Hello)),
+                "SlowHello" => Ok(params.get::<SlowHello>().map(Self::SlowHello)),
+                _ => Err(glib::Error::new(IOErrorEnum::Failed, "No such method")),
+            }
+            .and_then(|p| {
+                p.ok_or_else(|| glib::Error::new(IOErrorEnum::Failed, "Invalid parameters"))
+            })
+        }
+    }
+
+    #[derive(Default)]
+    pub struct SampleApplication {
+        registration_id: RefCell<Option<gio::RegistrationId>>,
+    }
+
+    impl SampleApplication {
+        fn register_object(&self, connection: &DBusConnection) {
+            let example = gio::DBusNodeInfo::for_xml(EXAMPLE_XML)
+                .ok()
+                .and_then(|e| e.lookup_interface("com.github.gtk_rs.examples.HelloWorld"))
+                .expect("Example interface");
+
+            if let Ok(id) = connection
+                .register_object("/com/github/gtk_rs/examples/HelloWorld", &example)
+                .typed_method_call::<HelloMethod>()
+                .invoke_and_return_future_local(|_, sender, call| {
+                    println!("Method call from {sender:?}");
+                    async {
+                        match call {
+                            HelloMethod::Hello(Hello { name }) => {
+                                let greet = format!("Hello {name}!");
+                                println!("{greet}");
+                                Ok(Some(greet.to_variant()))
+                            }
+                            HelloMethod::SlowHello(SlowHello { name, delay }) => {
+                                glib::timeout_future(Duration::from_secs(delay as u64)).await;
+                                let greet = format!("Hello {name} after {delay} seconds!");
+                                println!("{greet}");
+                                Ok(Some(greet.to_variant()))
+                            }
+                        }
                     }
-                    HelloMethod::SlowHello(SlowHello { name, delay }) => {
-                        glib::timeout_future(Duration::from_secs(delay as u64)).await;
-                        let greet = format!("Hello {name} after {delay} seconds!");
-                        println!("{greet}");
-                        Ok(Some(greet.to_variant()))
-                    }
+                })
+                .build()
+            {
+                println!("Registered object");
+                self.registration_id.replace(Some(id));
+            } else {
+                eprintln!("Could not register object");
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SampleApplication {
+        const NAME: &'static str = "SampleApplication";
+
+        type Type = super::SampleApplication;
+
+        type ParentType = gio::Application;
+    }
+
+    impl ObjectImpl for SampleApplication {}
+
+    impl ApplicationImpl for SampleApplication {
+        fn startup(&self) {
+            self.parent_startup();
+            let connection = self.obj().dbus_connection().expect("connection");
+            self.register_object(&connection);
+        }
+
+        fn shutdown(&self) {
+            if let Some(id) = self.registration_id.take() {
+                let connection = self.obj().dbus_connection().expect("connection");
+                if connection.unregister_object(id).is_ok() {
+                    println!("Unregistered object");
+                } else {
+                    eprintln!("Could not unregister object");
                 }
             }
-        })
-        .build()
-    {
-        println!("Registered object");
-        tx.send(id).unwrap();
-    } else {
-        eprintln!("Could not register object");
-    }
-}
+        }
 
-fn on_shutdown(app: &gio::Application, rx: &Receiver<gio::RegistrationId>) {
-    let connection = app.dbus_connection().expect("connection");
-    if let Ok(registration_id) = rx.try_recv() {
-        if connection.unregister_object(registration_id).is_ok() {
-            println!("Unregistered object");
-        } else {
-            eprintln!("Could not unregister object");
+        fn activate(&self) {
+            println!("Waiting for DBus Hello method to be called. Call the following command from another terminal:");
+            println!("dbus-send --print-reply --dest=com.github.gtk-rs.examples.RegisterDBusObject /com/github/gtk_rs/examples/HelloWorld com.github.gtk_rs.examples.HelloWorld.Hello string:YourName");
         }
     }
 }
 
 fn main() -> glib::ExitCode {
-    let app = gio::Application::builder()
-        .application_id("com.github.gtk-rs.examples.RegisterDBusObject")
-        .build();
+    let app = SampleApplication::default();
     let _guard = app.hold();
-    let (tx, rx) = channel::<gio::RegistrationId>();
-
-    app.connect_startup(move |app| {
-        on_startup(app, &tx);
-    });
-
-    app.connect_activate(move |_| {
-        println!("Waiting for DBus Hello method to be called. Call the following command from another terminal:");
-        println!("dbus-send --print-reply --dest=com.github.gtk-rs.examples.RegisterDBusObject /com/github/gtk_rs/examples/HelloWorld com.github.gtk_rs.examples.HelloWorld.Hello string:YourName");
-    });
-
-    app.connect_shutdown(move |app| {
-        on_shutdown(app, &rx);
-    });
-
     app.run()
 }

--- a/examples/gio_dbus_register_object/main.rs
+++ b/examples/gio_dbus_register_object/main.rs
@@ -23,7 +23,7 @@ mod imp {
 
     use gio::prelude::*;
     use gio::subclass::prelude::*;
-    use gio::{DBusConnection, IOErrorEnum};
+    use gio::{DBusConnection, DBusError};
 
     const EXAMPLE_XML: &str = r#"
 <node>
@@ -71,10 +71,10 @@ mod imp {
                 "Hello" => Ok(params.get::<Hello>().map(Self::Hello)),
                 "SlowHello" => Ok(params.get::<SlowHello>().map(Self::SlowHello)),
                 "GoodBye" => Ok(Some(Self::GoodBye)),
-                _ => Err(glib::Error::new(IOErrorEnum::Failed, "No such method")),
+                _ => Err(glib::Error::new(DBusError::UnknownMethod, "No such method")),
             }
             .and_then(|p| {
-                p.ok_or_else(|| glib::Error::new(IOErrorEnum::Failed, "Invalid parameters"))
+                p.ok_or_else(|| glib::Error::new(DBusError::InvalidArgs, "Invalid parameters"))
             })
         }
     }

--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -114,6 +114,10 @@ pub trait ApplicationImpl:
     fn dbus_register(&self, connection: &DBusConnection, object_path: &str) -> Result<(), Error> {
         self.parent_dbus_register(connection, object_path)
     }
+
+    fn dbus_unregister(&self, connection: &DBusConnection, object_path: &str) {
+        self.parent_dbus_unregister(connection, object_path)
+    }
 }
 
 pub trait ApplicationImplExt: ApplicationImpl {
@@ -297,6 +301,21 @@ pub trait ApplicationImplExt: ApplicationImpl {
             }
         }
     }
+
+    fn parent_dbus_unregister(&self, connection: &DBusConnection, object_path: &str) {
+        unsafe {
+            let data = Self::type_data();
+            let parent_class = data.as_ref().parent_class() as *mut ffi::GApplicationClass;
+            let f = (*parent_class)
+                .dbus_unregister
+                .expect("No parent class implementation for \"dbus_unregister\"");
+            f(
+                self.obj().unsafe_cast_ref::<Application>().to_glib_none().0,
+                connection.to_glib_none().0,
+                object_path.to_glib_none().0,
+            );
+        }
+    }
 }
 
 impl<T: ApplicationImpl> ApplicationImplExt for T {}
@@ -317,7 +336,8 @@ unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application {
         klass.shutdown = Some(application_shutdown::<T>);
         klass.startup = Some(application_startup::<T>);
         klass.handle_local_options = Some(application_handle_local_options::<T>);
-        klass.dbus_register = Some(application_dbus_register::<T>)
+        klass.dbus_register = Some(application_dbus_register::<T>);
+        klass.dbus_unregister = Some(application_dbus_unregister::<T>);
     }
 }
 
@@ -443,6 +463,19 @@ unsafe extern "C" fn application_dbus_register<T: ApplicationImpl>(
             glib::ffi::GFALSE
         }
     }
+}
+
+unsafe extern "C" fn application_dbus_unregister<T: ApplicationImpl>(
+    ptr: *mut ffi::GApplication,
+    connection: *mut ffi::GDBusConnection,
+    object_path: *const c_char,
+) {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.imp();
+    imp.dbus_unregister(
+        &from_glib_borrow(connection),
+        &glib::GString::from_glib_borrow(object_path),
+    );
 }
 
 #[cfg(test)]

--- a/gio/src/subclass/application.rs
+++ b/gio/src/subclass/application.rs
@@ -2,10 +2,10 @@
 
 use std::{ffi::OsString, fmt, ops::Deref, ptr};
 
-use glib::{prelude::*, subclass::prelude::*, translate::*, ExitCode, VariantDict};
+use glib::{prelude::*, subclass::prelude::*, translate::*, Error, ExitCode, VariantDict};
 use libc::{c_char, c_int, c_void};
 
-use crate::{ffi, ActionGroup, ActionMap, Application};
+use crate::{ffi, ActionGroup, ActionMap, Application, DBusConnection};
 
 pub struct ArgumentList {
     pub(crate) ptr: *mut *mut *mut c_char,
@@ -109,6 +109,10 @@ pub trait ApplicationImpl:
 
     fn handle_local_options(&self, options: &VariantDict) -> ExitCode {
         self.parent_handle_local_options(options)
+    }
+
+    fn dbus_register(&self, connection: &DBusConnection, object_path: &str) -> Result<(), Error> {
+        self.parent_dbus_register(connection, object_path)
     }
 }
 
@@ -266,6 +270,33 @@ pub trait ApplicationImplExt: ApplicationImpl {
             }
         }
     }
+
+    fn parent_dbus_register(
+        &self,
+        connection: &DBusConnection,
+        object_path: &str,
+    ) -> Result<(), glib::Error> {
+        unsafe {
+            let data = Self::type_data();
+            let parent_class = data.as_ref().parent_class() as *mut ffi::GApplicationClass;
+            let f = (*parent_class)
+                .dbus_register
+                .expect("No parent class implementation for \"dbus_register\"");
+            let mut err = ptr::null_mut();
+            let res = f(
+                self.obj().unsafe_cast_ref::<Application>().to_glib_none().0,
+                connection.to_glib_none().0,
+                object_path.to_glib_none().0,
+                &mut err,
+            );
+            if res == glib::ffi::GFALSE {
+                Err(from_glib_full(err))
+            } else {
+                debug_assert!(err.is_null());
+                Ok(())
+            }
+        }
+    }
 }
 
 impl<T: ApplicationImpl> ApplicationImplExt for T {}
@@ -286,6 +317,7 @@ unsafe impl<T: ApplicationImpl> IsSubclassable<T> for Application {
         klass.shutdown = Some(application_shutdown::<T>);
         klass.startup = Some(application_startup::<T>);
         klass.handle_local_options = Some(application_handle_local_options::<T>);
+        klass.dbus_register = Some(application_dbus_register::<T>)
     }
 }
 
@@ -388,6 +420,29 @@ unsafe extern "C" fn application_handle_local_options<T: ApplicationImpl>(
     let imp = instance.imp();
 
     imp.handle_local_options(&from_glib_borrow(options)).into()
+}
+
+unsafe extern "C" fn application_dbus_register<T: ApplicationImpl>(
+    ptr: *mut ffi::GApplication,
+    connection: *mut ffi::GDBusConnection,
+    object_path: *const c_char,
+    error: *mut *mut glib::ffi::GError,
+) -> glib::ffi::gboolean {
+    let instance = &*(ptr as *mut T::Instance);
+    let imp = instance.imp();
+
+    match imp.dbus_register(
+        &from_glib_borrow(connection),
+        &glib::GString::from_glib_borrow(object_path),
+    ) {
+        Ok(()) => glib::ffi::GTRUE,
+        Err(e) => {
+            if !error.is_null() {
+                *error = e.into_glib_ptr();
+            }
+            glib::ffi::GFALSE
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Using this vfunc makes exporting objects on the app's bus name much easier and more reliable.

I've rewritten the corresponding example to use these two methods, as the GIO docs recommend to use these vfuncs for object registration.  Also, registering an object in startup is prone to race conditions wrt to bus ownership as the object gets registered only after the application claimed the bus name.