### PR TITLE
glib/bytes: relax start offset constraint for `from_bytes`

### DIFF
--- a/glib/src/bytes.rs
+++ b/glib/src/bytes.rs
@@ -109,7 +109,7 @@ impl Bytes {
             Bound::Excluded(v) => v.checked_add(1).expect("Invalid start offset"),
             Bound::Unbounded => 0,
         };
-        assert!(start_offset < len, "Start offset after valid range");
+        assert!(start_offset <= len, "Start offset after valid range");
 
         let end_offset = match range.end_bound() {
             Bound::Included(v) => v.checked_add(1).expect("Invalid end offset"),
@@ -338,6 +338,8 @@ mod tests {
         assert_eq!(b2, [1u8, 2u8].as_ref());
         let b2 = Bytes::from_bytes(&b1, ..);
         assert_eq!(b2, [1u8, 2u8, 3u8].as_ref());
+        let b2 = Bytes::from_bytes(&b1, 3..);
+        assert_eq!(b2, [].as_ref());
     }
 
     #[test]


### PR DESCRIPTION
Maybe I've missed something, but it was faster opening a one-line PR for seeking feedback.

In rust this is totally valid:
```rust
let bytes = b"1234";
let sub = &bytes[4..];
```

But this is not in `glib` at the moment:
```rust
let bytes = glib::Bytes::from_static(b"1234");
let sub = glib::Bytes::from_bytes(&bytes, 4..);  // This crashes without this patch
```

This patch does not contradict [Bytes.new_from_bytes](https://docs.gtk.org/glib/ctor.Bytes.new_from_bytes.html) 'cause `end + 0 <= len` holds.