### PR TITLE
glib: Make sure that empty `glib::StrV` / `glib::PtrSlice` returns a valid pointer

### DIFF
--- a/glib/src/collections/ptr_slice.rs
+++ b/glib/src/collections/ptr_slice.rs
@@ -658,13 +658,21 @@ impl<T: TransparentPtrType> PtrSlice<T> {
     /// This is guaranteed to be `NULL`-terminated.
     #[inline]
     pub fn into_raw(mut self) -> *mut <T as GlibPtrDefault>::GlibType {
+        // Make sure to allocate a valid pointer that points to a
+        // NULL-pointer.
         if self.len == 0 {
-            ptr::null_mut()
-        } else {
-            self.len = 0;
-            self.capacity = 0;
-            self.ptr.as_ptr()
+            self.reserve(0);
+            unsafe {
+                ptr::write(
+                    self.ptr.as_ptr().add(0),
+                    Ptr::from(ptr::null_mut::<<T as GlibPtrDefault>::GlibType>()),
+                );
+            }
         }
+
+        self.len = 0;
+        self.capacity = 0;
+        self.ptr.as_ptr()
     }
 
     // rustdoc-stripper-ignore-next

--- a/glib/src/collections/slice.rs
+++ b/glib/src/collections/slice.rs
@@ -546,8 +546,6 @@ impl<T: TransparentType> Slice<T> {
 
     // rustdoc-stripper-ignore-next
     /// Returns the underlying pointer.
-    ///
-    /// This is guaranteed to be `NULL`-terminated.
     #[inline]
     pub fn as_ptr(&self) -> *const T::GlibType {
         if self.len == 0 {
@@ -559,8 +557,6 @@ impl<T: TransparentType> Slice<T> {
 
     // rustdoc-stripper-ignore-next
     /// Returns the underlying pointer.
-    ///
-    /// This is guaranteed to be `NULL`-terminated.
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T::GlibType {
         if self.len == 0 {
@@ -572,8 +568,6 @@ impl<T: TransparentType> Slice<T> {
 
     // rustdoc-stripper-ignore-next
     /// Consumes the slice and returns the underlying pointer.
-    ///
-    /// This is guaranteed to be `NULL`-terminated.
     #[inline]
     pub fn into_raw(mut self) -> *mut T::GlibType {
         if self.len == 0 {

--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -646,13 +646,18 @@ impl StrV {
     /// This is guaranteed to be `NULL`-terminated.
     #[inline]
     pub fn into_raw(mut self) -> *mut *mut c_char {
+        // Make sure to allocate a valid pointer that points to a
+        // NULL-pointer.
         if self.len == 0 {
-            ptr::null_mut()
-        } else {
-            self.len = 0;
-            self.capacity = 0;
-            self.ptr.as_ptr()
+            self.reserve(0);
+            unsafe {
+                *self.ptr.as_ptr().add(0) = ptr::null_mut();
+            }
         }
+
+        self.len = 0;
+        self.capacity = 0;
+        self.ptr.as_ptr()
     }
 
     // rustdoc-stripper-ignore-next


### PR DESCRIPTION
Instead of returning `NULL` make sure to return a valid pointer that dereferences into a `NULL`-pointer.

Fixes https://github.com/gtk-rs/gtk-rs-core/issues/1733
