### PR TITLE
Re-export CancelledHandlerId

### DIFF
--- a/gio/src/cancellable_future.rs
+++ b/gio/src/cancellable_future.rs
@@ -9,7 +9,7 @@ use std::{
 
 use pin_project_lite::pin_project;
 
-use crate::{cancellable::CancelledHandlerId, prelude::*, Cancellable, IOErrorEnum};
+use crate::{prelude::*, Cancellable, CancelledHandlerId, IOErrorEnum};
 
 // rustdoc-stripper-ignore-next
 /// Indicator that the [`CancellableFuture`] was cancelled.

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -19,6 +19,7 @@ pub use action_entry::{ActionEntry, ActionEntryBuilder};
 pub use application::{ApplicationBusyGuard, ApplicationHoldGuard};
 mod async_initable;
 mod cancellable;
+pub use cancellable::CancelledHandlerId;
 mod cancellable_future;
 pub use crate::cancellable_future::{CancellableFuture, Cancelled};
 mod converter;


### PR DESCRIPTION
This type is effectively public, because it’s returned by `Cancellable::connect_cancelled`, but because it’s not re-exported it can’t be named, making it awkward to e.g. save it in a struct field.

Fixes GH-1649.