### PR TITLE
gio: Return `glib::ExitCode` from `gio::Application` signal handlers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.80.0"
+          - "1.83.0"
         conf:
           - { name: "cairo", features: "png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface", nightly: "--features 'png,pdf,svg,ps,use_glib,v1_18,freetype,script,xcb,xlib,win32-surface'", test_sys: true }
           - { name: "gdk-pixbuf", features: "v2_42", nightly: "--all-features", test_sys: true }
@@ -104,7 +104,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.80.0"
+          - "1.83.0"
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ repository = "https://github.com/gtk-rs/gtk-rs-core"
 license = "MIT"
 exclude = ["gir-files/*"]
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.83"
 
 [workspace.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ information about each crate, please refer to their `README.md` file in their di
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Documentation
 

--- a/cairo/README.md
+++ b/cairo/README.md
@@ -8,7 +8,7 @@ Cairo __1.14__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Default-on features
 

--- a/gdk-pixbuf/README.md
+++ b/gdk-pixbuf/README.md
@@ -6,7 +6,7 @@ GDK-PixBuf __2.36.8__ is the lowest supported version for the underlying library
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Documentation
 

--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -310,6 +310,14 @@ generate_builder = true
     name = "open"
     manual = true
     doc_trait_name = "ApplicationExtManual"
+    [[object.signal]]
+    name = "command-line"
+    manual = true
+    doc_trait_name = "ApplicationExtManual"
+    [[object.signal]]
+    name = "handle-local-options"
+    manual = true
+    doc_trait_name = "ApplicationExtManual"
     [[object.function]]
     name = "run"
     manual = true

--- a/gio/README.md
+++ b/gio/README.md
@@ -6,7 +6,7 @@ GIO __2.56__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Documentation
 

--- a/gio/src/application.rs
+++ b/gio/src/application.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::{boxed::Box as Box_, mem::transmute};
+use std::{boxed::Box as Box_, mem::transmute, ops::ControlFlow};
 
 use glib::{
     prelude::*,
@@ -9,13 +9,14 @@ use glib::{
     ExitCode, GString,
 };
 
-use crate::{ffi, Application, File};
+use crate::{ffi, Application, ApplicationCommandLine, File};
 
 pub trait ApplicationExtManual: IsA<Application> {
     #[doc(alias = "g_application_run")]
     fn run(&self) -> ExitCode {
         self.run_with_args(&std::env::args().collect::<Vec<_>>())
     }
+
     #[doc(alias = "g_application_run")]
     fn run_with_args<S: AsRef<str>>(&self, args: &[S]) -> ExitCode {
         let argv: Vec<&str> = args.iter().map(|a| a.as_ref()).collect();
@@ -23,8 +24,10 @@ pub trait ApplicationExtManual: IsA<Application> {
         let exit_code = unsafe {
             ffi::g_application_run(self.as_ref().to_glib_none().0, argc, argv.to_glib_none().0)
         };
-        ExitCode::from(exit_code)
+        ExitCode::try_from(exit_code).unwrap()
     }
+
+    #[doc(alias = "open")]
     fn connect_open<F: Fn(&Self, &[File], &str) + 'static>(&self, f: F) -> SignalHandlerId {
         unsafe extern "C" fn open_trampoline<P, F: Fn(&P, &[File], &str) + 'static>(
             this: *mut ffi::GApplication,
@@ -50,6 +53,76 @@ pub trait ApplicationExtManual: IsA<Application> {
                 b"open\0".as_ptr() as *const _,
                 Some(transmute::<*const (), unsafe extern "C" fn()>(
                     open_trampoline::<Self, F> as *const (),
+                )),
+                Box_::into_raw(f),
+            )
+        }
+    }
+
+    #[doc(alias = "command-line")]
+    fn connect_command_line<F: Fn(&Self, &ApplicationCommandLine) -> ExitCode + 'static>(
+        &self,
+        f: F,
+    ) -> SignalHandlerId {
+        unsafe extern "C" fn command_line_trampoline<
+            P: IsA<Application>,
+            F: Fn(&P, &ApplicationCommandLine) -> ExitCode + 'static,
+        >(
+            this: *mut ffi::GApplication,
+            command_line: *mut ffi::GApplicationCommandLine,
+            f: glib::ffi::gpointer,
+        ) -> std::ffi::c_int {
+            let f: &F = &*(f as *const F);
+            f(
+                Application::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(command_line),
+            )
+            .into()
+        }
+        unsafe {
+            let f: Box_<F> = Box_::new(f);
+            connect_raw(
+                self.as_ptr() as *mut _,
+                c"command-line".as_ptr() as *const _,
+                Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
+                    command_line_trampoline::<Self, F> as *const (),
+                )),
+                Box_::into_raw(f),
+            )
+        }
+    }
+
+    #[doc(alias = "handle-local-options")]
+    fn connect_handle_local_options<
+        F: Fn(&Self, &glib::VariantDict) -> ControlFlow<ExitCode> + 'static,
+    >(
+        &self,
+        f: F,
+    ) -> SignalHandlerId {
+        unsafe extern "C" fn handle_local_options_trampoline<
+            P: IsA<Application>,
+            F: Fn(&P, &glib::VariantDict) -> ControlFlow<ExitCode> + 'static,
+        >(
+            this: *mut ffi::GApplication,
+            options: *mut glib::ffi::GVariantDict,
+            f: glib::ffi::gpointer,
+        ) -> std::ffi::c_int {
+            let f: &F = &*(f as *const F);
+            f(
+                Application::from_glib_borrow(this).unsafe_cast_ref(),
+                &from_glib_borrow(options),
+            )
+            .break_value()
+            .map(i32::from)
+            .unwrap_or(-1)
+        }
+        unsafe {
+            let f: Box_<F> = Box_::new(f);
+            connect_raw(
+                self.as_ptr() as *mut _,
+                c"handle-local-options".as_ptr() as *const _,
+                Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
+                    handle_local_options_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )

--- a/gio/src/auto/application.rs
+++ b/gio/src/auto/application.rs
@@ -3,8 +3,7 @@
 // DO NOT EDIT
 
 use crate::{
-    ffi, ActionGroup, ActionMap, ApplicationCommandLine, ApplicationFlags, Cancellable,
-    DBusConnection, File, Notification,
+    ffi, ActionGroup, ActionMap, ApplicationFlags, Cancellable, DBusConnection, File, Notification,
 };
 use glib::{
     object::ObjectType as _,
@@ -458,70 +457,6 @@ pub trait ApplicationExt: IsA<Application> + 'static {
                 c"activate".as_ptr() as *const _,
                 Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
                     activate_trampoline::<Self, F> as *const (),
-                )),
-                Box_::into_raw(f),
-            )
-        }
-    }
-
-    #[doc(alias = "command-line")]
-    fn connect_command_line<F: Fn(&Self, &ApplicationCommandLine) -> i32 + 'static>(
-        &self,
-        f: F,
-    ) -> SignalHandlerId {
-        unsafe extern "C" fn command_line_trampoline<
-            P: IsA<Application>,
-            F: Fn(&P, &ApplicationCommandLine) -> i32 + 'static,
-        >(
-            this: *mut ffi::GApplication,
-            command_line: *mut ffi::GApplicationCommandLine,
-            f: glib::ffi::gpointer,
-        ) -> std::ffi::c_int {
-            let f: &F = &*(f as *const F);
-            f(
-                Application::from_glib_borrow(this).unsafe_cast_ref(),
-                &from_glib_borrow(command_line),
-            )
-        }
-        unsafe {
-            let f: Box_<F> = Box_::new(f);
-            connect_raw(
-                self.as_ptr() as *mut _,
-                c"command-line".as_ptr() as *const _,
-                Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
-                    command_line_trampoline::<Self, F> as *const (),
-                )),
-                Box_::into_raw(f),
-            )
-        }
-    }
-
-    #[doc(alias = "handle-local-options")]
-    fn connect_handle_local_options<F: Fn(&Self, &glib::VariantDict) -> i32 + 'static>(
-        &self,
-        f: F,
-    ) -> SignalHandlerId {
-        unsafe extern "C" fn handle_local_options_trampoline<
-            P: IsA<Application>,
-            F: Fn(&P, &glib::VariantDict) -> i32 + 'static,
-        >(
-            this: *mut ffi::GApplication,
-            options: *mut glib::ffi::GVariantDict,
-            f: glib::ffi::gpointer,
-        ) -> std::ffi::c_int {
-            let f: &F = &*(f as *const F);
-            f(
-                Application::from_glib_borrow(this).unsafe_cast_ref(),
-                &from_glib_borrow(options),
-            )
-        }
-        unsafe {
-            let f: Box_<F> = Box_::new(f);
-            connect_raw(
-                self.as_ptr() as *mut _,
-                c"handle-local-options".as_ptr() as *const _,
-                Some(std::mem::transmute::<*const (), unsafe extern "C" fn()>(
-                    handle_local_options_trampoline::<Self, F> as *const (),
                 )),
                 Box_::into_raw(f),
             )

--- a/gio/src/gio_future.rs
+++ b/gio/src/gio_future.rs
@@ -115,7 +115,7 @@ where
             && self
                 .receiver
                 .as_ref()
-                .map_or(true, |receiver| receiver.is_terminated())
+                .is_none_or(|receiver| receiver.is_terminated())
     }
 }
 

--- a/glib-build-tools/README.md
+++ b/glib-build-tools/README.md
@@ -4,7 +4,7 @@ Crate containing helpers for building GIO-based applications.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Documentation
 

--- a/glib/README.md
+++ b/glib/README.md
@@ -16,7 +16,7 @@ crates.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Dynamic typing
 

--- a/glib/src/exit_code.rs
+++ b/glib/src/exit_code.rs
@@ -1,33 +1,87 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::process::Termination;
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord)]
-pub struct ExitCode(i32);
+pub struct ExitCode(u8);
 
 impl ExitCode {
-    pub const SUCCESS: Self = Self(0);
-    pub const FAILURE: Self = Self(1);
+    const MIN: i32 = u8::MIN as i32;
+    const MAX: i32 = u8::MAX as i32;
 
-    pub fn value(&self) -> i32 {
+    // rustdoc-stripper-ignore-next
+    /// The canonical ExitCode for successful termination on this platform.
+    pub const SUCCESS: Self = Self(libc::EXIT_SUCCESS as u8);
+
+    // rustdoc-stripper-ignore-next
+    /// The canonical ExitCode for unsuccessful termination on this platform.
+    pub const FAILURE: Self = Self(libc::EXIT_FAILURE as u8);
+
+    pub const fn new(code: u8) -> Self {
+        Self(code)
+    }
+
+    pub const fn get(&self) -> u8 {
         self.0
     }
 }
 
-impl From<i32> for ExitCode {
-    fn from(value: i32) -> Self {
+#[derive(Clone, Copy, PartialEq, Eq, Debug, PartialOrd, Ord)]
+pub struct InvalidExitCode(i32);
+
+impl InvalidExitCode {
+    pub const fn new(code: i32) -> Option<Self> {
+        match code {
+            ExitCode::MIN..=ExitCode::MAX => None,
+            _ => Some(Self(code)),
+        }
+    }
+
+    pub const fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for InvalidExitCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(code) = self;
+        write!(f, "{code} is not a valid glib exit code")
+    }
+}
+
+impl std::error::Error for InvalidExitCode {}
+
+impl From<u8> for ExitCode {
+    fn from(value: u8) -> Self {
         Self(value)
     }
 }
 
-impl From<ExitCode> for i32 {
-    fn from(value: ExitCode) -> Self {
-        value.0
+impl TryFrom<i32> for ExitCode {
+    type Error = InvalidExitCode;
+
+    fn try_from(code: i32) -> Result<Self, Self::Error> {
+        match code {
+            ExitCode::MIN..=ExitCode::MAX => Ok(Self(code as _)),
+            _ => Err(InvalidExitCode(code)),
+        }
     }
 }
 
-impl Termination for ExitCode {
+macro_rules! impl_from_exit_code_0 {
+    ($($ty:ty)*) => {
+        $(
+            impl From<ExitCode> for $ty {
+                fn from(code: ExitCode) -> Self {
+                    <$ty>::from(code.0)
+                }
+            }
+        )*
+    };
+}
+
+impl_from_exit_code_0! { u8 u16 u32 u64 i16 i32 i64 std::process::ExitCode }
+
+impl std::process::Termination for ExitCode {
     fn report(self) -> std::process::ExitCode {
-        std::process::ExitCode::from(self.0 as u8)
+        self.into()
     }
 }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -117,7 +117,7 @@ pub mod object;
 mod boxed_any_object;
 pub use boxed_any_object::BoxedAnyObject;
 mod exit_code;
-pub use exit_code::ExitCode;
+pub use exit_code::{ExitCode, InvalidExitCode};
 
 pub mod collections;
 pub use collections::{List, PtrSlice, SList, Slice, StrV};

--- a/glib/src/source_futures.rs
+++ b/glib/src/source_futures.rs
@@ -101,7 +101,7 @@ where
             && self
                 .source
                 .as_ref()
-                .map_or(true, |(_, receiver)| receiver.is_terminated())
+                .is_none_or(|(_, receiver)| receiver.is_terminated())
     }
 }
 
@@ -313,7 +313,7 @@ where
             && self
                 .source
                 .as_ref()
-                .map_or(true, |(_, receiver)| receiver.is_terminated())
+                .is_none_or(|(_, receiver)| receiver.is_terminated())
     }
 }
 

--- a/graphene/README.md
+++ b/graphene/README.md
@@ -6,7 +6,7 @@ Graphene __1.10__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Documentation
 

--- a/pango/README.md
+++ b/pango/README.md
@@ -6,7 +6,7 @@ Pango __1.40__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Documentation
 

--- a/pangocairo/README.md
+++ b/pangocairo/README.md
@@ -7,7 +7,7 @@ PangoCairo __1.40__ is the lowest supported version for the underlying library.
 
 ## Minimum supported Rust version
 
-Currently, the minimum supported Rust version is `1.80.0`.
+Currently, the minimum supported Rust version is `1.83.0`.
 
 ## Documentation
 

--- a/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
+++ b/tests/two-levels-glib-dependent/glib-dependent-dependent/Cargo.toml
@@ -6,7 +6,7 @@ description = "crate that depends on a glib-rs dependent crate for validation of
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.83"
 
 [dependencies]
 # Use `gstreamer` as a simulation of an identified crate re-exporting `glib`.

--- a/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gstreamer/Cargo.toml
@@ -7,7 +7,7 @@ description = "gstreamer simulator as a glib dependent crate for validation of g
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.83"
 
 [dependencies]
 glib = { path = "../../../glib" }

--- a/tests/two-levels-glib-dependent/gtk/Cargo.toml
+++ b/tests/two-levels-glib-dependent/gtk/Cargo.toml
@@ -7,7 +7,7 @@ description = "gtk simulator as a glib dependent crate for validation of glib re
 keywords = ["gtk-rs-core", "integration"]
 license = "MIT/Apache-2.0"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.83"
 
 [dependencies]
 glib = { path = "../../../glib" }


### PR DESCRIPTION
Add a manual override to use `glib::ExitCode` instead of the gir generated `i32` return value for `connect_command_line` and `connect_handle_local_options`.

This fixes #1691 