### PR TITLE
glib-macros/async_test: Fixes unwrap result and move context

### DIFF
--- a/glib-macros/src/async_test.rs
+++ b/glib-macros/src/async_test.rs
@@ -34,7 +34,7 @@ pub(crate) fn async_test(_args: TokenStream, mut item: TokenStream) -> TokenStre
     item_fn.block = syn::parse2(quote::quote! {
         {
             let main_ctx = glib::MainContext::new();
-            main_ctx.with_thread_default(move || main_ctx.block_on(async #body))
+            main_ctx.with_thread_default(|| main_ctx.block_on(async #body))
                 .expect("cannot set thread default main context for test")
         }
     })


### PR DESCRIPTION
Tested code:
```
#[glib::async_test]
async fn my_test() {
    use std::time::Duration;

    glib::timeout_future(Duration::from_secs(1)).await;
}
```
## Before this PR
```
fn my_test() {
    let main_ctx = glib::MainContext::new();
    main_ctx
        .with_thread_default(move || {
            main_ctx
                .block_on(async {
                    use std::time::Duration;
                    glib::timeout_future(Duration::from_secs(1)).await;
                })
        })
}
```

```
error[E0308]: mismatched types
  --> src/main.rs:12:1
   |
12 | #[glib::async_test]
   | ^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<(), BoolError>`
   |
   = note: expected unit type `()`
                   found enum `Result<(), BoolError>`
```

AND
```
error[E0505]: cannot move out of `main_ctx` because it is borrowed
  --> src/main.rs:23:30
   |
21 |     let main_ctx = glib::MainContext::new();
   |         -------- binding `main_ctx` declared here
22 |     main_ctx
   |     -------- borrow of `main_ctx` occurs here
23 |         .with_thread_default(move || {
   |          ------------------- ^^^^^^^ move out of `main_ctx` occurs here
   |          |
   |          borrow later used by call
24 |             main_ctx
   |             -------- move occurs due to use in closure
   |
help: consider cloning the value if the performance cost is acceptable
   |
22 |     main_ctx.clone()
   |             ++++++++
```

## After this PR
```
fn my_test() {
    let main_ctx = glib::MainContext::new();
    main_ctx
        .with_thread_default(|| {
            main_ctx
                .block_on(async {
                    use std::time::Duration;
                    glib::timeout_future(Duration::from_secs(1)).await;
                })
        })
        .expect("cannot set thread default main context for test")
}

```