### PR TITLE
gio: Remove "gio" from package.keywords

### DIFF
--- a/gio/Cargo.toml
+++ b/gio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gio"
-keywords = ["glib", "gio", "D-Bus", "DBus", "gtk-rs", "gnome"]
+keywords = ["glib", "D-Bus", "DBus", "gtk-rs", "gnome"]
 readme = "README.md"
 documentation = "https://gtk-rs.org/gtk-rs-core/stable/latest/docs/gio/"
 description = "Rust bindings for the Gio library"


### PR DESCRIPTION
We can have at most five keywords (see https://github.com/gtk-rs/gtk-rs-core/pull/1935#issuecomment-4188558473), and using our package name as a keyword provides no benefits.