### PR TITLE
glib: Mark `setenv()` / `unsetenv()` as unsafe

### DIFF
--- a/glib/Gir.toml
+++ b/glib/Gir.toml
@@ -233,7 +233,9 @@ status = "generate"
         [object.function.return]
         string_type = "os_string"
     [[object.function]]
-    pattern = "setenv"
+    name = "setenv"
+    unsafe = true
+
         [[object.function.parameter]]
         name = "variable"
         string_type = "os_string"
@@ -251,6 +253,8 @@ status = "generate"
         string_type = "os_string"
     [[object.function]]
     name = "unsetenv"
+    unsafe = true
+
         [[object.function.parameter]]
         name = "variable"
         string_type = "os_string"

--- a/glib/src/auto/functions.rs
+++ b/glib/src/auto/functions.rs
@@ -628,7 +628,7 @@ pub fn set_application_name(application_name: &str) {
 }
 
 #[doc(alias = "g_setenv")]
-pub fn setenv(
+pub unsafe fn setenv(
     variable: impl AsRef<std::ffi::OsStr>,
     value: impl AsRef<std::ffi::OsStr>,
     overwrite: bool,
@@ -834,7 +834,7 @@ pub fn unlink(filename: impl AsRef<std::path::Path>) -> i32 {
 }
 
 #[doc(alias = "g_unsetenv")]
-pub fn unsetenv(variable: impl AsRef<std::ffi::OsStr>) {
+pub unsafe fn unsetenv(variable: impl AsRef<std::ffi::OsStr>) {
     unsafe {
         ffi::g_unsetenv(variable.as_ref().to_glib_none().0);
     }

--- a/glib/src/utils.rs
+++ b/glib/src/utils.rs
@@ -217,8 +217,10 @@ mod tests {
     fn check_setenv(val: &str) {
         let _data = lock().lock().unwrap();
 
-        crate::setenv(VAR_NAME, val, true).unwrap();
-        assert_eq!(env::var_os(VAR_NAME), Some(val.into()));
+        unsafe {
+            crate::setenv(VAR_NAME, val, true).unwrap();
+            assert_eq!(env::var_os(VAR_NAME), Some(val.into()));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Same rationale as for the corresponding std functions.