### PR TITLE
glib: collections: Fix theoretical use-after-frees if dropping an ite…

### DIFF
--- a/glib/src/collections/list.rs
+++ b/glib/src/collections/list.rs
@@ -368,8 +368,9 @@ impl<T: TransparentPtrType> List<T> {
                     let item = &*(&(*ptr).data as *const ffi::gpointer as *const T);
                     let next = (*ptr).next;
                     if !f(item) {
-                        ptr::drop_in_place(&mut (*ptr).data as *mut ffi::gpointer as *mut T);
+                        let mut item_ptr = (*ptr).data;
                         self.ptr = ptr::NonNull::new(ffi::g_list_delete_link(head.as_ptr(), ptr));
+                        ptr::drop_in_place(&mut item_ptr as *mut ffi::gpointer as *mut T);
                     }
                     ptr = next;
                 }
@@ -417,7 +418,7 @@ impl<T: TransparentPtrType> Clone for List<T> {
 impl<T: TransparentPtrType> Drop for List<T> {
     #[inline]
     fn drop(&mut self) {
-        if let Some(ptr) = self.ptr {
+        if let Some(ptr) = self.ptr.take() {
             unsafe {
                 if mem::needs_drop::<T>() {
                     unsafe extern "C" fn drop_item<T: TransparentPtrType>(mut ptr: ffi::gpointer) {

--- a/glib/src/collections/list.rs
+++ b/glib/src/collections/list.rs
@@ -361,19 +361,19 @@ impl<T: TransparentPtrType> List<T> {
     /// Only keeps the item in the list for which `f` returns `true`.
     #[inline]
     pub fn retain(&mut self, mut f: impl FnMut(&T) -> bool) {
-        if let Some(head) = self.ptr {
-            unsafe {
-                let mut ptr = head.as_ptr();
-                while !ptr.is_null() {
-                    let item = &*(&(*ptr).data as *const ffi::gpointer as *const T);
-                    let next = (*ptr).next;
-                    if !f(item) {
-                        let mut item_ptr = (*ptr).data;
-                        self.ptr = ptr::NonNull::new(ffi::g_list_delete_link(head.as_ptr(), ptr));
-                        ptr::drop_in_place(&mut item_ptr as *mut ffi::gpointer as *mut T);
-                    }
-                    ptr = next;
+        let mut head = self.ptr.map(|p| p.as_ptr()).unwrap_or(ptr::null_mut());
+        unsafe {
+            let mut ptr = head;
+            while !ptr.is_null() {
+                let item = &*(&(*ptr).data as *const ffi::gpointer as *const T);
+                let next = (*ptr).next;
+                if !f(item) {
+                    let mut item_ptr = (*ptr).data;
+                    head = ffi::g_list_delete_link(head, ptr);
+                    self.ptr = ptr::NonNull::new(head);
+                    ptr::drop_in_place(&mut item_ptr as *mut ffi::gpointer as *mut T);
                 }
+                ptr = next;
             }
         }
     }
@@ -983,5 +983,25 @@ mod test {
             list.iter().map(|dt| dt.to_unix()).collect::<Vec<_>>(),
             vec![21, 22]
         );
+    }
+
+    #[test]
+    fn retain_deletes_head() {
+        let mut list = List::<crate::DateTime>::new();
+        let items = [
+            crate::DateTime::from_unix_utc(1).unwrap(),
+            crate::DateTime::from_unix_utc(2).unwrap(),
+            crate::DateTime::from_unix_utc(3).unwrap(),
+        ];
+        for item in &items {
+            list.push_back(item.clone());
+        }
+        assert_eq!(list.len(), 3);
+
+        // Delete first and second nodes, keep third
+        list.retain(|item| item.to_unix() >= 3);
+
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.pop_front().unwrap().to_unix(), 3);
     }
 }

--- a/glib/src/collections/ptr_slice.rs
+++ b/glib/src/collections/ptr_slice.rs
@@ -83,13 +83,15 @@ impl<T: TransparentPtrType> Drop for PtrSlice<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
+            let len = mem::replace(&mut self.len, 0);
             if mem::needs_drop::<T>() {
-                for i in 0..self.len {
+                for i in 0..len {
                     ptr::drop_in_place::<T>(self.ptr.as_ptr().add(i) as *mut T);
                 }
             }
 
-            if self.capacity != 0 {
+            let capacity = mem::replace(&mut self.capacity, 0);
+            if capacity != 0 {
                 ffi::g_free(self.ptr.as_ptr() as ffi::gpointer);
             }
         }
@@ -263,13 +265,15 @@ impl<T: TransparentPtrType> Drop for IntoIter<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
+            let len = mem::replace(&mut self.len, 0);
             if mem::needs_drop::<T>() {
-                for i in 0..self.len {
+                for i in 0..len {
                     ptr::drop_in_place::<T>(self.idx.as_ptr().add(i) as *mut T);
                 }
             }
 
-            if !self.empty {
+            let empty = mem::replace(&mut self.empty, true);
+            if !empty {
                 ffi::g_free(self.ptr.as_ptr() as ffi::gpointer);
             }
         }
@@ -789,13 +793,12 @@ impl<T: TransparentPtrType> PtrSlice<T> {
     #[inline]
     pub fn clear(&mut self) {
         unsafe {
+            let len = mem::replace(&mut self.len, 0);
             if mem::needs_drop::<T>() {
-                for i in 0..self.len {
+                for i in 0..len {
                     ptr::drop_in_place::<T>(self.ptr.as_ptr().add(i) as *mut T);
                 }
             }
-
-            self.len = 0;
         }
     }
 
@@ -929,14 +932,18 @@ impl<T: TransparentPtrType> PtrSlice<T> {
         }
 
         unsafe {
-            while self.len > len {
-                self.len -= 1;
-                let p = self.ptr.as_ptr().add(self.len);
-                ptr::drop_in_place::<T>(p as *mut T);
-                ptr::write(
-                    p,
-                    Ptr::from(ptr::null_mut::<<T as GlibPtrDefault>::GlibType>()),
-                );
+            if mem::needs_drop::<T>() {
+                while self.len > len {
+                    self.len -= 1;
+                    let p = self.ptr.as_ptr().add(self.len);
+                    ptr::drop_in_place::<T>(p as *mut T);
+                    ptr::write(
+                        p,
+                        Ptr::from(ptr::null_mut::<<T as GlibPtrDefault>::GlibType>()),
+                    );
+                }
+            } else {
+                self.len = len;
             }
         }
     }

--- a/glib/src/collections/slice.rs
+++ b/glib/src/collections/slice.rs
@@ -76,13 +76,15 @@ impl<T: TransparentType> Drop for Slice<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
+            let len = mem::replace(&mut self.len, 0);
             if mem::needs_drop::<T>() {
-                for i in 0..self.len {
+                for i in 0..len {
                     ptr::drop_in_place::<T>(self.ptr.as_ptr().add(i) as *mut T);
                 }
             }
 
-            if self.capacity != 0 {
+            let capacity = mem::replace(&mut self.capacity, 0);
+            if capacity != 0 {
                 ffi::g_free(self.ptr.as_ptr() as ffi::gpointer);
             }
         }
@@ -256,13 +258,15 @@ impl<T: TransparentType> Drop for IntoIter<T> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
+            let len = mem::replace(&mut self.len, 0);
             if mem::needs_drop::<T>() {
-                for i in 0..self.len {
+                for i in 0..len {
                     ptr::drop_in_place::<T>(self.idx.as_ptr().add(i) as *mut T);
                 }
             }
 
-            if !self.empty {
+            let empty = mem::replace(&mut self.empty, true);
+            if !empty {
                 ffi::g_free(self.ptr.as_ptr() as ffi::gpointer);
             }
         }
@@ -684,13 +688,12 @@ impl<T: TransparentType> Slice<T> {
     #[inline]
     pub fn clear(&mut self) {
         unsafe {
+            let len = mem::replace(&mut self.len, 0);
             if mem::needs_drop::<T>() {
-                for i in 0..self.len {
+                for i in 0..len {
                     ptr::drop_in_place::<T>(self.ptr.as_ptr().add(i) as *mut T);
                 }
             }
-
-            self.len = 0;
         }
     }
 
@@ -799,10 +802,14 @@ impl<T: TransparentType> Slice<T> {
         }
 
         unsafe {
-            while self.len > len {
-                self.len -= 1;
-                let p = self.ptr.as_ptr().add(self.len);
-                ptr::drop_in_place::<T>(p as *mut T);
+            if mem::needs_drop::<T>() {
+                while self.len > len {
+                    self.len -= 1;
+                    let p = self.ptr.as_ptr().add(self.len);
+                    ptr::drop_in_place::<T>(p as *mut T);
+                }
+            } else {
+                self.len = len;
             }
         }
     }

--- a/glib/src/collections/slist.rs
+++ b/glib/src/collections/slist.rs
@@ -356,19 +356,19 @@ impl<T: TransparentPtrType> SList<T> {
     /// Only keeps the item in the list for which `f` returns `true`.
     #[inline]
     pub fn retain(&mut self, mut f: impl FnMut(&T) -> bool) {
-        if let Some(head) = self.ptr {
-            unsafe {
-                let mut ptr = head.as_ptr();
-                while !ptr.is_null() {
-                    let item = &*(&(*ptr).data as *const ffi::gpointer as *const T);
-                    let next = (*ptr).next;
-                    if !f(item) {
-                        let mut item_ptr = (*ptr).data;
-                        self.ptr = ptr::NonNull::new(ffi::g_slist_delete_link(head.as_ptr(), ptr));
-                        ptr::drop_in_place(&mut item_ptr as *mut ffi::gpointer as *mut T);
-                    }
-                    ptr = next;
+        let mut head = self.ptr.map(|p| p.as_ptr()).unwrap_or(ptr::null_mut());
+        unsafe {
+            let mut ptr = head;
+            while !ptr.is_null() {
+                let item = &*(&(*ptr).data as *const ffi::gpointer as *const T);
+                let next = (*ptr).next;
+                if !f(item) {
+                    let mut item_ptr = (*ptr).data;
+                    head = ffi::g_slist_delete_link(head, ptr);
+                    self.ptr = ptr::NonNull::new(head);
+                    ptr::drop_in_place(&mut item_ptr as *mut ffi::gpointer as *mut T);
                 }
+                ptr = next;
             }
         }
     }
@@ -976,5 +976,25 @@ mod test {
             list.iter().map(|dt| dt.to_unix()).collect::<Vec<_>>(),
             vec![21, 22]
         );
+    }
+
+    #[test]
+    fn retain_deletes_head() {
+        let mut list = SList::<crate::DateTime>::new();
+        let items = [
+            crate::DateTime::from_unix_utc(1).unwrap(),
+            crate::DateTime::from_unix_utc(2).unwrap(),
+            crate::DateTime::from_unix_utc(3).unwrap(),
+        ];
+        for item in &items {
+            list.push_back(item.clone());
+        }
+        assert_eq!(list.len(), 3);
+
+        // Delete first and second nodes, keep third
+        list.retain(|item| item.to_unix() >= 3);
+
+        assert_eq!(list.len(), 1);
+        assert_eq!(list.pop_front().unwrap().to_unix(), 3);
     }
 }

--- a/glib/src/collections/slist.rs
+++ b/glib/src/collections/slist.rs
@@ -363,8 +363,9 @@ impl<T: TransparentPtrType> SList<T> {
                     let item = &*(&(*ptr).data as *const ffi::gpointer as *const T);
                     let next = (*ptr).next;
                     if !f(item) {
-                        ptr::drop_in_place(&mut (*ptr).data as *mut ffi::gpointer as *mut T);
+                        let mut item_ptr = (*ptr).data;
                         self.ptr = ptr::NonNull::new(ffi::g_slist_delete_link(head.as_ptr(), ptr));
+                        ptr::drop_in_place(&mut item_ptr as *mut ffi::gpointer as *mut T);
                     }
                     ptr = next;
                 }
@@ -412,7 +413,7 @@ impl<T: TransparentPtrType> Clone for SList<T> {
 impl<T: TransparentPtrType> Drop for SList<T> {
     #[inline]
     fn drop(&mut self) {
-        if let Some(ptr) = self.ptr {
+        if let Some(ptr) = self.ptr.take() {
             unsafe {
                 if mem::needs_drop::<T>() {
                     unsafe extern "C" fn drop_item<T: TransparentPtrType>(mut ptr: ffi::gpointer) {


### PR DESCRIPTION
…m panics

This is currently not a problem because all collections require the item type to implement `TransparentType` or `TransparentPtrType`, which are unsafe traits that are only implemented by the `glib::wrapper!` macro and require the `Drop` impl to not panic (among other things).

As such this has no effect right now but is cleaner and might avoid bugs in the future if the requirements of the two traits are ever weakened.

Thanks to JuHyung Son (@tooson9010-spec) for reporting.