### PR TITLE
gio: Allow DBus get/set_property to return a Result 

### DIFF
--- a/examples/gio_dbus_register_object/main.rs
+++ b/examples/gio_dbus_register_object/main.rs
@@ -25,9 +25,14 @@ mod imp {
     use gio::subclass::prelude::*;
     use gio::{DBusConnection, DBusError};
 
+    const INTERFACE_NAME: &str = "com.github.gtk_rs.examples.HelloWorld";
+    const OBJECT_PATH: &str = "/com/github/gtk_rs/examples/HelloWorld";
+    const LAST_GREETED_NAME_PROPERTY: &str = "LastGreetedName";
+
     const EXAMPLE_XML: &str = r#"
 <node>
   <interface name='com.github.gtk_rs.examples.HelloWorld'>
+    <property name='LastGreetedName' type='s' access='read' />
     <method name='Hello'>
       <arg type='s' name='name' direction='in'/>
       <arg type='s' name='greet' direction='out'/>
@@ -82,6 +87,7 @@ mod imp {
     #[derive(Default)]
     pub struct SampleApplication {
         registration_id: RefCell<Option<gio::RegistrationId>>,
+        last_greeted_name: RefCell<Option<String>>,
     }
 
     impl SampleApplication {
@@ -91,16 +97,40 @@ mod imp {
         ) -> Result<gio::RegistrationId, glib::Error> {
             let example = gio::DBusNodeInfo::for_xml(EXAMPLE_XML)
                 .ok()
-                .and_then(|e| e.lookup_interface("com.github.gtk_rs.examples.HelloWorld"))
+                .and_then(|e| e.lookup_interface(INTERFACE_NAME))
                 .expect("Example interface");
 
             connection
-                .register_object("/com/github/gtk_rs/examples/HelloWorld", &example)
+                .register_object(OBJECT_PATH, &example)
+                .property(glib::clone!(
+                    #[weak(rename_to = app)]
+                    self.obj(),
+                    #[upgrade_or_else]
+                    || Err(glib::Error::new(gio::DBusError::Failed, "exiting")),
+                    move |_, _, _, _, property_name| {
+                        match property_name {
+                            LAST_GREETED_NAME_PROPERTY => {
+                                if let Some(name) = &*app.imp().last_greeted_name.borrow() {
+                                    Ok(name.to_variant())
+                                } else {
+                                    Err(glib::Error::new(
+                                        gio::DBusError::Failed,
+                                        "nobody has been greeted yet",
+                                    ))
+                                }
+                            }
+                            _ => Err(glib::Error::new(
+                                gio::DBusError::UnknownProperty,
+                                "unknown property",
+                            )),
+                        }
+                    },
+                ))
                 .typed_method_call::<HelloMethod>()
                 .invoke_and_return_future_local(glib::clone!(
                     #[weak_allow_none(rename_to = app)]
                     self.obj(),
-                    move |_, sender, call| {
+                    move |connection, sender, call| {
                         println!("Method call from {sender:?}");
                         let app = app.clone();
                         async move {
@@ -108,12 +138,18 @@ mod imp {
                                 HelloMethod::Hello(Hello { name }) => {
                                     let greet = format!("Hello {name}!");
                                     println!("{greet}");
+                                    if let Some(app) = app {
+                                        app.imp().set_last_greeted_name(name, &connection);
+                                    }
                                     Ok(Some(greet.to_variant()))
                                 }
                                 HelloMethod::SlowHello(SlowHello { name, delay }) => {
                                     glib::timeout_future(Duration::from_secs(delay as u64)).await;
                                     let greet = format!("Hello {name} after {delay} seconds!");
                                     println!("{greet}");
+                                    if let Some(app) = app {
+                                        app.imp().set_last_greeted_name(name, &connection);
+                                    }
                                     Ok(Some(greet.to_variant()))
                                 }
                                 HelloMethod::GoodBye => {
@@ -127,6 +163,22 @@ mod imp {
                     }
                 ))
                 .build()
+        }
+
+        fn set_last_greeted_name(&self, name: String, connection: &DBusConnection) {
+            *self.last_greeted_name.borrow_mut() = Some(name.clone());
+
+            let changed_properties = glib::VariantDict::default();
+            changed_properties.insert(LAST_GREETED_NAME_PROPERTY, name);
+            let invalidated_properties: &[&str] = &[];
+            let parameters = (INTERFACE_NAME, changed_properties, invalidated_properties);
+            _ = connection.emit_signal(
+                None,
+                OBJECT_PATH,
+                "org.freedesktop.DBus.Properties",
+                "PropertiesChanged",
+                Some(&parameters.to_variant()),
+            );
         }
     }
 

--- a/gio/src/dbus_connection.rs
+++ b/gio/src/dbus_connection.rs
@@ -4,7 +4,7 @@ use std::{boxed::Box as Box_, future::Future, marker::PhantomData, num::NonZeroU
 
 use crate::{
     ActionGroup, DBusConnection, DBusInterfaceInfo, DBusMessage, DBusMethodInvocation,
-    DBusSignalFlags, MenuModel, ffi,
+    DBusPropertyInfoFlags, DBusSignalFlags, MenuModel, ffi,
 };
 use futures_channel::mpsc;
 use futures_core::{FusedStream, Stream};
@@ -307,11 +307,30 @@ pub struct RegistrationBuilder<'a> {
         >,
     >,
     #[allow(clippy::type_complexity)]
-    get_property:
-        Option<Box_<dyn Fn(DBusConnection, Option<&str>, &str, &str, &str) -> glib::Variant>>,
+    get_property: Option<
+        Box_<
+            dyn Fn(
+                DBusConnection,
+                Option<&str>,
+                &str,
+                &str,
+                &str,
+            ) -> Result<glib::Variant, glib::Error>,
+        >,
+    >,
     #[allow(clippy::type_complexity)]
-    set_property:
-        Option<Box_<dyn Fn(DBusConnection, Option<&str>, &str, &str, &str, glib::Variant) -> bool>>,
+    set_property: Option<
+        Box_<
+            dyn Fn(
+                DBusConnection,
+                Option<&str>,
+                &str,
+                &str,
+                &str,
+                glib::Variant,
+            ) -> Result<(), glib::Error>,
+        >,
+    >,
 }
 
 impl<'a> RegistrationBuilder<'a> {
@@ -348,7 +367,8 @@ impl<'a> RegistrationBuilder<'a> {
 
     #[doc(alias = "get_property")]
     pub fn property<
-        F: Fn(DBusConnection, Option<&str>, &str, &str, &str) -> glib::Variant + 'static,
+        F: Fn(DBusConnection, Option<&str>, &str, &str, &str) -> Result<glib::Variant, glib::Error>
+            + 'static,
     >(
         mut self,
         f: F,
@@ -358,7 +378,15 @@ impl<'a> RegistrationBuilder<'a> {
     }
 
     pub fn set_property<
-        F: Fn(DBusConnection, Option<&str>, &str, &str, &str, glib::Variant) -> bool + 'static,
+        F: Fn(
+                DBusConnection,
+                Option<&str>,
+                &str,
+                &str,
+                &str,
+                glib::Variant,
+            ) -> Result<(), glib::Error>
+            + 'static,
     >(
         mut self,
         f: F,
@@ -368,14 +396,17 @@ impl<'a> RegistrationBuilder<'a> {
     }
 
     pub fn build(self) -> Result<RegistrationId, glib::Error> {
+        const PROPERTIES_INTERFACE: &str = "org.freedesktop.DBus.Properties";
         unsafe {
             let mut error = std::ptr::null_mut();
+            let interface_info = self.interface_info.clone();
+            // We handle get_/set_property ourselves because the closure versions can't return errors.
             let id = ffi::g_dbus_connection_register_object_with_closures(
                 self.connection.to_glib_none().0,
                 self.object_path.to_glib_none().0,
                 self.interface_info.to_glib_none().0,
                 self.method_call
-                    .map(|f| {
+                    .map(move |f| {
                         glib::Closure::new_local(move |args| {
                             let conn = args[0].get::<DBusConnection>().unwrap();
                             let sender = args[1].get::<Option<&str>>().unwrap();
@@ -396,57 +427,61 @@ impl<'a> RegistrationBuilder<'a> {
                             )
                                 as *mut ffi::GDBusMethodInvocation);
 
-                            f(
-                                conn,
-                                sender,
-                                object_path,
-                                interface_name,
-                                method_name,
-                                parameters,
-                                invocation,
-                            );
+                            if interface_name == Some(PROPERTIES_INTERFACE)
+                                && method_name == "Get"
+                                && let Some(get_property) = self.get_property.as_deref()
+                            {
+                                handle_get_property(
+                                    conn,
+                                    sender,
+                                    object_path,
+                                    parameters,
+                                    invocation,
+                                    get_property,
+                                );
+                            } else if interface_name == Some(PROPERTIES_INTERFACE)
+                                && method_name == "Set"
+                                && let Some(set_property) = self.set_property.as_deref()
+                            {
+                                handle_set_property(
+                                    conn,
+                                    sender,
+                                    object_path,
+                                    parameters,
+                                    invocation,
+                                    set_property,
+                                );
+                            } else if interface_name == Some(PROPERTIES_INTERFACE)
+                                && method_name == "GetAll"
+                                && let Some(get_property) = self.get_property.as_deref()
+                            {
+                                handle_get_all_properties(
+                                    conn,
+                                    sender,
+                                    object_path,
+                                    &interface_info,
+                                    invocation,
+                                    get_property,
+                                );
+                            } else {
+                                f(
+                                    conn,
+                                    sender,
+                                    object_path,
+                                    interface_name,
+                                    method_name,
+                                    parameters,
+                                    invocation,
+                                );
+                            }
+
                             None
                         })
                     })
                     .to_glib_none()
                     .0,
-                self.get_property
-                    .map(|f| {
-                        glib::Closure::new_local(move |args| {
-                            let conn = args[0].get::<DBusConnection>().unwrap();
-                            let sender = args[1].get::<Option<&str>>().unwrap();
-                            let object_path = args[2].get::<&str>().unwrap();
-                            let interface_name = args[3].get::<&str>().unwrap();
-                            let property_name = args[4].get::<&str>().unwrap();
-                            let result =
-                                f(conn, sender, object_path, interface_name, property_name);
-                            Some(result.to_value())
-                        })
-                    })
-                    .to_glib_none()
-                    .0,
-                self.set_property
-                    .map(|f| {
-                        glib::Closure::new_local(move |args| {
-                            let conn = args[0].get::<DBusConnection>().unwrap();
-                            let sender = args[1].get::<Option<&str>>().unwrap();
-                            let object_path = args[2].get::<&str>().unwrap();
-                            let interface_name = args[3].get::<&str>().unwrap();
-                            let property_name = args[4].get::<&str>().unwrap();
-                            let value = args[5].get::<glib::Variant>().unwrap();
-                            let result = f(
-                                conn,
-                                sender,
-                                object_path,
-                                interface_name,
-                                property_name,
-                                value,
-                            );
-                            Some(result.to_value())
-                        })
-                    })
-                    .to_glib_none()
-                    .0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
                 &mut error,
             );
 
@@ -457,6 +492,102 @@ impl<'a> RegistrationBuilder<'a> {
             }
         }
     }
+}
+
+fn handle_get_property(
+    connection: DBusConnection,
+    sender: Option<&str>,
+    object_path: &str,
+    parameters: glib::Variant,
+    invocation: DBusMethodInvocation,
+    get_property_func: &dyn Fn(
+        DBusConnection,
+        Option<&str>,
+        &str,
+        &str,
+        &str,
+    ) -> Result<glib::Variant, glib::Error>,
+) {
+    let (interface_name, property_name): (String, String) = parameters
+        .get()
+        .expect("parameters are guaranteed to have correct types by gdbus");
+    let result = get_property_func(
+        connection,
+        sender,
+        object_path,
+        &interface_name,
+        &property_name,
+    );
+    invocation.return_result(result.map(|variant| Some(variant.to_variant())));
+}
+
+fn handle_set_property(
+    connection: DBusConnection,
+    sender: Option<&str>,
+    object_path: &str,
+    parameters: glib::Variant,
+    invocation: DBusMethodInvocation,
+    set_property_func: &dyn Fn(
+        DBusConnection,
+        Option<&str>,
+        &str,
+        &str,
+        &str,
+        glib::Variant,
+    ) -> Result<(), glib::Error>,
+) {
+    let (interface_name, property_name, value): (String, String, _) = parameters
+        .get()
+        .expect("parameters are guaranteed to have correct types by gdbus");
+    let result = set_property_func(
+        connection,
+        sender,
+        object_path,
+        &interface_name,
+        &property_name,
+        value,
+    )
+    .map(|_| None);
+    invocation.return_result(result);
+}
+
+// Re-implementation of `invoke_get_all_properties_in_idle_cb` in gdbusconnection.c
+fn handle_get_all_properties(
+    connection: DBusConnection,
+    sender: Option<&str>,
+    object_path: &str,
+    interface_info: &DBusInterfaceInfo,
+    invocation: DBusMethodInvocation,
+    get_property_func: &dyn Fn(
+        DBusConnection,
+        Option<&str>,
+        &str,
+        &str,
+        &str,
+    ) -> Result<glib::Variant, glib::Error>,
+) {
+    // Interface name is already validated by gdbus
+
+    let interface_name = interface_info.name();
+    let readable_properties = interface_info
+        .properties()
+        .filter(|p| p.flags().contains(DBusPropertyInfoFlags::READABLE));
+
+    let property_values = glib::VariantDict::default();
+    for property in readable_properties {
+        let property_name = property.name();
+        if let Ok(value) = get_property_func(
+            connection.clone(),
+            sender,
+            object_path,
+            interface_name,
+            property_name,
+        ) {
+            property_values.insert(property_name, value);
+        }
+    }
+
+    invocation.return_value(Some(&(property_values,).to_variant()));
 }
 
 impl DBusConnection {

--- a/gio/src/dbus_interface_info.rs
+++ b/gio/src/dbus_interface_info.rs
@@ -92,7 +92,7 @@ mod tests {
     fn iterate_empty_properties() {
         const XML: &str = r#"
         <node>
-            <interface name='com.github.gtk_rs.Test />
+            <interface name='com.github.gtk_rs.Test' />
         </node>
         "#;
         let node_info = DBusNodeInfo::for_xml(XML).unwrap();

--- a/gio/src/dbus_interface_info.rs
+++ b/gio/src/dbus_interface_info.rs
@@ -2,7 +2,9 @@
 
 use std::ffi::CStr;
 
-use crate::DBusInterfaceInfo;
+use crate::ffi;
+use crate::{DBusInterfaceInfo, DBusPropertyInfo};
+use glib::translate::*;
 
 impl DBusInterfaceInfo {
     pub fn name(&self) -> &str {
@@ -13,5 +15,113 @@ impl DBusInterfaceInfo {
             let c_str = CStr::from_ptr(name);
             c_str.to_str().unwrap()
         }
+    }
+
+    pub fn properties(&self) -> DBusInterfaceInfoPropertiesIter<'_> {
+        DBusInterfaceInfoPropertiesIter::new(self)
+    }
+}
+
+pub struct DBusInterfaceInfoPropertiesIter<'a> {
+    _stash: Stash<'a, *mut ffi::GDBusInterfaceInfo, DBusInterfaceInfo>,
+    next_property: *mut *mut ffi::GDBusPropertyInfo,
+}
+
+impl<'a> DBusInterfaceInfoPropertiesIter<'a> {
+    fn new(info: &'a DBusInterfaceInfo) -> Self {
+        let stash: Stash<*mut ffi::GDBusInterfaceInfo, _> = info.to_glib_none();
+        // SAFETY:
+        // * the stash is stored in the struct to keep the pointer valid
+        // * though not explicitly documented, this struct is assumed to be immutable after creation
+        //   (with the exception of ref_count of course). See usage in gdbusconnection.c
+        let next_property = unsafe { *stash.0 }.properties;
+        Self {
+            _stash: stash,
+            next_property,
+        }
+    }
+}
+
+impl<'a> Iterator for DBusInterfaceInfoPropertiesIter<'a> {
+    type Item = DBusPropertyInfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // SAFETY: `self.next_property` is a pointer to a NULL-terminated
+        // array of pointers to GDBusPropertyInfo.
+        unsafe {
+            assert!(!self.next_property.is_null());
+            let property = *self.next_property;
+            if !property.is_null() {
+                self.next_property = self.next_property.add(1);
+                Some(from_glib_none(property))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DBusNodeInfo;
+
+    #[test]
+    fn iterate_properties() {
+        const XML: &str = r#"
+        <node>
+            <interface name='com.github.gtk_rs.Test'>
+                <property name='Name' type='s' access='read' />
+                <property name='Count' type='x' access='write' />
+            </interface>
+        </node>
+        "#;
+        let node_info = DBusNodeInfo::for_xml(XML).unwrap();
+        let interface = node_info
+            .lookup_interface("com.github.gtk_rs.Test")
+            .unwrap();
+
+        let mut properties = interface.properties();
+        let property = properties.next().unwrap();
+        assert_eq!("Name", property.name());
+        let property = properties.next().unwrap();
+        assert_eq!("Count", property.name());
+        assert!(properties.next().is_none());
+    }
+
+    #[test]
+    fn iterate_empty_properties() {
+        const XML: &str = r#"
+        <node>
+            <interface name='com.github.gtk_rs.Test />
+        </node>
+        "#;
+        let node_info = DBusNodeInfo::for_xml(XML).unwrap();
+        let interface = node_info
+            .lookup_interface("com.github.gtk_rs.Test")
+            .unwrap();
+
+        let mut properties = interface.properties();
+        assert!(properties.next().is_none());
+    }
+
+    #[test]
+    fn iterator_is_sealed() {
+        const XML: &str = r#"
+        <node>
+            <interface name='com.github.gtk_rs.Test'>
+                <property name='Count' type='x' access='write' />
+            </interface>
+        </node>
+        "#;
+        let node_info = DBusNodeInfo::for_xml(XML).unwrap();
+        let interface = node_info
+            .lookup_interface("com.github.gtk_rs.Test")
+            .unwrap();
+
+        let mut properties = interface.properties();
+        let _property = properties.next().unwrap();
+        assert!(properties.next().is_none());
+
+        assert!(properties.next().is_none());
     }
 }

--- a/gio/src/dbus_property_info.rs
+++ b/gio/src/dbus_property_info.rs
@@ -1,0 +1,41 @@
+// Take a look at the license at the top of the repository in the LICENSE file.
+
+use crate::{DBusPropertyInfo, DBusPropertyInfoFlags};
+use glib::translate::*;
+use std::ffi::CStr;
+
+// SAFETY:
+// though not explicitly documented, this struct is assumed to be immutable after creation
+// (with the exception of ref_count of course). See usage in gdbusconnection.c
+
+impl DBusPropertyInfo {
+    pub fn name(&self) -> &str {
+        // SAFETY: See top-level comment.
+        unsafe {
+            let c_obj = self.as_ptr();
+            let name = (*c_obj).name;
+            assert!(!name.is_null());
+            let c_str = CStr::from_ptr(name);
+            c_str.to_str().unwrap()
+        }
+    }
+
+    pub fn signature(&self) -> &str {
+        // SAFETY: See top-level comment.
+        unsafe {
+            let c_obj = self.as_ptr();
+            let signature = (*c_obj).signature;
+            assert!(!signature.is_null());
+            let c_str = CStr::from_ptr(signature);
+            c_str.to_str().unwrap()
+        }
+    }
+
+    pub fn flags(&self) -> DBusPropertyInfoFlags {
+        unsafe {
+            let c_obj = self.as_ptr();
+            let flags = (*c_obj).flags;
+            from_glib(flags)
+        }
+    }
+}

--- a/gio/src/lib.rs
+++ b/gio/src/lib.rs
@@ -31,6 +31,7 @@ mod datagram_based;
 mod dbus;
 pub use self::dbus::*;
 mod dbus_connection;
+mod dbus_property_info;
 pub use self::dbus_connection::{
     ActionGroupExportId, DBusSignalRef, FilterId, MenuModelExportId, RegistrationBuilder,
     RegistrationId, SignalSubscription, SignalSubscriptionId, SubscribedSignalStream, WatcherId,

--- a/gio/tests/dbus_peer.rs
+++ b/gio/tests/dbus_peer.rs
@@ -81,7 +81,7 @@ fn test_gdbus_peer_connection() {
                         _property_name
                     );
                     assert_eq!(_property_name, "Number");
-                    123.to_variant()
+                    Ok(123.to_variant())
                 }
             })
             .set_property({
@@ -96,7 +96,7 @@ fn test_gdbus_peer_connection() {
                     );
                     assert_eq!(_property_name, "Number");
                     assert_eq!(_value, 456.to_variant());
-                    true
+                    Ok(())
                 }
             })
             .build()


### PR DESCRIPTION
By using `g_dbus_connection_register_object` instead of `g_dbus_connection_register_object_with_closures`, we are able to return `Result`s from `get_property` and `set_property`.

This is a breaking change. Should I change this in a backwards-compatible way instead?
