### PR TITLE
glib: gate `BookmarkFile` with `cfg(feature = "v2.76")`

### DIFF
--- a/glib/src/bookmark_file.rs
+++ b/glib/src/bookmark_file.rs
@@ -5,29 +5,13 @@
 use crate::DateTime;
 use crate::{ffi, translate::*};
 
-#[allow(clippy::missing_safety_doc)]
-unsafe fn g_bookmark_file_copy(bookmark: *mut ffi::GBookmarkFile) -> *mut ffi::GBookmarkFile {
-    #[cfg(not(feature = "v2_76"))]
-    unsafe {
-        crate::gobject_ffi::g_boxed_copy(
-            ffi::g_bookmark_file_get_type(),
-            bookmark as ffi::gconstpointer,
-        ) as *mut ffi::GBookmarkFile
-    }
-
-    #[cfg(feature = "v2_76")]
-    unsafe {
-        ffi::g_bookmark_file_copy(mut_override(bookmark))
-    }
-}
-
 crate::wrapper! {
     #[doc(alias = "GBookmarkFile")]
     #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct BookmarkFile(Boxed<ffi::GBookmarkFile>);
 
     match fn {
-        copy => |ptr| g_bookmark_file_copy(mut_override(ptr)),
+        copy => |ptr| ffi::g_bookmark_file_copy(mut_override(ptr)),
         free => |ptr| ffi::g_bookmark_file_free(ptr),
         type_ => || ffi::g_bookmark_file_get_type(),
     }

--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -42,7 +42,6 @@ pub use gobject_sys as gobject_ffi;
 
 pub use self::{
     FileError,
-    bookmark_file::BookmarkFile,
     byte_array::ByteArray,
     bytes::Bytes,
     closure::{Closure, RustClosure},
@@ -147,6 +146,12 @@ pub use self::gobject::{BindingGroup, BindingGroupBuilder};
 
 mod gobject;
 
+#[cfg(feature = "v2_76")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v2_76")))]
+pub use self::bookmark_file::BookmarkFile;
+
+#[cfg(feature = "v2_76")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v2_76")))]
 mod bookmark_file;
 mod byte_array;
 mod bytes;


### PR DESCRIPTION
Fixes #1966 by gating `glib::BookmarkFile` with `cfg(feature = "v2.76")`.

Version gating on individual methods is kept in case the module-level gating is relaxed in the future.