### PR TITLE
glib-win32: fix export of function

### DIFF
--- a/glib-win32/src/functions.rs
+++ b/glib-win32/src/functions.rs
@@ -9,7 +9,7 @@ use crate::ffi;
 
 #[doc(alias = "g_win32_get_package_installation_directory_of_module")]
 #[doc(alias = "get_package_installation_directory_of_module")]
-#[cfg(all(docsrs, windows))]
+#[cfg(any(windows, docsrs))]
 pub fn package_installation_directory_of_module(
     hmodule: std::os::windows::raw::HANDLE,
 ) -> Result<PathBuf, std::io::Error> {


### PR DESCRIPTION
Regression from the commit: 27e19a89abf126426a2353976b63420b76cc4603 The function must be always exported for windows