### PR TITLE
gio: Mark DBusInterface.get_info's return value as nullable

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -649,6 +649,10 @@ status = "generate"
     [[object.function]]
     name = "dup_object"
     rename = "get"
+    [[object.function]]
+    name = "get_info"
+        [object.function.return]
+        nullable = true
 
 [[object]]
 name = "Gio.DBusInterfaceInfo"

--- a/gio/src/auto/dbus_interface.rs
+++ b/gio/src/auto/dbus_interface.rs
@@ -31,7 +31,7 @@ pub trait DBusInterfaceExt: IsA<DBusInterface> + 'static {
 
     #[doc(alias = "g_dbus_interface_get_info")]
     #[doc(alias = "get_info")]
-    fn info(&self) -> DBusInterfaceInfo {
+    fn info(&self) -> Option<DBusInterfaceInfo> {
         unsafe {
             from_glib_none(ffi::g_dbus_interface_get_info(
                 self.as_ref().to_glib_none().0,


### PR DESCRIPTION
It looks to me like [`DBusInterface.get_info`](https://docs.gtk.org/gio/method.DBusInterface.get_info.html) can return null.

[`DBusProxy`](https://docs.gtk.org/gio/class.DBusProxy.html), which implements `DBusInterface` returns null if it is created without an interface info. The `DBusProxy`-specific function [`get_interface_info`](https://docs.gtk.org/gio/method.DBusProxy.get_interface_info.html) is even marked as nullable.

```rust
let proxy = DBusProxy::for_bus_future(
    BusType::Session,
    DBusProxyFlags::NONE,
    None,
    "org.freedesktop.portal.Desktop",
    "/org/freedesktop/portal/desktop",
    "org.freedesktop.portal.NetworkMonitor",
)
.await
.unwrap();
let _info = proxy.info();
// thread 'main' (175265) panicked at /home/tau/Source/GNOME/Rust/gtk-rs-core/glib/src/shared.rs:557:9:
// assertion failed: !ptr.is_null()
```