### PR TITLE
cairo: write-to-stream callbacks should accept const pointers to data

### DIFF
--- a/cairo/src/stream.rs
+++ b/cairo/src/stream.rs
@@ -200,7 +200,7 @@ struct MutableCallbackEnvironment {
 // so code outside of the `catch_unwind` call must never panic.
 extern "C" fn write_callback<W: io::Write + 'static>(
     env: *mut c_void,
-    data: *mut c_uchar,
+    data: *const c_uchar,
     length: c_uint,
 ) -> ffi::cairo_status_t {
     // This is consistent with the type of `env` in `Surface::_for_stream`.

--- a/cairo/src/surface_png.rs
+++ b/cairo/src/surface_png.rs
@@ -57,7 +57,7 @@ struct WriteEnv<'a, W: 'a + Write> {
 
 unsafe extern "C" fn write_func<W: Write>(
     closure: *mut c_void,
-    data: *mut u8,
+    data: *const u8,
     len: c_uint,
 ) -> crate::ffi::cairo_status_t {
     let write_env: &mut WriteEnv<W> = &mut *(closure as *mut WriteEnv<W>);

--- a/cairo/sys/src/lib.rs
+++ b/cairo/sys/src/lib.rs
@@ -262,7 +262,7 @@ pub type cairo_destroy_func_t = Option<unsafe extern "C" fn(*mut c_void)>;
 pub type cairo_read_func_t =
     Option<unsafe extern "C" fn(*mut c_void, *mut c_uchar, c_uint) -> cairo_status_t>;
 pub type cairo_write_func_t =
-    Option<unsafe extern "C" fn(*mut c_void, *mut c_uchar, c_uint) -> cairo_status_t>;
+    Option<unsafe extern "C" fn(*mut c_void, *const c_uchar, c_uint) -> cairo_status_t>;
 
 #[cfg(feature = "freetype")]
 #[cfg_attr(docsrs, doc(cfg(feature = "freetype")))]


### PR DESCRIPTION
This is in line with the [corresponding C types](https://www.cairographics.org/manual/cairo-PNG-Support.html#cairo-write-func-t); they don't need to mutate this data.

Closes #1771.