### PR TITLE
Add cargo feature for quartz surface

### DIFF
--- a/cairo/Cargo.toml
+++ b/cairo/Cargo.toml
@@ -29,6 +29,7 @@ freetype = ["cairo-sys-rs/freetype", "freetype-rs"]
 script = ["cairo-sys-rs/script"]
 xcb = ["cairo-sys-rs/xcb"]
 xlib = ["cairo-sys-rs/xlib"]
+quartz-surface = ["cairo-sys-rs/quartz-surface"]
 win32-surface = ["cairo-sys-rs/win32-surface"]
 
 [dependencies.glib]

--- a/cairo/src/lib.rs
+++ b/cairo/src/lib.rs
@@ -282,9 +282,9 @@ mod ps;
 #[cfg(feature = "svg")]
 mod svg;
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "quartz-surface"))]
 mod quartz_surface;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "quartz-surface"))]
 pub use quartz_surface::QuartzSurface;
 
 #[cfg(all(windows, feature = "win32-surface"))]

--- a/cairo/sys/Cargo.toml
+++ b/cairo/sys/Cargo.toml
@@ -48,6 +48,7 @@ freetype = []
 script = []
 xcb = []
 use_glib = ["glib-sys"]
+quartz-surface = []
 win32-surface = ["windows-sys"]
 
 [dependencies]

--- a/cairo/sys/src/lib.rs
+++ b/cairo/sys/src/lib.rs
@@ -1496,22 +1496,22 @@ extern "C" {
     #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "win32-surface"))))]
     pub fn cairo_win32_surface_get_image(surface: *mut cairo_surface_t) -> *mut cairo_surface_t;
 
-    #[cfg(target_os = "macos")]
-    #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+    #[cfg(all(target_os = "macos", feature = "quartz-surface"))]
+    #[cfg_attr(docsrs, doc(cfg(all(target_os = "macos", feature = "quartz-surface"))))]
     pub fn cairo_quartz_surface_create(
         format: cairo_format_t,
         width: c_uint,
         height: c_uint,
     ) -> *mut cairo_surface_t;
-    #[cfg(target_os = "macos")]
-    #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+    #[cfg(all(target_os = "macos", feature = "quartz-surface"))]
+    #[cfg_attr(docsrs, doc(cfg(all(target_os = "macos", feature = "quartz-surface"))))]
     pub fn cairo_quartz_surface_create_for_cg_context(
         cg_context: CGContextRef,
         width: c_uint,
         height: c_uint,
     ) -> *mut cairo_surface_t;
-    #[cfg(target_os = "macos")]
-    #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+    #[cfg(all(target_os = "macos", feature = "quartz-surface"))]
+    #[cfg_attr(docsrs, doc(cfg(all(target_os = "macos", feature = "quartz-surface"))))]
     pub fn cairo_quartz_surface_get_cg_context(surface: *mut cairo_surface_t) -> CGContextRef;
 
     // CAIRO SCRIPT


### PR DESCRIPTION
In [Prince](https://www.princexml.com/) we use a custom build of Cairo that is built with a shared configuration across platforms. This configuration does not enable Quartz surfaces, since we don't use them. When trying to use this build of cairo from cairo-rs on macOS we get these linker errors:

```
Making Mercury/hlc.par.gc/aarch64-apple-darwin23.3.0/Mercury/bin/prince
Undefined symbols for architecture arm64:
  "_cairo_quartz_surface_create", referenced from:
      cairo::quartz_surface::QuartzSurface::create::hd523178627094f5c in libfontcode.a[26](cairo-985f17ee8c3b353d.cairo.82c62016cb75f98b-cgu.7.rcgu.o)
  "_cairo_quartz_surface_create_for_cg_context", referenced from:
      cairo::quartz_surface::QuartzSurface::create_for_cg_context::hfd933effa02b3a48 in libfontcode.a[26](cairo-985f17ee8c3b353d.cairo.82c62016cb75f98b-cgu.7.rcgu.o)
  "_cairo_quartz_surface_get_cg_context", referenced from:
      cairo::quartz_surface::QuartzSurface::cg_context::h0e678fb701e283dd in libfontcode.a[26](cairo-985f17ee8c3b353d.cairo.82c62016cb75f98b-cgu.7.rcgu.o)
ld: symbol(s) not found for architecture arm64
```

This PR introduces a `quartz-surface` cargo feature to make it possible to compile cairo-rs without Quartz surfaces.

As it stands this will be a breaking change from the status quo as Quartz surfaces will become opt-in. I'm aware that this may not be desired, but it does match the win32 behaviour. If this is not desired I can add it to the `default` features.