### PR TITLE
Add safe wrapper for `g_log_writer_default_set_debug_domains`

### DIFF
--- a/glib/src/lib.rs
+++ b/glib/src/lib.rs
@@ -214,6 +214,8 @@ mod log;
 #[cfg_attr(docsrs, doc(cfg(feature = "log_macros")))]
 pub use rs_log;
 
+#[cfg(feature = "v2_80")]
+pub use self::log::log_writer_default_set_debug_domains;
 pub use self::log::{
     LogField, LogHandlerId, LogLevel, LogLevels, log_default_handler, log_remove_handler,
     log_set_always_fatal, log_set_default_handler, log_set_fatal_mask, log_set_handler,

--- a/glib/src/log.rs
+++ b/glib/src/log.rs
@@ -7,6 +7,8 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
+#[cfg(feature = "v2_80")]
+use crate::StrVRef;
 use crate::{GStr, GString, LogWriterOutput, ffi, translate::*};
 
 #[derive(Debug)]
@@ -1090,4 +1092,12 @@ pub fn log_writer_default_would_drop(log_level: LogLevel, log_domain: Option<&st
             log_domain.to_glib_none().0,
         ))
     }
+}
+
+#[cfg(feature = "v2_80")]
+#[cfg_attr(docsrs, doc(cfg(feature = "v2_80")))]
+#[doc(alias = "g_log_writer_default_set_debug_domains")]
+#[inline]
+pub fn log_writer_default_set_debug_domains(domains: &StrVRef) {
+    unsafe { ffi::g_log_writer_default_set_debug_domains(domains.to_glib_none().0) }
 }


### PR DESCRIPTION
The function is [explicitly documented](https://docs.gtk.org/glib/func.log_writer_default_set_debug_domains.html) as thread-safe:
> This function is thread-safe.