### PR TITLE
gio-unix: Do not expose DesktopAppInfo on macos

### DIFF
--- a/gio-unix/Gir.toml
+++ b/gio-unix/Gir.toml
@@ -49,6 +49,7 @@ status = "generate"
 name = "GioUnix.DesktopAppInfo"
 status = "generate"
 manual_traits = ["DesktopAppInfoExtManual"]
+cfg_condition = "not(target_os = \"macos\")"
     [[object.function]]
     name = "get_boolean"
     # Retrieves the boolean value of a key

--- a/gio-unix/src/auto/mod.rs
+++ b/gio-unix/src/auto/mod.rs
@@ -2,7 +2,11 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
+#[cfg(not(target_os = "macos"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_os = "macos"))))]
 mod desktop_app_info;
+#[cfg(not(target_os = "macos"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_os = "macos"))))]
 pub use self::desktop_app_info::DesktopAppInfo;
 
 mod fd_message;

--- a/gio-unix/src/lib.rs
+++ b/gio-unix/src/lib.rs
@@ -10,7 +10,7 @@ pub use gio_unix_sys as ffi;
 mod auto;
 pub use auto::*;
 
-#[cfg(feature = "v2_58")]
+#[cfg(all(feature = "v2_58", not(target_os = "macos")))]
 mod desktop_app_info;
 mod fd_message;
 mod file_descriptor_based;
@@ -29,7 +29,7 @@ pub mod prelude {
 
     pub use super::auto::traits::*;
 
-    #[cfg(feature = "v2_58")]
+    #[cfg(all(feature = "v2_58", not(target_os = "macos")))]
     pub use crate::desktop_app_info::DesktopAppInfoExtManual;
 
     pub use crate::fd_message::FDMessageExtManual;


### PR DESCRIPTION
In gio-unix, add the cfg_condition `not(target_os = "macos")` to DesktopAppInfo 

https://github.com/gtk-rs/gtk-rs-core/issues/1953

