### PR TITLE
Doc: clarify the GObject subclass mechanism

### DIFF
--- a/glib/src/subclass/mod.rs
+++ b/glib/src/subclass/mod.rs
@@ -225,10 +225,10 @@
 //! //                                     ffi::GObject (first member of instance struct)
 //! //                                      |
 //! // |--private data (imp::SimpleObject)--|--instance struct (basic::InstanceStruct)--|
-//! //                    ^
-//! //                    |
-//! //                    |
-//! //               SimpleObject
+//! //                                      ^
+//! //                                      |
+//! //                                      |
+//! //                                 SimpleObject
 //!
 //! pub fn main() {
 //!     let obj = SimpleObject::new();


### PR DESCRIPTION
The example given in the top-level [subclassing module](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/subclass/index.html) is not quite accurate because the wrapper type is not optional.

Update the comments in the example while peeling back some of the magic of how of this framework bridges Rust and GObject. For instance, it wasn't obvious to me just from reading the public documentation how `SimpleObject` "inherits" the public methods of `Object`. Please let me know if I have misunderstood some of the details.

Closes #1870 .