### PR TITLE
glib: Implement From<PtrSlice<GStringPtr> for StrV

### DIFF
--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -445,6 +445,14 @@ impl From<crate::PtrSlice<GStringPtr>> for StrV {
     }
 }
 
+impl From<StrV> for crate::PtrSlice<GStringPtr> {
+    #[inline]
+    fn from(value: StrV) -> Self {
+        let len = value.len();
+        unsafe { Self::from_glib_full_num(value.into_glib_ptr(), len, true) }
+    }
+}
+
 impl Clone for StrV {
     #[inline]
     fn clone(&self) -> Self {
@@ -1919,6 +1927,17 @@ mod test {
 
         for (i, item) in items.into_iter().enumerate() {
             assert_eq!(strv[i], item);
+        }
+    }
+
+    #[test]
+    fn test_into_ptr_slice() {
+        let items = [crate::gstr!("a"), crate::gstr!("b"), crate::gstr!("c")];
+        let strv: StrV = StrV::from(&items[..]);
+        let ptr_slice: crate::PtrSlice<GStringPtr> = strv.into();
+
+        for (i, item) in items.into_iter().enumerate() {
+            assert_eq!(ptr_slice[i], item);
         }
     }
 }


### PR DESCRIPTION
In C they are the same. For example glib::KeyFile::string_list() returns a PtrSlice instead of a StrV so it's nice to be able to convert it to a StrV which implements GValue.

It could also make sense to just do https://github.com/gtk-rs/gtk-rs-core/issues/939