### PR TITLE
gio: Use manual env: &[OsString] parameter for SubprocessLauncher::set_environ

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -1443,6 +1443,9 @@ status = "generate"
     [[object.function]]
     name = "close"
     cfg_condition = "unix"
+    [[object.function]]
+    name = "set_environ"
+    manual = true
 
 [[object]]
 name = "Gio.ThemedIcon"

--- a/gio/src/auto/subprocess_launcher.rs
+++ b/gio/src/auto/subprocess_launcher.rs
@@ -79,13 +79,6 @@ impl SubprocessLauncher {
         }
     }
 
-    #[doc(alias = "g_subprocess_launcher_set_environ")]
-    pub fn set_environ(&self, env: &[&std::path::Path]) {
-        unsafe {
-            ffi::g_subprocess_launcher_set_environ(self.to_glib_none().0, env.to_glib_none().0);
-        }
-    }
-
     #[doc(alias = "g_subprocess_launcher_set_flags")]
     pub fn set_flags(&self, flags: SubprocessFlags) {
         unsafe {

--- a/gio/src/subprocess_launcher.rs
+++ b/gio/src/subprocess_launcher.rs
@@ -3,12 +3,9 @@
 #[cfg(any(unix, all(docsrs, unix)))]
 use std::os::unix::io::IntoRawFd;
 
-#[cfg(unix)]
 use glib::translate::*;
 
-#[cfg(unix)]
 use crate::ffi;
-
 use crate::SubprocessLauncher;
 
 #[cfg(all(docsrs, not(unix)))]
@@ -19,6 +16,13 @@ pub trait IntoRawFd: Sized {
 }
 
 impl SubprocessLauncher {
+    #[doc(alias = "g_subprocess_launcher_set_environ")]
+    pub fn set_environ(&self, env: &[std::ffi::OsString]) {
+        unsafe {
+            ffi::g_subprocess_launcher_set_environ(self.to_glib_none().0, env.to_glib_none().0);
+        }
+    }
+
     #[cfg(unix)]
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     #[doc(alias = "g_subprocess_launcher_take_fd")]


### PR DESCRIPTION
See #1638

This should be better than the existing bindings, but changing the API to something that accepts `&[impl AsRef<OsStr>]` would be preferable.