### PR TITLE
Bug fixes for `StrV[Ref]`

### DIFF
--- a/glib/src/collections/ptr_slice.rs
+++ b/glib/src/collections/ptr_slice.rs
@@ -713,7 +713,7 @@ impl<T: TransparentPtrType> PtrSlice<T> {
     #[allow(clippy::int_plus_one)]
     pub fn reserve(&mut self, additional: usize) {
         // Nothing new to reserve as there's still enough space
-        if self.len + additional + 1 <= self.capacity {
+        if additional < self.capacity - self.len {
             return;
         }
 
@@ -788,7 +788,7 @@ impl<T: TransparentPtrType> PtrSlice<T> {
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[T]) {
         // Nothing new to reserve as there's still enough space
-        if self.len + other.len() + 1 > self.capacity {
+        if other.len() >= self.capacity - self.len {
             self.reserve(other.len());
         }
 
@@ -815,7 +815,7 @@ impl<T: TransparentPtrType> PtrSlice<T> {
         assert!(index <= self.len);
 
         // Nothing new to reserve as there's still enough space
-        if self.len + 1 + 1 > self.capacity {
+        if 1 >= self.capacity - self.len {
             self.reserve(1);
         }
 
@@ -842,7 +842,7 @@ impl<T: TransparentPtrType> PtrSlice<T> {
     #[inline]
     pub fn push(&mut self, item: T) {
         // Nothing new to reserve as there's still enough space
-        if self.len + 1 + 1 > self.capacity {
+        if 1 >= self.capacity - self.len {
             self.reserve(1);
         }
 

--- a/glib/src/collections/slice.rs
+++ b/glib/src/collections/slice.rs
@@ -614,7 +614,7 @@ impl<T: TransparentType> Slice<T> {
     /// Reserves at least this much additional capacity.
     pub fn reserve(&mut self, additional: usize) {
         // Nothing new to reserve as there's still enough space
-        if self.len + additional <= self.capacity {
+        if additional <= self.capacity - self.len {
             return;
         }
 
@@ -685,7 +685,7 @@ impl<T: TransparentType> Slice<T> {
     #[inline]
     pub fn extend_from_slice(&mut self, other: &[T]) {
         // Nothing new to reserve as there's still enough space
-        if self.len + other.len() > self.capacity {
+        if other.len() > self.capacity - self.len {
             self.reserve(other.len());
         }
 
@@ -706,7 +706,7 @@ impl<T: TransparentType> Slice<T> {
         assert!(index <= self.len);
 
         // Nothing new to reserve as there's still enough space
-        if self.len + 1 > self.capacity {
+        if 1 > self.capacity - self.len {
             self.reserve(1);
         }
 
@@ -729,7 +729,7 @@ impl<T: TransparentType> Slice<T> {
     #[allow(clippy::int_plus_one)]
     pub fn push(&mut self, item: T) {
         // Nothing new to reserve as there's still enough space
-        if self.len + 1 > self.capacity {
+        if 1 > self.capacity - self.len {
             self.reserve(1);
         }
 

--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -800,7 +800,7 @@ impl StrV {
         assert!(index <= self.len);
 
         // Nothing new to reserve as there's still enough space
-        if self.len + 1 + 1 > self.capacity {
+        if 1 >= self.capacity - self.len {
             self.reserve(1);
         }
 
@@ -824,7 +824,7 @@ impl StrV {
     #[inline]
     pub fn push(&mut self, item: GString) {
         // Nothing new to reserve as there's still enough space
-        if self.len + 1 + 1 > self.capacity {
+        if 1 >= self.capacity - self.len {
             self.reserve(1);
         }
 


### PR DESCRIPTION
Fixes the following bugs:

- `StrV::reserve` can return without actually reserving if `additional` is too large (`>= usize::MAX - self.len()`) and overflow checking is disabled
- `StrV::extend_from_slice` can incorrectly skip `StrV::reserve` before writing elements if it is given a ZST slice containing a large number of elements (`>= usize::MAX - self.len()`) and overflow checking is disabled
- `StrV::extend_from_slice` is not panic safe
- `<StrVRef as PartialEq<[&str]>>::eq` incorrectly evaluates to `false` if two slices have different numbers of elements but their prefixes match
