### PR TITLE
Remove unsafe interface requirement for into ptr conversion

### DIFF
--- a/cairo/src/context.rs
+++ b/cairo/src/context.rs
@@ -60,7 +60,7 @@ pub struct Context(ptr::NonNull<ffi::cairo_t>);
 #[cfg_attr(docsrs, doc(cfg(feature = "use_glib")))]
 impl IntoGlibPtr<*mut ffi::cairo_t> for Context {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::cairo_t {
+    fn into_glib_ptr(self) -> *mut ffi::cairo_t {
         (&*std::mem::ManuallyDrop::new(self)).to_glib_none().0
     }
 }

--- a/cairo/src/device.rs
+++ b/cairo/src/device.rs
@@ -317,7 +317,7 @@ impl Device {
 #[cfg_attr(docsrs, doc(cfg(feature = "use_glib")))]
 impl IntoGlibPtr<*mut ffi::cairo_device_t> for Device {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::cairo_device_t {
+    fn into_glib_ptr(self) -> *mut ffi::cairo_device_t {
         std::mem::ManuallyDrop::new(self).to_glib_none().0
     }
 }

--- a/cairo/src/region.rs
+++ b/cairo/src/region.rs
@@ -17,7 +17,7 @@ pub struct Region(ptr::NonNull<ffi::cairo_region_t>);
 #[cfg(feature = "use_glib")]
 impl IntoGlibPtr<*mut ffi::cairo_region_t> for Region {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::cairo_region_t {
+    fn into_glib_ptr(self) -> *mut ffi::cairo_region_t {
         (&*std::mem::ManuallyDrop::new(self)).to_glib_none().0
     }
 }

--- a/cairo/src/surface.rs
+++ b/cairo/src/surface.rs
@@ -292,7 +292,7 @@ impl Surface {
 #[cfg(feature = "use_glib")]
 impl IntoGlibPtr<*mut ffi::cairo_surface_t> for Surface {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::cairo_surface_t {
+    fn into_glib_ptr(self) -> *mut ffi::cairo_surface_t {
         std::mem::ManuallyDrop::new(self).to_glib_none().0
     }
 }

--- a/cairo/src/surface_macros.rs
+++ b/cairo/src/surface_macros.rs
@@ -41,7 +41,7 @@ macro_rules! declare_surface {
         #[cfg(feature = "use_glib")]
         impl IntoGlibPtr<*mut crate::ffi::cairo_surface_t> for $surf_name {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut crate::ffi::cairo_surface_t {
+            fn into_glib_ptr(self) -> *mut crate::ffi::cairo_surface_t {
                 std::mem::ManuallyDrop::new(self).to_glib_none().0
             }
         }

--- a/glib-macros/src/boxed_derive.rs
+++ b/glib-macros/src/boxed_derive.rs
@@ -241,7 +241,7 @@ pub fn impl_boxed(input: &syn::DeriveInput) -> syn::Result<TokenStream> {
 
         impl #crate_ident::translate::IntoGlibPtr<*mut #name> for #name {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut #name {
+            fn into_glib_ptr(self) -> *mut #name {
                 ::std::boxed::Box::into_raw(::std::boxed::Box::new(self)) as *mut _
             }
         }

--- a/glib-macros/src/shared_boxed_derive.rs
+++ b/glib-macros/src/shared_boxed_derive.rs
@@ -262,7 +262,7 @@ pub fn impl_shared_boxed(input: &syn::DeriveInput) -> syn::Result<proc_macro2::T
 
         impl #crate_ident::translate::IntoGlibPtr<*mut #refcounted_type_prefix::InnerType> for #name {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut #refcounted_type_prefix::InnerType {
+            fn into_glib_ptr(self) -> *mut #refcounted_type_prefix::InnerType {
                 let r = <Self as #crate_ident::subclass::shared::SharedType>::into_refcounted(self);
                 #refcounted_type_prefix::into_raw(r) as *mut _
             }

--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -306,7 +306,7 @@ macro_rules! glib_boxed_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*mut $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut $ffi_name {
+            fn into_glib_ptr(self) -> *mut $ffi_name {
                 let s = std::mem::ManuallyDrop::new(self);
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(&*s).0 as *mut _
             }
@@ -315,7 +315,7 @@ macro_rules! glib_boxed_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*const $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *const $ffi_name {
+            fn into_glib_ptr(self) -> *const $ffi_name {
                 let s = std::mem::ManuallyDrop::new(self);
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(&*s).0 as *const _
             }

--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -538,7 +538,7 @@ macro_rules! glib_boxed_inline_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*mut $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut $ffi_name {
+            fn into_glib_ptr(self) -> *mut $ffi_name {
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_full(&self) as *mut _
             }
         }
@@ -546,7 +546,7 @@ macro_rules! glib_boxed_inline_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*const $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *const $ffi_name {
+            fn into_glib_ptr(self) -> *const $ffi_name {
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_full(&self)
             }
         }

--- a/glib/src/collections/list.rs
+++ b/glib/src/collections/list.rs
@@ -621,7 +621,7 @@ impl<'a, T: TransparentPtrType + 'a> ToGlibPtrMut<'a, *mut ffi::GList> for List<
 
 impl<T: TransparentPtrType> IntoGlibPtr<*mut ffi::GList> for List<T> {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::GList {
+    fn into_glib_ptr(self) -> *mut ffi::GList {
         self.into_raw()
     }
 }

--- a/glib/src/collections/ptr_slice.rs
+++ b/glib/src/collections/ptr_slice.rs
@@ -1050,7 +1050,7 @@ impl<'a, T: TransparentPtrType + 'a> ToGlibPtrMut<'a, *mut <T as GlibPtrDefault>
 
 impl<T: TransparentPtrType> IntoGlibPtr<*mut <T as GlibPtrDefault>::GlibType> for PtrSlice<T> {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut <T as GlibPtrDefault>::GlibType {
+    fn into_glib_ptr(self) -> *mut <T as GlibPtrDefault>::GlibType {
         self.into_raw()
     }
 }

--- a/glib/src/collections/slice.rs
+++ b/glib/src/collections/slice.rs
@@ -874,7 +874,7 @@ impl<'a, T: TransparentType + 'a> ToGlibPtrMut<'a, *mut T::GlibType> for Slice<T
 
 impl<T: TransparentType + 'static> IntoGlibPtr<*mut T::GlibType> for Slice<T> {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut T::GlibType {
+    fn into_glib_ptr(self) -> *mut T::GlibType {
         self.into_raw()
     }
 }

--- a/glib/src/collections/slist.rs
+++ b/glib/src/collections/slist.rs
@@ -615,7 +615,7 @@ impl<'a, T: TransparentPtrType + 'a> ToGlibPtrMut<'a, *mut ffi::GSList> for SLis
 
 impl<T: TransparentPtrType> IntoGlibPtr<*mut ffi::GSList> for SList<T> {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::GSList {
+    fn into_glib_ptr(self) -> *mut ffi::GSList {
         self.into_raw()
     }
 }

--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -1010,7 +1010,7 @@ impl<'a> ToGlibPtr<'a, *const *mut c_char> for StrV {
 
 impl IntoGlibPtr<*mut *mut c_char> for StrV {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut *mut c_char {
+    fn into_glib_ptr(self) -> *mut *mut c_char {
         self.into_raw()
     }
 }

--- a/glib/src/gstring.rs
+++ b/glib/src/gstring.rs
@@ -775,7 +775,7 @@ impl Deref for GStringPtr {
 
 impl IntoGlibPtr<*mut c_char> for GStringPtr {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut c_char {
+    fn into_glib_ptr(self) -> *mut c_char {
         self.0.as_ptr()
     }
 }
@@ -1518,16 +1518,16 @@ impl IntoGlibPtr<*mut c_char> for GString {
     // rustdoc-stripper-ignore-next
     /// Transform into a nul-terminated raw C string pointer.
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut c_char {
+    fn into_glib_ptr(self) -> *mut c_char {
         match self.0 {
-            Inner::Native(ref s) => ffi::g_strndup(s.as_ptr() as *const _, s.len()),
+            Inner::Native(ref s) => unsafe { ffi::g_strndup(s.as_ptr() as *const _, s.len()) },
             Inner::Foreign { ptr, .. } => {
                 let _s = mem::ManuallyDrop::new(self);
                 ptr.as_ptr()
             }
-            Inner::Inline { len, ref data } => {
+            Inner::Inline { len, ref data } => unsafe {
                 ffi::g_strndup(data.as_ptr() as *const _, len as usize)
-            }
+            },
         }
     }
 }
@@ -2127,7 +2127,7 @@ impl<'a> ToGlibPtr<'a, *const u8> for GString {
 
     #[inline]
     fn to_glib_full(&self) -> *const u8 {
-        unsafe { self.clone().into_glib_ptr() as *const u8 }
+        self.clone().into_glib_ptr() as *const u8
     }
 }
 
@@ -2143,7 +2143,7 @@ impl<'a> ToGlibPtr<'a, *const i8> for GString {
 
     #[inline]
     fn to_glib_full(&self) -> *const i8 {
-        unsafe { self.clone().into_glib_ptr() as *const i8 }
+        self.clone().into_glib_ptr() as *const i8
     }
 }
 
@@ -2159,7 +2159,7 @@ impl<'a> ToGlibPtr<'a, *mut u8> for GString {
 
     #[inline]
     fn to_glib_full(&self) -> *mut u8 {
-        unsafe { self.clone().into_glib_ptr() as *mut u8 }
+        self.clone().into_glib_ptr() as *mut u8
     }
 }
 
@@ -2175,7 +2175,7 @@ impl<'a> ToGlibPtr<'a, *mut i8> for GString {
 
     #[inline]
     fn to_glib_full(&self) -> *mut i8 {
-        unsafe { self.clone().into_glib_ptr() as *mut i8 }
+        self.clone().into_glib_ptr() as *mut i8
     }
 }
 

--- a/glib/src/match_info.rs
+++ b/glib/src/match_info.rs
@@ -152,7 +152,7 @@ impl FromGlibPtrBorrow<*const ffi::GMatchInfo> for MatchInfo<'_> {
 #[doc(hidden)]
 impl IntoGlibPtr<*mut ffi::GMatchInfo> for MatchInfo<'_> {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::GMatchInfo {
+    fn into_glib_ptr(self) -> *mut ffi::GMatchInfo {
         let s = std::mem::ManuallyDrop::new(self);
         ToGlibPtr::<*const ffi::GMatchInfo>::to_glib_none(&*s).0 as *mut _
     }
@@ -160,7 +160,7 @@ impl IntoGlibPtr<*mut ffi::GMatchInfo> for MatchInfo<'_> {
 #[doc(hidden)]
 impl IntoGlibPtr<*const ffi::GMatchInfo> for MatchInfo<'_> {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *const ffi::GMatchInfo {
+    fn into_glib_ptr(self) -> *const ffi::GMatchInfo {
         let s = std::mem::ManuallyDrop::new(self);
         ToGlibPtr::<*const ffi::GMatchInfo>::to_glib_none(&*s).0 as *const _
     }

--- a/glib/src/object.rs
+++ b/glib/src/object.rs
@@ -813,7 +813,7 @@ macro_rules! glib_object_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*mut $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut $ffi_name {
+            fn into_glib_ptr(self) -> *mut $ffi_name {
                 let s = std::mem::ManuallyDrop::new(self);
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(&*s).0 as *mut _
             }
@@ -822,7 +822,7 @@ macro_rules! glib_object_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*const $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *const $ffi_name {
+            fn into_glib_ptr(self) -> *const $ffi_name {
                 let s = std::mem::ManuallyDrop::new(self);
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(&*s).0 as *const _
             }

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -434,7 +434,7 @@ macro_rules! define_param_spec {
         #[doc(hidden)]
         impl IntoGlibPtr<*mut gobject_ffi::GParamSpec> for $rust_type {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut gobject_ffi::GParamSpec {
+            fn into_glib_ptr(self) -> *mut gobject_ffi::GParamSpec {
                 let s = std::mem::ManuallyDrop::new(self);
                 s.to_glib_none().0
             }
@@ -443,7 +443,7 @@ macro_rules! define_param_spec {
         #[doc(hidden)]
         impl IntoGlibPtr<*const gobject_ffi::GParamSpec> for $rust_type {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *const gobject_ffi::GParamSpec {
+            fn into_glib_ptr(self) -> *const gobject_ffi::GParamSpec {
                 let s = std::mem::ManuallyDrop::new(self);
                 s.to_glib_none().0
             }

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -323,7 +323,7 @@ macro_rules! glib_shared_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*mut $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *mut $ffi_name {
+            fn into_glib_ptr(self) -> *mut $ffi_name {
                 let s = std::mem::ManuallyDrop::new(self);
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(&*s).0 as *mut _
             }
@@ -332,7 +332,7 @@ macro_rules! glib_shared_wrapper {
         #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::IntoGlibPtr<*const $ffi_name> for $name $(<$($generic),+>)? {
             #[inline]
-            unsafe fn into_glib_ptr(self) -> *const $ffi_name {
+            fn into_glib_ptr(self) -> *const $ffi_name {
                 let s = std::mem::ManuallyDrop::new(self);
                 $crate::translate::ToGlibPtr::<*const $ffi_name>::to_glib_none(&*s).0 as *const _
             }

--- a/glib/src/subclass/boxed.rs
+++ b/glib/src/subclass/boxed.rs
@@ -131,7 +131,7 @@ mod test {
         assert!(MyBoxed::static_type().is_valid());
 
         let b = MyBoxed(String::from("abc"));
-        let raw_ptr = unsafe { MyBoxed::into_glib_ptr(b) };
+        let raw_ptr = MyBoxed::into_glib_ptr(b);
 
         // test that the from_glib_borrow does not take ownership of the raw_ptr
         let _ = unsafe { MyBoxed::from_glib_borrow(raw_ptr) };

--- a/glib/src/subclass/shared.rs
+++ b/glib/src/subclass/shared.rs
@@ -20,7 +20,7 @@ pub unsafe trait RefCounted: Clone + Sized + 'static {
 
     // rustdoc-stripper-ignore-next
     /// Converts the RefCounted object to a raw pointer to InnerType
-    unsafe fn into_raw(self) -> *const Self::InnerType;
+    fn into_raw(self) -> *const Self::InnerType;
 
     // rustdoc-stripper-ignore-next
     /// Converts a raw pointer to InnerType to a RefCounted object
@@ -45,7 +45,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_raw(self) -> *const Self::InnerType {
+    fn into_raw(self) -> *const Self::InnerType {
         std::sync::Arc::into_raw(self)
     }
 
@@ -74,7 +74,7 @@ where
     }
 
     #[inline]
-    unsafe fn into_raw(self) -> *const Self::InnerType {
+    fn into_raw(self) -> *const Self::InnerType {
         std::rc::Rc::into_raw(self)
     }
 

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -716,12 +716,12 @@ pub trait IntoGlibPtr<P: Ptr> {
     // rustdoc-stripper-ignore-next
     /// Transfer: full.
     #[allow(clippy::wrong_self_convention)]
-    unsafe fn into_glib_ptr(self) -> P;
+    fn into_glib_ptr(self) -> P;
 }
 
 impl<P: Ptr, T: IntoGlibPtr<P>> IntoGlibPtr<P> for Option<T> {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> P {
+    fn into_glib_ptr(self) -> P {
         self.map_or(Ptr::from::<()>(ptr::null_mut()), |s| {
             IntoGlibPtr::into_glib_ptr(s)
         })

--- a/glib/src/variant_type.rs
+++ b/glib/src/variant_type.rs
@@ -186,7 +186,7 @@ impl<'a> From<VariantType> for Cow<'a, VariantTy> {
 #[doc(hidden)]
 impl IntoGlibPtr<*mut ffi::GVariantType> for VariantType {
     #[inline]
-    unsafe fn into_glib_ptr(self) -> *mut ffi::GVariantType {
+    fn into_glib_ptr(self) -> *mut ffi::GVariantType {
         std::mem::ManuallyDrop::new(self).to_glib_none().0
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/gtk-rs/gtk-rs-core/issues/1663

### For reviewers to focus on
Beside "`sed` changes", manual changes also include:
 * `impl IntoGlibPtr<*mut c_char> for GString` requires inner `unsafe` block as calling `extern "C"` functions
 * `pub unsafe trait RefCounted::into_raw` also changed removing `unsafe` requirement.
 * This is a API (breaking/major) change