### PR TITLE
Allow specifying a default via `Default` in a field within `Properties`

### DIFF
--- a/glib-macros/src/lib.rs
+++ b/glib-macros/src/lib.rs
@@ -525,9 +525,12 @@ pub fn closure_local(item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// When using the [`Properties`] macro with enums that derive [`Enum`], the default value must be
-/// explicitly set via the `builder` parameter of the `#[property]` attribute. See
-/// [here](Properties#supported-types) for details.
+/// When using the [`Properties`] macro with enums that derive [`Enum`], the
+/// default value can be explicitly set via the `builder` parameter of the
+/// `#[property]` attribute. If the enum implements or derives
+/// `Default`, you can specify that should be the default value
+/// via the `default` parameter. See [here](Properties#supported-types) for
+/// details.
 ///
 /// An enum can be registered as a dynamic type by setting the derive macro
 /// helper attribute `enum_dynamic`:
@@ -1333,7 +1336,8 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 /// | `construct` | Specify that the property is construct property. Ensures that the property is always set during construction (if not explicitly then the default value is used). The use of a custom internal setter is supported. | | `#[property(get, construct)]` or `#[property(get, set = set_prop, construct)]` |
 /// | `construct_only` | Specify that the property is construct only. This will not generate a public setter and only allow the property to be set during object construction. The use of a custom internal setter is supported. | | `#[property(get, construct_only)]` or `#[property(get, set = set_prop, construct_only)]` |
 /// | `builder(<required-params>)[.ident]*` | Used to input required params or add optional Param Spec builder fields | | `#[property(builder(SomeEnum::default()))]`, `#[builder().default_value(1).minimum(0).maximum(5)]`, etc.  |
-/// | `default` | Sets the `default_value` field of the Param Spec builder | | `#[property(default = 1)]` |
+/// | `default` | Sets the param spec builder field to the default value | | `#[property(default)]` |
+/// | `default = expr` | Sets the `default_value` field of the Param Spec builder | | `#[property(default = 1)]` |
 /// | `<optional-pspec-builder-fields> = expr` | Used to add optional Param Spec builder fields | | `#[property(minimum = 0)` , `#[property(minimum = 0, maximum = 1)]`, etc. |
 /// | `<optional-pspec-builder-fields>` | Used to add optional Param Spec builder fields | | `#[property(explicit_notify)]` , `#[property(construct_only)]`, etc. |
 ///
@@ -1443,6 +1447,8 @@ pub fn cstr_bytes(item: TokenStream) -> TokenStream {
 ///         smart_pointer: Rc<RefCell<String>>,
 ///         #[property(get, set, builder(MyEnum::Val))]
 ///         my_enum: Cell<MyEnum>,
+///         #[property(get, set, default)]
+///         my_enum_with_default: Cell<MyEnum>,
 ///         /// # Getter
 ///         ///
 ///         /// Get the value of the property `extra_comments`

--- a/glib-macros/tests/properties.rs
+++ b/glib-macros/tests/properties.rs
@@ -69,6 +69,7 @@ mod foo {
     pub enum SimpleEnum {
         #[default]
         One,
+        Two,
     }
 
     #[derive(Default, Clone)]
@@ -129,10 +130,14 @@ mod foo {
             builder_fields_without_builder: RefCell<u32>,
             #[property(get, set, builder('c'))]
             builder_with_required_param: RefCell<char>,
+            #[property(get, set, default)]
+            char_default: RefCell<char>,
             #[property(get, set)]
             boxed: RefCell<SimpleBoxedString>,
-            #[property(get, set, builder(SimpleEnum::One))]
+            #[property(get, set, builder(SimpleEnum::Two))]
             fenum: RefCell<SimpleEnum>,
+            #[property(get, set, default)]
+            fenum_default: RefCell<SimpleEnum>,
             #[property(get, set, nullable)]
             object: RefCell<Option<glib::Object>>,
             #[property(get, set, nullable)]
@@ -206,6 +211,8 @@ mod foo {
 
 #[test]
 fn props() {
+    use crate::foo::SimpleEnum;
+
     let myfoo: foo::Foo = glib::object::Object::new();
 
     // Read values
@@ -272,6 +279,25 @@ fn props() {
             .get::<String>()
             .unwrap(),
         "hello".to_string()
+    );
+
+    assert_eq!(
+        myfoo
+            .find_property("fenum")
+            .unwrap()
+            .default_value()
+            .get::<SimpleEnum>()
+            .unwrap(),
+        SimpleEnum::Two
+    );
+    assert_eq!(
+        myfoo
+            .find_property("fenum_default")
+            .unwrap()
+            .default_value()
+            .get::<SimpleEnum>()
+            .unwrap(),
+        SimpleEnum::One
     );
 
     // numeric builder

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -2174,6 +2174,20 @@ pub trait HasParamSpec {
     fn param_spec_builder() -> Self::BuilderFn;
 }
 
+// unless a custom `default` attribute is specified, the macro will use this trait.
+pub trait HasParamSpecDefaulted: HasParamSpec + Default {
+    type BuilderFnDefaulted;
+    fn param_spec_builder_defaulted() -> Self::BuilderFnDefaulted;
+}
+
+// Manually implement the trait for every Enum
+impl<T: HasParamSpec<ParamSpec = ParamSpecEnum> + StaticType + FromGlib<i32> + IntoGlib<GlibType = i32> + Default> HasParamSpecDefaulted for T {
+    type BuilderFnDefaulted = fn(name: &str) -> ParamSpecEnumBuilder<T>;
+    fn param_spec_builder_defaulted() -> Self::BuilderFnDefaulted {
+        |name| Self::ParamSpec::builder(name)
+    }
+}
+
 impl<T: crate::value::ToValueOptional + HasParamSpec> HasParamSpec for Option<T> {
     type ParamSpec = T::ParamSpec;
     type SetValue = T::SetValue;

--- a/glib/src/param_spec.rs
+++ b/glib/src/param_spec.rs
@@ -2181,10 +2181,25 @@ pub trait HasParamSpecDefaulted: HasParamSpec + Default {
 }
 
 // Manually implement the trait for every Enum
-impl<T: HasParamSpec<ParamSpec = ParamSpecEnum> + StaticType + FromGlib<i32> + IntoGlib<GlibType = i32> + Default> HasParamSpecDefaulted for T {
+impl<
+        T: HasParamSpec<ParamSpec = ParamSpecEnum>
+            + StaticType
+            + FromGlib<i32>
+            + IntoGlib<GlibType = i32>
+            + Default,
+    > HasParamSpecDefaulted for T
+{
     type BuilderFnDefaulted = fn(name: &str) -> ParamSpecEnumBuilder<T>;
     fn param_spec_builder_defaulted() -> Self::BuilderFnDefaulted {
         |name| Self::ParamSpec::builder(name)
+    }
+}
+
+// Manually implement the trait for chars
+impl HasParamSpecDefaulted for char {
+    type BuilderFnDefaulted = fn(name: &str) -> ParamSpecUnicharBuilder;
+    fn param_spec_builder_defaulted() -> Self::BuilderFnDefaulted {
+        |name| Self::ParamSpec::builder(name, Default::default())
     }
 }
 


### PR DESCRIPTION
Given a struct like

```rust
#[derive(Copy, Default, Clone, Debug, PartialEq, Eq, glib::Enum)]
#[enum_type(name = "SimpleEnum")]
pub enum SimpleEnum {
    #[default]
    One,
    Two,
}
```

you currently have to specify the default value as part of the param spec builder, e.g.

```rust
            #[property(get, set, builder(SimpleEnum::One))]
            fenum: RefCell<SimpleEnum>,
```

With this PR, we allow for that to change to 

```rust
            #[property(get, set, default)]
            fenum: RefCell<SimpleEnum>,
```

as discussed in #930. This started with what @ranfdev wrote though it changed a little bit.

It's still a bit messier than I was hoping as you still have a few different ways of setting the default value, you can have

    #[property(default)]
    #[property(builder(Type::Default))]

which is fine for compat and because not every enum has a built-in default, but you could also do things like

    #[property(builder(Type::Default).default_value(Type::OtherDefault))]
    #[property(default, builder().default_value(Type::OtherDefault))]

though you shouldn't and probably wouldn't because why would you. It comes out of the generic nature of this and it's probably not worth catching this and erroring out, but it doesn't make the whole thing easier to understand.

The main thing here are `Enum`s but I also added it for `char`s because they do have a default value in Rust. This might however not make as much sense in glib? I'm not sure if there's an actually-correct answer there.

As I mentioned in https://github.com/gtk-rs/gtk-rs-core/issues/930#issuecomment-3033592982 I don't think you can make this an actual blanket implementation because you need to know a lot about the types and the builder function, which is arbitrary. But covering enums sounds like it's 90% of the use-case, and other libraries can still implement it themselves.