### PR TITLE
Use BTreeMap instead of HashMap

### DIFF
--- a/glib-macros/src/properties.rs
+++ b/glib-macros/src/properties.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::format_ident;
 use quote::{quote, quote_spanned};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use syn::ext::IdentExt;
 use syn::parenthesized;
 use syn::parse::Parse;
@@ -216,7 +216,7 @@ struct ReceivedAttrs {
     member: Option<syn::Ident>,
     name: Option<syn::LitStr>,
     builder: Option<(Punctuated<syn::Expr, Token![,]>, TokenStream2)>,
-    builder_fields: HashMap<syn::Ident, Option<syn::Expr>>,
+    builder_fields: BTreeMap<syn::Ident, Option<syn::Expr>>,
     use_default: bool,
 }
 
@@ -271,7 +271,7 @@ struct PropDesc {
     set: Option<MaybeCustomFn>,
     member: Option<syn::Ident>,
     builder: Option<(Punctuated<syn::Expr, Token![,]>, TokenStream2)>,
-    builder_fields: HashMap<syn::Ident, Option<syn::Expr>>,
+    builder_fields: BTreeMap<syn::Ident, Option<syn::Expr>>,
     is_construct_only: bool,
     use_default: bool,
 }


### PR DESCRIPTION
Use `BTreeMap` instead of `HashMap`
to have deterministic output ordering
to allow for reproducible builds.

See https://reproducible-builds.org/ for why this is good.

Without this patch, ArchLinux' and [openSUSE's `identity` package](https://build.opensuse.org/package/show/openSUSE:Factory/identity) varied between builds.

Special thanks go to @kpcyrd for help in debugging this.