### PR TITLE
gobject: Work around wrongly added v2_82 feature

### DIFF
--- a/glib/gobject-sys/Gir.toml
+++ b/glib/gobject-sys/Gir.toml
@@ -9,7 +9,9 @@ girs_directories = ["../../gir-files"]
 external_libraries = [
     "GLib",
 ]
-
+extra_versions = [
+    "2.82"
+]
 ignore = [
     "GObject.VaClosureMarshal",
     "GObject.SignalCVaMarshaller",


### PR DESCRIPTION
That feature should not even exist at all. The problem comes from <https://github.com/gtk-rs/gir/blob/main/src/codegen/sys/cargo_toml.rs#L126-L136> but as i don't have the time to track it down, let us work around it for now