### PR TITLE
Add new FromGlibPtrBorrow2 and FromGlibPtrBorrowMut2 traits

### DIFF
--- a/glib/src/boxed.rs
+++ b/glib/src/boxed.rs
@@ -47,6 +47,7 @@ macro_rules! glib_boxed_wrapper {
 
             #[doc = "Borrows the underlying C value."]
             #[inline]
+            #[deprecated = "Use FromGlibBorrow2 trait"]
             pub unsafe fn from_glib_ptr_borrow(ptr: &*mut $ffi_name) -> &Self {
                 debug_assert_eq!(
                     std::mem::size_of::<Self>(),
@@ -58,6 +59,7 @@ macro_rules! glib_boxed_wrapper {
 
             #[doc = "Borrows the underlying C value mutably."]
             #[inline]
+            #[deprecated = "Use FromGlibBorrowMut2 trait"]
             pub unsafe fn from_glib_ptr_borrow_mut(ptr: &mut *mut $ffi_name) -> &mut Self {
                 debug_assert_eq!(
                     std::mem::size_of::<Self>(),
@@ -253,6 +255,45 @@ macro_rules! glib_boxed_wrapper {
         }
 
         #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibPtrBorrow2<*mut $ffi_name> for $name $(<$($generic),+>)? {
+            #[inline]
+            unsafe fn from_glib_borrow2(ptr: &*mut $ffi_name) -> &Self {
+                debug_assert_eq!(
+                    std::mem::size_of::<Self>(),
+                    std::mem::size_of::<$crate::ffi::gpointer>()
+                );
+                debug_assert!(!ptr.is_null());
+                &*(ptr as *const *mut $ffi_name as *const Self)
+            }
+        }
+
+        #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibPtrBorrow2<*const $ffi_name> for $name $(<$($generic),+>)? {
+            #[inline]
+            unsafe fn from_glib_borrow2(ptr: &*const $ffi_name) -> &Self {
+                debug_assert_eq!(
+                    std::mem::size_of::<Self>(),
+                    std::mem::size_of::<$crate::ffi::gpointer>()
+                );
+                debug_assert!(!ptr.is_null());
+                &*(ptr as *const *const $ffi_name as *const Self)
+            }
+        }
+
+        #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibPtrBorrowMut2<*mut $ffi_name> for $name $(<$($generic),+>)? {
+            #[inline]
+            unsafe fn from_glib_borrow_mut2(ptr: &mut *mut $ffi_name) -> &mut Self {
+                debug_assert_eq!(
+                    std::mem::size_of::<Self>(),
+                    std::mem::size_of::<$crate::ffi::gpointer>()
+                );
+                debug_assert!(!ptr.is_null());
+                &mut *(ptr as *mut *mut $ffi_name as *mut Self)
+            }
+        }
+
+        #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name $(<$($generic),+>)? {
             unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
@@ -363,7 +404,7 @@ macro_rules! glib_boxed_wrapper {
             #[inline]
             unsafe fn from_value(value: &'a $crate::Value) -> Self {
                 let value = &*(value as *const $crate::Value as *const $crate::gobject_ffi::GValue);
-                <$name $(<$($generic),+>)?>::from_glib_ptr_borrow(&*(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *mut $ffi_name))
+                <$name $(<$($generic),+>)? as $crate::translate::FromGlibPtrBorrow2<*mut $ffi_name>>::from_glib_borrow2(&*(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *mut $ffi_name))
             }
         }
 

--- a/glib/src/boxed_inline.rs
+++ b/glib/src/boxed_inline.rs
@@ -171,6 +171,7 @@ macro_rules! glib_boxed_inline_wrapper {
 
             #[doc = "Borrows the underlying C value."]
             #[inline]
+            #[deprecated = "Use FromGlibBorrow2 trait"]
             pub unsafe fn from_glib_ptr_borrow<'a>(ptr: *const $ffi_name) -> &'a Self {
                 debug_assert!(!ptr.is_null());
                 &*(ptr as *const Self)
@@ -178,6 +179,7 @@ macro_rules! glib_boxed_inline_wrapper {
 
             #[doc = "Borrows the underlying C value mutably."]
             #[inline]
+            #[deprecated = "Use FromGlibBorrowMut2 trait"]
             pub unsafe fn from_glib_ptr_borrow_mut<'a>(ptr: *mut $ffi_name) -> &'a mut Self {
                 debug_assert!(!ptr.is_null());
                 &mut *(ptr as *mut Self)
@@ -229,6 +231,7 @@ macro_rules! glib_boxed_inline_wrapper {
             }
 
             #[inline]
+            #[allow(unused_unsafe)]
             fn to_glib_full(&self) -> *const $ffi_name {
                 unsafe {
                     let copy = |$copy_arg: *const $ffi_name| $copy_expr;
@@ -431,6 +434,30 @@ macro_rules! glib_boxed_inline_wrapper {
         }
 
         #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibPtrBorrow2<$ffi_name> for $name $(<$($generic),+>)? {
+            #[inline]
+            unsafe fn from_glib_borrow2(ptr: &$ffi_name) -> &Self {
+                debug_assert_eq!(
+                    std::mem::size_of::<Self>(),
+                    std::mem::size_of::<$ffi_name>()
+                );
+                &*(ptr as *const $ffi_name as *const Self)
+            }
+        }
+
+        #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibPtrBorrowMut2<$ffi_name> for $name $(<$($generic),+>)? {
+            #[inline]
+            unsafe fn from_glib_borrow_mut2(ptr: &mut $ffi_name) -> &mut Self {
+                debug_assert_eq!(
+                    std::mem::size_of::<Self>(),
+                    std::mem::size_of::<$ffi_name>()
+                );
+                &mut *(ptr as *mut $ffi_name as *mut Self)
+            }
+        }
+
+        #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut $ffi_name> for $name $(<$($generic),+>)? {
             unsafe fn from_glib_none_num_as_vec(ptr: *mut $ffi_name, num: usize) -> Vec<Self> {
                 $crate::translate::FromGlibContainerAsVec::from_glib_none_num_as_vec(ptr as *const _, num)
@@ -593,7 +620,7 @@ macro_rules! glib_boxed_inline_wrapper {
             unsafe fn from_value(value: &'_ $crate::Value) -> Self {
                 let ptr = $crate::gobject_ffi::g_value_get_boxed($crate::translate::ToGlibPtr::to_glib_none(value).0);
                 debug_assert!(!ptr.is_null());
-                &*(ptr as *const $ffi_name as *const $name $(<$($generic),+>)?)
+                <$name $(<$($generic),+>)? as $crate::translate::FromGlibPtrBorrow2<$ffi_name>>::from_glib_borrow2(&*(ptr as *const $ffi_name))
             }
         }
 

--- a/glib/src/gobject/interface_info.rs
+++ b/glib/src/gobject/interface_info.rs
@@ -1,40 +1,18 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::gobject_ffi;
+use crate::{gobject_ffi, translate::*};
 
-#[derive(Debug, Copy, Clone)]
-#[doc(alias = "GInterfaceInfo")]
-#[repr(transparent)]
-pub struct InterfaceInfo(pub(crate) gobject_ffi::GInterfaceInfo);
-
-impl InterfaceInfo {
-    // rustdoc-stripper-ignore-next
-    /// Returns a `GInterfaceInfo` pointer.
-    #[doc(hidden)]
-    #[inline]
-    pub fn as_ptr(&self) -> *mut gobject_ffi::GInterfaceInfo {
-        &self.0 as *const gobject_ffi::GInterfaceInfo as *mut _
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Borrows the underlying C value mutably.
-    #[doc(hidden)]
-    #[inline]
-    pub unsafe fn from_glib_ptr_borrow_mut<'a>(
-        ptr: *mut gobject_ffi::GInterfaceInfo,
-    ) -> &'a mut Self {
-        &mut *(ptr as *mut Self)
-    }
+wrapper! {
+    #[derive(Debug)]
+    #[doc(alias = "GInterfaceInfo")]
+    pub struct InterfaceInfo(BoxedInline<gobject_ffi::GInterfaceInfo>);
 }
 
+unsafe impl Send for InterfaceInfo {}
+unsafe impl Sync for InterfaceInfo {}
+
 impl Default for InterfaceInfo {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new InterfaceInfo with default value.
     fn default() -> Self {
-        Self(gobject_ffi::GInterfaceInfo {
-            interface_init: None,
-            interface_finalize: None,
-            interface_data: ::std::ptr::null_mut(),
-        })
+        unsafe { Self::uninitialized() }
     }
 }

--- a/glib/src/gobject/type_info.rs
+++ b/glib/src/gobject/type_info.rs
@@ -1,45 +1,18 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::gobject_ffi;
+use crate::{gobject_ffi, translate::*};
 
-#[derive(Debug, Copy, Clone)]
-#[doc(alias = "GTypeInfo")]
-#[repr(transparent)]
-pub struct TypeInfo(pub(crate) gobject_ffi::GTypeInfo);
-
-impl TypeInfo {
-    // rustdoc-stripper-ignore-next
-    /// Returns a `GTypeInfo` pointer.
-    #[doc(hidden)]
-    #[inline]
-    pub fn as_ptr(&self) -> *mut gobject_ffi::GTypeInfo {
-        &self.0 as *const gobject_ffi::GTypeInfo as *mut _
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Borrows the underlying C value mutably.
-    #[doc(hidden)]
-    #[inline]
-    pub unsafe fn from_glib_ptr_borrow_mut<'a>(ptr: *mut gobject_ffi::GTypeInfo) -> &'a mut Self {
-        &mut *(ptr as *mut Self)
-    }
+wrapper! {
+    #[derive(Debug)]
+    #[doc(alias = "GTypeInfo")]
+    pub struct TypeInfo(BoxedInline<gobject_ffi::GTypeInfo>);
 }
 
+unsafe impl Send for TypeInfo {}
+unsafe impl Sync for TypeInfo {}
+
 impl Default for TypeInfo {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new TypeInfo with default value.
     fn default() -> Self {
-        Self(gobject_ffi::GTypeInfo {
-            class_size: 0u16,
-            base_init: None,
-            base_finalize: None,
-            class_init: None,
-            class_finalize: None,
-            class_data: ::std::ptr::null(),
-            instance_size: 0,
-            n_preallocs: 0,
-            instance_init: None,
-            value_table: ::std::ptr::null(),
-        })
+        unsafe { Self::uninitialized() }
     }
 }

--- a/glib/src/gobject/type_value_table.rs
+++ b/glib/src/gobject/type_value_table.rs
@@ -1,45 +1,18 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use crate::gobject_ffi;
+use crate::{gobject_ffi, translate::*};
 
-#[derive(Debug, Copy, Clone)]
-#[doc(alias = "GTypeValueTable")]
-#[repr(transparent)]
-pub struct TypeValueTable(pub(crate) gobject_ffi::GTypeValueTable);
-
-impl TypeValueTable {
-    // rustdoc-stripper-ignore-next
-    /// Returns a `GTypeValueTable` pointer.
-    #[doc(hidden)]
-    #[inline]
-    pub fn as_ptr(&self) -> *mut gobject_ffi::GTypeValueTable {
-        &self.0 as *const gobject_ffi::GTypeValueTable as *mut _
-    }
-
-    // rustdoc-stripper-ignore-next
-    /// Borrows the underlying C value mutably.
-    #[doc(hidden)]
-    #[inline]
-    pub unsafe fn from_glib_ptr_borrow_mut<'a>(
-        ptr: *mut gobject_ffi::GTypeValueTable,
-    ) -> &'a mut Self {
-        &mut *(ptr as *mut Self)
-    }
+wrapper! {
+    #[derive(Debug)]
+    #[doc(alias = "GTypeValueTable")]
+    pub struct TypeValueTable(BoxedInline<gobject_ffi::GTypeValueTable>);
 }
 
+unsafe impl Send for TypeValueTable {}
+unsafe impl Sync for TypeValueTable {}
+
 impl Default for TypeValueTable {
-    // rustdoc-stripper-ignore-next
-    /// Creates a new TypeValueTable with default value.
     fn default() -> Self {
-        Self(gobject_ffi::GTypeValueTable {
-            value_init: None,
-            value_free: None,
-            value_copy: None,
-            value_peek_pointer: None,
-            collect_format: ::std::ptr::null(),
-            collect_value: None,
-            lcopy_format: ::std::ptr::null(),
-            lcopy_value: None,
-        })
+        unsafe { Self::uninitialized() }
     }
 }

--- a/glib/src/match_info.rs
+++ b/glib/src/match_info.rs
@@ -36,16 +36,6 @@ impl MatchInfo<'_> {
     pub fn as_ptr(&self) -> *mut ffi::GMatchInfo {
         self.inner.as_ptr()
     }
-    #[doc = "Borrows the underlying C value."]
-    #[inline]
-    pub unsafe fn from_glib_ptr_borrow(ptr: &*mut ffi::GMatchInfo) -> &Self {
-        debug_assert_eq!(
-            std::mem::size_of::<Self>(),
-            std::mem::size_of::<crate::ffi::gpointer>()
-        );
-        debug_assert!(!ptr.is_null());
-        &*(ptr as *const *mut ffi::GMatchInfo as *const Self)
-    }
 }
 
 #[doc(hidden)]
@@ -149,6 +139,32 @@ impl FromGlibPtrBorrow<*const ffi::GMatchInfo> for MatchInfo<'_> {
     }
 }
 
+impl<'a> FromGlibPtrBorrow2<*mut ffi::GMatchInfo> for MatchInfo<'a> {
+    #[doc = "Borrows the underlying C value."]
+    #[inline]
+    unsafe fn from_glib_borrow2(ptr: &*mut ffi::GMatchInfo) -> &Self {
+        debug_assert_eq!(
+            std::mem::size_of::<Self>(),
+            std::mem::size_of::<crate::ffi::gpointer>()
+        );
+        debug_assert!(!ptr.is_null());
+        &*(ptr as *const *mut ffi::GMatchInfo as *const Self)
+    }
+}
+
+impl<'a> FromGlibPtrBorrow2<*const ffi::GMatchInfo> for MatchInfo<'a> {
+    #[doc = "Borrows the underlying C value."]
+    #[inline]
+    unsafe fn from_glib_borrow2(ptr: &*const ffi::GMatchInfo) -> &Self {
+        debug_assert_eq!(
+            std::mem::size_of::<Self>(),
+            std::mem::size_of::<crate::ffi::gpointer>()
+        );
+        debug_assert!(!ptr.is_null());
+        &*(ptr as *const *const ffi::GMatchInfo as *const Self)
+    }
+}
+
 #[doc(hidden)]
 impl IntoGlibPtr<*mut ffi::GMatchInfo> for MatchInfo<'_> {
     #[inline]
@@ -200,7 +216,7 @@ unsafe impl<'a, 'input: 'a> crate::value::FromValue<'a> for &'a MatchInfo<'input
     #[inline]
     unsafe fn from_value(value: &'a crate::Value) -> Self {
         let value = &*(value as *const crate::Value as *const crate::gobject_ffi::GValue);
-        <MatchInfo<'input>>::from_glib_ptr_borrow(
+        <MatchInfo<'input>>::from_glib_borrow2(
             &*(&value.data[0].v_pointer as *const crate::ffi::gpointer
                 as *const *mut ffi::GMatchInfo),
         )

--- a/glib/src/shared.rs
+++ b/glib/src/shared.rs
@@ -45,6 +45,7 @@ macro_rules! glib_shared_wrapper {
 
             #[doc = "Borrows the underlying C value."]
             #[inline]
+            #[deprecated = "Use FromGlibBorrow2 trait"]
             pub unsafe fn from_glib_ptr_borrow(ptr: &*mut $ffi_name) -> &Self {
                 debug_assert_eq!(
                     std::mem::size_of::<Self>(),
@@ -235,6 +236,32 @@ macro_rules! glib_shared_wrapper {
         }
 
         #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibPtrBorrow2<*mut $ffi_name> for $name $(<$($generic),+>)? {
+            #[inline]
+            unsafe fn from_glib_borrow2(ptr: &*mut $ffi_name) -> &Self {
+                debug_assert_eq!(
+                    std::mem::size_of::<Self>(),
+                    std::mem::size_of::<$crate::ffi::gpointer>()
+                );
+                debug_assert!(!ptr.is_null());
+                &*(ptr as *const *mut $ffi_name as *const Self)
+            }
+        }
+
+        #[doc(hidden)]
+        impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibPtrBorrow2<*const $ffi_name> for $name $(<$($generic),+>)? {
+            #[inline]
+            unsafe fn from_glib_borrow2(ptr: &*const $ffi_name) -> &Self {
+                debug_assert_eq!(
+                    std::mem::size_of::<Self>(),
+                    std::mem::size_of::<$crate::ffi::gpointer>()
+                );
+                debug_assert!(!ptr.is_null());
+                &*(ptr as *const *const $ffi_name as *const Self)
+            }
+        }
+
+        #[doc(hidden)]
         impl $(<$($generic $(: $bound $(+ $bound2)*)?),+>)? $crate::translate::FromGlibContainerAsVec<*mut $ffi_name, *mut *mut $ffi_name> for $name $(<$($generic),+>)? {
             unsafe fn from_glib_none_num_as_vec(ptr: *mut *mut $ffi_name, num: usize) -> Vec<Self> {
                 if num == 0 || ptr.is_null() {
@@ -378,7 +405,7 @@ macro_rules! glib_shared_wrapper {
             #[inline]
             unsafe fn from_value(value: &'a $crate::Value) -> Self {
                 let value = &*(value as *const $crate::Value as *const $crate::gobject_ffi::GValue);
-                <$name $(<$($generic),+>)?>::from_glib_ptr_borrow(&*(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *mut $ffi_name))
+                <$name $(<$($generic),+>)? as $crate::translate::FromGlibPtrBorrow2<*mut $ffi_name>>::from_glib_borrow2(&*(&value.data[0].v_pointer as *const $crate::ffi::gpointer as *const *mut $ffi_name))
             }
         }
 

--- a/glib/src/subclass/interface.rs
+++ b/glib/src/subclass/interface.rs
@@ -287,10 +287,10 @@ pub fn register_dynamic_interface<P: DynamicObjectRegisterExt, T: ObjectInterfac
         let already_registered =
             gobject_ffi::g_type_from_name(type_name.as_ptr()) != gobject_ffi::G_TYPE_INVALID;
 
-        let type_info = TypeInfo(gobject_ffi::GTypeInfo {
+        let type_info = TypeInfo::unsafe_from(gobject_ffi::GTypeInfo {
             class_size: mem::size_of::<T::Interface>() as u16,
             class_init: Some(interface_init::<T>),
-            ..TypeInfo::default().0
+            ..TypeInfo::default().inner
         });
 
         // registers the interface within the `type_plugin`

--- a/glib/src/subclass/type_plugin.rs
+++ b/glib/src/subclass/type_plugin.rs
@@ -149,8 +149,8 @@ unsafe extern "C" fn complete_type_info<T: TypePluginImpl>(
     let instance = &*(type_plugin as *mut T::Instance);
     let imp = instance.imp();
     let type_ = Type::from_glib(gtype);
-    let info = TypeInfo::from_glib_ptr_borrow_mut(info_ptr);
-    let value_table = TypeValueTable::from_glib_ptr_borrow_mut(value_table_ptr);
+    let info = TypeInfo::from_glib_borrow_mut2(&mut *info_ptr);
+    let value_table = TypeValueTable::from_glib_borrow_mut2(&mut *value_table_ptr);
 
     let (info_, value_table_) = imp.complete_type_info(type_);
 
@@ -169,7 +169,7 @@ unsafe extern "C" fn complete_interface_info<T: TypePluginImpl>(
     let imp = instance.imp();
     let instance_type = Type::from_glib(instance_gtype);
     let interface_type = Type::from_glib(interface_gtype);
-    let info = InterfaceInfo::from_glib_ptr_borrow_mut(info_ptr);
+    let info = InterfaceInfo::from_glib_borrow_mut2(&mut *info_ptr);
 
     let info_ = imp.complete_interface_info(instance_type, interface_type);
     *info = info_;

--- a/glib/src/subclass/types.rs
+++ b/glib/src/subclass/types.rs
@@ -368,13 +368,12 @@ where
     <A as ObjectType>::GlibClassType: Copy,
 {
     fn iface_infos() -> Vec<(Type, InterfaceInfo)> {
-        vec![(
-            A::static_type(),
-            InterfaceInfo(gobject_ffi::GInterfaceInfo {
+        vec![(A::static_type(), unsafe {
+            InterfaceInfo::unsafe_from(gobject_ffi::GInterfaceInfo {
                 interface_init: Some(interface_init::<T, A>),
-                ..InterfaceInfo::default().0
-            }),
-        )]
+                ..InterfaceInfo::default().inner
+            })
+        })]
     }
 
     #[inline]
@@ -413,11 +412,13 @@ macro_rules! interface_list_trait_impl(
                     $(
                         (
                             $name::static_type(),
-                            InterfaceInfo(gobject_ffi::GInterfaceInfo {
-                                interface_init: Some(interface_init::<T, $name>),
-                                interface_finalize: None,
-                                interface_data: ptr::null_mut(),
-                            }),
+                            unsafe {
+                                InterfaceInfo::unsafe_from(gobject_ffi::GInterfaceInfo {
+                                    interface_init: Some(interface_init::<T, $name>),
+                                    interface_finalize: None,
+                                    interface_data: ptr::null_mut(),
+                                })
+                            },
                         )
                     ),+
                 ]
@@ -1122,12 +1123,12 @@ pub fn register_dynamic_type<P: DynamicObjectRegisterExt, T: ObjectSubclass>(
         let already_registered =
             gobject_ffi::g_type_from_name(type_name.as_ptr()) != gobject_ffi::G_TYPE_INVALID;
 
-        let type_info = TypeInfo(gobject_ffi::GTypeInfo {
+        let type_info = TypeInfo::unsafe_from(gobject_ffi::GTypeInfo {
             class_size: mem::size_of::<T::Class>() as u16,
             class_init: Some(class_init::<T>),
             instance_size: mem::size_of::<T::Instance>() as u16,
             instance_init: Some(instance_init::<T>),
-            ..TypeInfo::default().0
+            ..TypeInfo::default().inner
         });
 
         // registers the type within the `type_plugin`

--- a/glib/src/translate.rs
+++ b/glib/src/translate.rs
@@ -1587,7 +1587,7 @@ pub trait FromGlibPtrFull<P: Ptr>: Sized {
 }
 
 // rustdoc-stripper-ignore-next
-/// Translate from a pointer type by borrowing, without affecting the refcount.
+/// Translate from a pointer type by borrowing, without affecting the refcount or copying.
 ///
 /// The purpose of this trait is to access values inside callbacks
 /// without changing their reference status.
@@ -1622,6 +1622,64 @@ pub trait FromGlibPtrBorrow<P: Ptr>: Sized {
 }
 
 // rustdoc-stripper-ignore-next
+/// Translate from a pointer type by borrowing, without affecting the refcount or copying.
+///
+/// The purpose of this trait is to access values inside callbacks
+/// without changing their reference status.
+/// The obtained borrow must not be accessed outside of the scope of the callback,
+/// and called procedures must not store any references to the underlying data.
+/// Safe Rust code must never obtain a mutable Rust reference.
+///
+/// <a name="safety_points"></a>
+/// # Safety
+///
+/// The implementation of this trait as well as the returned type
+/// must satisfy the same constraints together.
+/// They must not take ownership of the underlying value, copy it,
+/// and should not change its reference count.
+/// If it does, it must properly release obtained references.
+///
+/// For more information, refer to module level documentation.
+// FIXME: Rename to FromGlibPtrBorrow once all users are gone
+pub trait FromGlibPtrBorrow2<P>: Sized {
+    // rustdoc-stripper-ignore-next
+    /// # Safety
+    ///
+    /// See trait level [notes on safety](#safety_points)
+    unsafe fn from_glib_borrow2(_ptr: &P) -> &Self {
+        unimplemented!();
+    }
+}
+
+// rustdoc-stripper-ignore-next
+/// Translate from a pointer type by borrowing mutably, without affecting the refcount or copying.
+///
+/// The purpose of this trait is to access values inside callbacks
+/// without changing their reference status.
+/// The obtained borrow must not be accessed outside of the scope of the callback,
+/// and called procedures must not store any references to the underlying data.
+///
+/// <a name="safety_points"></a>
+/// # Safety
+///
+/// The implementation of this trait as well as the returned type
+/// must satisfy the same constraints together.
+/// They must not take ownership of the underlying value, copy it,
+/// and should not change its reference count.
+///
+/// For more information, refer to module level documentation.
+// FIXME: Rename to FromGlibPtrBorrowMut once all users are gone
+pub trait FromGlibPtrBorrowMut2<P>: Sized {
+    // rustdoc-stripper-ignore-next
+    /// # Safety
+    ///
+    /// See trait level [notes on safety](#safety_points)
+    unsafe fn from_glib_borrow_mut2(_ptr: &mut P) -> &mut Self {
+        unimplemented!();
+    }
+}
+
+// rustdoc-stripper-ignore-next
 /// Translate from a pointer type, transfer: none.
 ///
 /// See [`FromGlibPtrNone`](trait.FromGlibPtrNone.html).
@@ -1646,6 +1704,24 @@ pub unsafe fn from_glib_full<P: Ptr, T: FromGlibPtrFull<P>>(ptr: P) -> T {
 #[inline]
 pub unsafe fn from_glib_borrow<P: Ptr, T: FromGlibPtrBorrow<P>>(ptr: P) -> Borrowed<T> {
     FromGlibPtrBorrow::from_glib_borrow(ptr)
+}
+
+// rustdoc-stripper-ignore-next
+/// Translate from a pointer type, borrowing the pointer.
+///
+/// See [`FromGlibPtrBorrow2`](trait.FromGlibPtrBorrow2.html).
+#[inline]
+pub unsafe fn from_glib_borrow2<P, T: FromGlibPtrBorrow2<P>>(ptr: &P) -> &T {
+    FromGlibPtrBorrow2::from_glib_borrow2(ptr)
+}
+
+// rustdoc-stripper-ignore-next
+/// Translate from a pointer type, borrowing the pointer mutable.
+///
+/// See [`FromGlibPtrBorrowMut2`](trait.FromGlibPtrBorrowMut2.html).
+#[inline]
+pub unsafe fn from_glib_borrow_mut2<P, T: FromGlibPtrBorrowMut2<P>>(ptr: &mut P) -> &mut T {
+    FromGlibPtrBorrowMut2::from_glib_borrow_mut2(ptr)
 }
 
 impl<P: Ptr, T: FromGlibPtrNone<P>> FromGlibPtrNone<P> for Option<T> {

--- a/glib/src/value_array.rs
+++ b/glib/src/value_array.rs
@@ -244,7 +244,7 @@ unsafe impl<'a> crate::value::FromValue<'a> for &'a ValueArray {
         );
         let value = &*(value as *const Value as *const gobject_ffi::GValue);
         debug_assert!(!value.data[0].v_pointer.is_null());
-        <ValueArray>::from_glib_ptr_borrow(
+        <ValueArray>::from_glib_borrow2(
             &*(&value.data[0].v_pointer as *const ffi::gpointer
                 as *const *mut gobject_ffi::GValueArray),
         )


### PR DESCRIPTION
These borrow more safely the underlying type and are supposed to replace the old FromGlibPtrBorrow trait once all users are gone, as well as the manual implementations for the trait functions which are deprecated now.