### PR TITLE
gio: Add "D-Bus" and "DBus" to Cargo.toml keywords and description

### DIFF
--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gio"
-keywords = ["glib", "gio", "gtk-rs", "gnome"]
+keywords = ["glib", "gio", "D-Bus", "DBus", "gtk-rs", "gnome"]
 readme = "README.md"
 documentation = "https://gtk-rs.org/gtk-rs-core/stable/latest/docs/gio/"
 description = "Rust bindings for the Gio library"


### PR DESCRIPTION
One good way to keep Rust binary sizes down when using D-Bus is to use `gio`’s D-Bus bindings and link dynamically to the system `libgio-2.0.so`.

However, if you’re not already aware that `gio` provides D-Bus bindings, it’s hard to discover that it does. For example, searching for "dbus" on https://crates.io/ does not list `gio` as an alternative.

This commit addresses that by including the terms "D-Bus" and "DBus" in the `gio` package keywords and description. We include both "D-Bus" and "DBus" because that’s what other D-Bus crates, such as [`dbus`][1] and [`zbus`][2], also do.

### Steps to reproduce the problem this commit should fix
1. Go to https://crates.io/search?q=dbus&sort=downloads

### Expected result
`gio` is listed on the first page.

### Actual result
`gio` is not listed at all, despite having enough total downloads to qualify for the top 10 results.

[1]: https://github.com/diwic/dbus-rs/blob/eee6bf5b2d9ff81fabd281cb24b222455f2b5919/dbus/Cargo.toml#L10C12-L10C28
[2]: https://github.com/z-galaxy/zbus/blob/3d3491dabe1914b619305e56e856b5c3555cca1b/zbus/Cargo.toml#L10C12-L10C36