### PR TITLE
First six async/finish implementations for the Gio file subclass

### DIFF
--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -808,10 +808,6 @@ manual_traits = ["FileExtManual"]
     name = "hash"
     ignore = true
     [[object.function]]
-    name = "enumerate_children_async"
-    # FileEnumerator
-    ignore = true
-    [[object.function]]
     name = "find_enclosing_mount_async"
     # Mount
     ignore = true

--- a/gio/Gir.toml
+++ b/gio/Gir.toml
@@ -808,10 +808,6 @@ manual_traits = ["FileExtManual"]
     name = "hash"
     ignore = true
     [[object.function]]
-    name = "find_enclosing_mount_async"
-    # Mount
-    ignore = true
-    [[object.function]]
     name = "replace_contents_async"
     # AsRef
     manual = true

--- a/gio/src/auto/file.rs
+++ b/gio/src/auto/file.rs
@@ -670,6 +670,90 @@ pub trait FileExt: IsA<File> + 'static {
         }
     }
 
+    #[doc(alias = "g_file_enumerate_children_async")]
+    fn enumerate_children_async<P: FnOnce(Result<FileEnumerator, glib::Error>) + 'static>(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        io_priority: glib::Priority,
+        cancellable: Option<&impl IsA<Cancellable>>,
+        callback: P,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+
+        let user_data: Box_<glib::thread_guard::ThreadGuard<P>> =
+            Box_::new(glib::thread_guard::ThreadGuard::new(callback));
+        unsafe extern "C" fn enumerate_children_async_trampoline<
+            P: FnOnce(Result<FileEnumerator, glib::Error>) + 'static,
+        >(
+            _source_object: *mut glib::gobject_ffi::GObject,
+            res: *mut crate::ffi::GAsyncResult,
+            user_data: glib::ffi::gpointer,
+        ) {
+            unsafe {
+                let mut error = std::ptr::null_mut();
+                let ret = ffi::g_file_enumerate_children_finish(
+                    _source_object as *mut _,
+                    res,
+                    &mut error,
+                );
+                let result = if error.is_null() {
+                    Ok(from_glib_full(ret))
+                } else {
+                    Err(from_glib_full(error))
+                };
+                let callback: Box_<glib::thread_guard::ThreadGuard<P>> =
+                    Box_::from_raw(user_data as *mut _);
+                let callback: P = callback.into_inner();
+                callback(result);
+            }
+        }
+        let callback = enumerate_children_async_trampoline::<P>;
+        unsafe {
+            ffi::g_file_enumerate_children_async(
+                self.as_ref().to_glib_none().0,
+                attributes.to_glib_none().0,
+                flags.into_glib(),
+                io_priority.into_glib(),
+                cancellable.map(|p| p.as_ref()).to_glib_none().0,
+                Some(callback),
+                Box_::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn enumerate_children_future(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        io_priority: glib::Priority,
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<FileEnumerator, glib::Error>> + 'static>>
+    {
+        let attributes = String::from(attributes);
+        Box_::pin(crate::GioFuture::new(
+            self,
+            move |obj, cancellable, send| {
+                obj.enumerate_children_async(
+                    &attributes,
+                    flags,
+                    io_priority,
+                    Some(cancellable),
+                    move |res| {
+                        send.resolve(res);
+                    },
+                );
+            },
+        ))
+    }
+
     #[doc(alias = "g_file_equal")]
     fn equal(&self, file2: &impl IsA<File>) -> bool {
         unsafe {

--- a/gio/src/auto/file.rs
+++ b/gio/src/auto/file.rs
@@ -784,6 +784,76 @@ pub trait FileExt: IsA<File> + 'static {
         }
     }
 
+    #[doc(alias = "g_file_find_enclosing_mount_async")]
+    fn find_enclosing_mount_async<P: FnOnce(Result<Mount, glib::Error>) + 'static>(
+        &self,
+        io_priority: glib::Priority,
+        cancellable: Option<&impl IsA<Cancellable>>,
+        callback: P,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+
+        let user_data: Box_<glib::thread_guard::ThreadGuard<P>> =
+            Box_::new(glib::thread_guard::ThreadGuard::new(callback));
+        unsafe extern "C" fn find_enclosing_mount_async_trampoline<
+            P: FnOnce(Result<Mount, glib::Error>) + 'static,
+        >(
+            _source_object: *mut glib::gobject_ffi::GObject,
+            res: *mut crate::ffi::GAsyncResult,
+            user_data: glib::ffi::gpointer,
+        ) {
+            unsafe {
+                let mut error = std::ptr::null_mut();
+                let ret = ffi::g_file_find_enclosing_mount_finish(
+                    _source_object as *mut _,
+                    res,
+                    &mut error,
+                );
+                let result = if error.is_null() {
+                    Ok(from_glib_full(ret))
+                } else {
+                    Err(from_glib_full(error))
+                };
+                let callback: Box_<glib::thread_guard::ThreadGuard<P>> =
+                    Box_::from_raw(user_data as *mut _);
+                let callback: P = callback.into_inner();
+                callback(result);
+            }
+        }
+        let callback = find_enclosing_mount_async_trampoline::<P>;
+        unsafe {
+            ffi::g_file_find_enclosing_mount_async(
+                self.as_ref().to_glib_none().0,
+                io_priority.into_glib(),
+                cancellable.map(|p| p.as_ref()).to_glib_none().0,
+                Some(callback),
+                Box_::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn find_enclosing_mount_future(
+        &self,
+        io_priority: glib::Priority,
+    ) -> Pin<Box_<dyn std::future::Future<Output = Result<Mount, glib::Error>> + 'static>> {
+        Box_::pin(crate::GioFuture::new(
+            self,
+            move |obj, cancellable, send| {
+                obj.find_enclosing_mount_async(io_priority, Some(cancellable), move |res| {
+                    send.resolve(res);
+                });
+            },
+        ))
+    }
+
     #[doc(alias = "g_file_get_basename")]
     #[doc(alias = "get_basename")]
     fn basename(&self) -> Option<std::path::PathBuf> {

--- a/gio/src/file.rs
+++ b/gio/src/file.rs
@@ -6,9 +6,7 @@ use glib::{prelude::*, translate::*};
 
 #[cfg(feature = "v2_74")]
 use crate::FileIOStream;
-use crate::{
-    Cancellable, File, FileAttributeValue, FileCreateFlags, FileEnumerator, FileQueryInfoFlags, ffi,
-};
+use crate::{Cancellable, File, FileAttributeValue, FileCreateFlags, FileQueryInfoFlags, ffi};
 
 impl File {
     #[cfg(feature = "v2_74")]
@@ -272,93 +270,6 @@ pub trait FileExtManual: IsA<File> + Sized {
                     etag.as_ref().map(|s| s.as_str()),
                     make_backup,
                     flags,
-                    Some(cancellable),
-                    move |res| {
-                        send.resolve(res);
-                    },
-                );
-            },
-        ))
-    }
-
-    #[doc(alias = "g_file_enumerate_children_async")]
-    fn enumerate_children_async<
-        P: IsA<Cancellable>,
-        Q: FnOnce(Result<FileEnumerator, glib::Error>) + 'static,
-    >(
-        &self,
-        attributes: &str,
-        flags: FileQueryInfoFlags,
-        io_priority: glib::Priority,
-        cancellable: Option<&P>,
-        callback: Q,
-    ) {
-        let main_context = glib::MainContext::ref_thread_default();
-        let is_main_context_owner = main_context.is_owner();
-        let has_acquired_main_context = (!is_main_context_owner)
-            .then(|| main_context.acquire().ok())
-            .flatten();
-        assert!(
-            is_main_context_owner || has_acquired_main_context.is_some(),
-            "Async operations only allowed if the thread is owning the MainContext"
-        );
-
-        let user_data: Box<glib::thread_guard::ThreadGuard<Q>> =
-            Box::new(glib::thread_guard::ThreadGuard::new(callback));
-        unsafe extern "C" fn create_async_trampoline<
-            Q: FnOnce(Result<FileEnumerator, glib::Error>) + 'static,
-        >(
-            _source_object: *mut glib::gobject_ffi::GObject,
-            res: *mut crate::ffi::GAsyncResult,
-            user_data: glib::ffi::gpointer,
-        ) {
-            unsafe {
-                let mut error = ptr::null_mut();
-                let ret = ffi::g_file_enumerate_children_finish(
-                    _source_object as *mut _,
-                    res,
-                    &mut error,
-                );
-                let result = if error.is_null() {
-                    Ok(from_glib_full(ret))
-                } else {
-                    Err(from_glib_full(error))
-                };
-                let callback: Box<glib::thread_guard::ThreadGuard<Q>> =
-                    Box::from_raw(user_data as *mut _);
-                let callback = callback.into_inner();
-                callback(result);
-            }
-        }
-        let callback = create_async_trampoline::<Q>;
-        unsafe {
-            ffi::g_file_enumerate_children_async(
-                self.as_ref().to_glib_none().0,
-                attributes.to_glib_none().0,
-                flags.into_glib(),
-                io_priority.into_glib(),
-                cancellable.map(|p| p.as_ref()).to_glib_none().0,
-                Some(callback),
-                Box::into_raw(user_data) as *mut _,
-            );
-        }
-    }
-
-    fn enumerate_children_future(
-        &self,
-        attributes: &str,
-        flags: FileQueryInfoFlags,
-        io_priority: glib::Priority,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<FileEnumerator, glib::Error>> + 'static>>
-    {
-        let attributes = attributes.to_owned();
-        Box::pin(crate::GioFuture::new(
-            self,
-            move |obj, cancellable, send| {
-                obj.enumerate_children_async(
-                    &attributes,
-                    flags,
-                    io_priority,
                     Some(cancellable),
                     move |res| {
                         send.resolve(res);

--- a/gio/src/subclass/file.rs
+++ b/gio/src/subclass/file.rs
@@ -108,6 +108,16 @@ pub trait FileImpl: ObjectImpl + ObjectSubclass<Type: IsA<File>> {
         self.parent_query_info(attributes, flags, cancellable)
     }
 
+    fn query_info_future(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+    {
+        self.parent_query_info_future(attributes, flags, priority)
+    }
+
     fn query_filesystem_info(
         &self,
         attributes: &str,
@@ -802,6 +812,102 @@ pub trait FileImplExt: FileImpl {
                 ))
             }
         }
+    }
+
+    fn parent_query_info_async<R: FnOnce(Result<FileInfo, Error>) + 'static>(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+        cancellable: Option<&Cancellable>,
+        callback: R,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface =
+                type_data.as_ref().parent_interface::<File>() as *const ffi::GFileIface;
+
+            let f = (*parent_iface)
+                .query_info_async
+                .expect("no parent interface implementation for \"query_info_async\"");
+            let finish = (*parent_iface)
+                .query_info_finish
+                .expect("no parent interface \"query_info_finish\" implementation");
+
+            let user_data: Box<(glib::thread_guard::ThreadGuard<R>, _)> =
+                Box::new((glib::thread_guard::ThreadGuard::new(callback), finish));
+
+            unsafe extern "C" fn query_info_async_trampoline<
+                T: FnOnce(Result<FileInfo, Error>) + 'static,
+            >(
+                source_object_ptr: *mut glib::gobject_ffi::GObject,
+                res: *mut ffi::GAsyncResult,
+                user_data: glib::ffi::gpointer,
+            ) {
+                unsafe {
+                    let mut error = std::ptr::null_mut();
+                    let cb: Box<(
+                        glib::thread_guard::ThreadGuard<T>,
+                        unsafe extern "C" fn(
+                            *mut gio_sys::GFile,
+                            *mut gio_sys::GAsyncResult,
+                            *mut *mut glib::ffi::GError,
+                        ) -> *mut ffi::GFileInfo,
+                    )> = Box::from_raw(user_data as *mut _);
+                    let ret = cb.1(source_object_ptr as _, res, &mut error);
+                    let result = if error.is_null() {
+                        Ok(from_glib_full(ret))
+                    } else {
+                        Err(from_glib_full(error))
+                    };
+                    let cb = cb.0.into_inner();
+                    cb(result);
+                };
+            }
+
+            f(
+                self.obj().unsafe_cast_ref::<File>().to_glib_none().0,
+                attributes.to_glib_none().0,
+                flags.into_glib(),
+                priority.into_glib(),
+                cancellable.to_glib_none().0,
+                Some(query_info_async_trampoline::<R>),
+                Box::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn parent_query_info_future(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+    {
+        let attributes = String::from(attributes);
+        Box::pin(GioFuture::new(
+            &self.ref_counted(),
+            move |imp, cancellable, send| {
+                imp.parent_query_info_async(
+                    &attributes,
+                    flags,
+                    priority,
+                    Some(cancellable),
+                    move |res| {
+                        send.resolve(res);
+                    },
+                );
+            },
+        ))
     }
 
     fn parent_query_filesystem_info(
@@ -2428,6 +2534,8 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         iface.enumerate_children_async = Some(file_enumerate_children_async::<T>);
         iface.enumerate_children_finish = Some(file_enumerate_children_finish);
         iface.query_info = Some(file_query_info::<T>);
+        iface.query_info_async = Some(file_query_info_async::<T>);
+        iface.query_info_finish = Some(file_query_info_finish);
         iface.query_filesystem_info = Some(file_query_filesystem_info::<T>);
         iface.find_enclosing_mount = Some(file_find_enclosing_mount::<T>);
         iface.set_display_name = Some(file_set_display_name::<T>);
@@ -2478,8 +2586,6 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         }
         // `GFile` already implements `xxx_async/xxx_finish` vfuncs and this should be ok.
         // TODO: when needed, override the `GFile` implementation of the following vfuncs:
-        // iface.query_info_async = Some(file_query_info_async::<T>);
-        // iface.query_info_finish = Some(file_query_info_finish);
         // iface.query_filesystem_info_async = Some(file_query_filesystem_info_async::<T>);
         // iface.query_filesystem_info_finish = Some(file_query_filesystem_info_finish::<T>);
         // iface.find_enclosing_mount_async = Some(file_find_enclosing_mount_asyncv);
@@ -2854,6 +2960,73 @@ unsafe extern "C" fn file_query_info<T: FileImpl>(
                     *error = err.to_glib_full()
                 }
                 std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn file_query_info_async<T: FileImpl>(
+    file: *mut ffi::GFile,
+    attributes: *const c_char,
+    flags: ffi::GFileQueryInfoFlags,
+    io_priority: i32,
+    cancellable: *mut ffi::GCancellable,
+    callback: ffi::GAsyncReadyCallback,
+    user_data: glib::ffi::gpointer,
+) {
+    unsafe {
+        let instance = &*(file as *mut T::Instance);
+        let imp = instance.imp();
+        let wrap: File = from_glib_none(file);
+        let attributes: glib::GString = from_glib_none(attributes);
+        let cancellable: Option<Cancellable> = from_glib_none(cancellable);
+
+        // Closure that will invoke the C callback when the LocalTask completes
+        let closure = move |task: LocalTask<FileInfo>, source_object: Option<&glib::Object>| {
+            let result: *mut ffi::GAsyncResult = task.upcast_ref::<AsyncResult>().to_glib_none().0;
+            let source_object: *mut glib::gobject_ffi::GObject = source_object.to_glib_none().0;
+            callback.unwrap()(source_object, result, user_data)
+        };
+
+        let t = LocalTask::new(
+            Some(wrap.upcast_ref::<glib::Object>()),
+            cancellable.as_ref(),
+            closure,
+        );
+
+        // Spawn the async work on the main context
+        glib::MainContext::ref_thread_default().spawn_local(async move {
+            // Call the trait method's future version
+            let res = imp
+                .query_info_future(
+                    attributes.as_str(),
+                    from_glib(flags),
+                    from_glib(io_priority),
+                )
+                .await;
+
+            // Store result in the task
+            t.return_result(res);
+        });
+    }
+}
+
+unsafe extern "C" fn file_query_info_finish(
+    _file: *mut ffi::GFile,
+    res_ptr: *mut ffi::GAsyncResult,
+    error_ptr: *mut *mut glib::ffi::GError,
+) -> *mut ffi::GFileInfo {
+    unsafe {
+        let res: AsyncResult = from_glib_none(res_ptr);
+        let t = res.downcast::<LocalTask<FileInfo>>().unwrap();
+        let ret = t.propagate();
+        match ret {
+            Ok(val) => val.to_glib_full(),
+            Err(e) => {
+                if !error_ptr.is_null() {
+                    *error_ptr = e.into_glib_ptr();
+                }
+                Ptr::from::<()>(std::ptr::null_mut())
             }
         }
     }

--- a/gio/src/subclass/file.rs
+++ b/gio/src/subclass/file.rs
@@ -8,7 +8,8 @@ use crate::{
     AsyncResult, Cancellable, DriveStartFlags, File, FileAttributeInfoList, FileAttributeValue,
     FileCopyFlags, FileCreateFlags, FileEnumerator, FileIOStream, FileInfo, FileInputStream,
     FileMeasureFlags, FileMonitor, FileMonitorFlags, FileOutputStream, FileQueryInfoFlags,
-    IOErrorEnum, Mount, MountMountFlags, MountOperation, MountUnmountFlags, Task, ffi,
+    GioFuture, IOErrorEnum, LocalTask, Mount, MountMountFlags, MountOperation, MountUnmountFlags,
+    Task, ffi,
 };
 
 use libc::{c_char, c_uint};
@@ -86,6 +87,16 @@ pub trait FileImpl: ObjectImpl + ObjectSubclass<Type: IsA<File>> {
         cancellable: Option<&Cancellable>,
     ) -> Result<FileEnumerator, Error> {
         self.parent_enumerate_children(attributes, flags, cancellable)
+    }
+
+    fn enumerate_children_future(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileEnumerator, Error>> + 'static>>
+    {
+        self.parent_enumerate_children_future(attributes, flags, priority)
     }
 
     fn query_info(
@@ -661,6 +672,102 @@ pub trait FileImplExt: FileImpl {
                 ))
             }
         }
+    }
+
+    fn parent_enumerate_children_async<R: FnOnce(Result<FileEnumerator, Error>) + 'static>(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+        cancellable: Option<&Cancellable>,
+        callback: R,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface =
+                type_data.as_ref().parent_interface::<File>() as *const ffi::GFileIface;
+
+            let f = (*parent_iface)
+                .enumerate_children_async
+                .expect("no parent interface implementation for \"enumerate_children_async\"");
+            let finish = (*parent_iface)
+                .enumerate_children_finish
+                .expect("no parent interface \"enumerate_children_finish\" implementation");
+
+            let user_data: Box<(glib::thread_guard::ThreadGuard<R>, _)> =
+                Box::new((glib::thread_guard::ThreadGuard::new(callback), finish));
+
+            unsafe extern "C" fn enumerate_children_async_trampoline<
+                T: FnOnce(Result<FileEnumerator, glib::Error>) + 'static,
+            >(
+                source_object_ptr: *mut glib::gobject_ffi::GObject,
+                res: *mut ffi::GAsyncResult,
+                user_data: glib::ffi::gpointer,
+            ) {
+                unsafe {
+                    let mut error = std::ptr::null_mut();
+                    let cb: Box<(
+                        glib::thread_guard::ThreadGuard<T>,
+                        unsafe extern "C" fn(
+                            *mut gio_sys::GFile,
+                            *mut gio_sys::GAsyncResult,
+                            *mut *mut glib::ffi::GError,
+                        ) -> *mut ffi::GFileEnumerator,
+                    )> = Box::from_raw(user_data as *mut _);
+                    let ret = cb.1(source_object_ptr as _, res, &mut error);
+                    let result = if error.is_null() {
+                        Ok(from_glib_full(ret))
+                    } else {
+                        Err(from_glib_full(error))
+                    };
+                    let cb = cb.0.into_inner();
+                    cb(result);
+                };
+            }
+
+            f(
+                self.obj().unsafe_cast_ref::<File>().to_glib_none().0,
+                attributes.to_glib_none().0,
+                flags.into_glib(),
+                priority.into_glib(),
+                cancellable.to_glib_none().0,
+                Some(enumerate_children_async_trampoline::<R>),
+                Box::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn parent_enumerate_children_future(
+        &self,
+        attributes: &str,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileEnumerator, Error>> + 'static>>
+    {
+        let attributes = String::from(attributes);
+        Box::pin(GioFuture::new(
+            &self.ref_counted(),
+            move |imp, cancellable, send| {
+                imp.parent_enumerate_children_async(
+                    &attributes,
+                    flags,
+                    priority,
+                    Some(cancellable),
+                    move |res| {
+                        send.resolve(res);
+                    },
+                );
+            },
+        ))
     }
 
     fn parent_query_info(
@@ -2318,6 +2425,8 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         iface.resolve_relative_path = Some(file_resolve_relative_path::<T>);
         iface.get_child_for_display_name = Some(file_get_child_for_display_name::<T>);
         iface.enumerate_children = Some(file_enumerate_children::<T>);
+        iface.enumerate_children_async = Some(file_enumerate_children_async::<T>);
+        iface.enumerate_children_finish = Some(file_enumerate_children_finish);
         iface.query_info = Some(file_query_info::<T>);
         iface.query_filesystem_info = Some(file_query_filesystem_info::<T>);
         iface.find_enclosing_mount = Some(file_find_enclosing_mount::<T>);
@@ -2369,10 +2478,8 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         }
         // `GFile` already implements `xxx_async/xxx_finish` vfuncs and this should be ok.
         // TODO: when needed, override the `GFile` implementation of the following vfuncs:
-        // iface.enumerate_children_async = Some(file_enumerate_children_async::<T>);
-        // iface.enumerate_children_finish = Some(file_enumerate_children_finish::<T>);
         // iface.query_info_async = Some(file_query_info_async::<T>);
-        // iface.query_info_finish = Some(file_query_info_finish::<T>);
+        // iface.query_info_finish = Some(file_query_info_finish);
         // iface.query_filesystem_info_async = Some(file_query_filesystem_info_async::<T>);
         // iface.query_filesystem_info_finish = Some(file_query_filesystem_info_finish::<T>);
         // iface.find_enclosing_mount_async = Some(file_find_enclosing_mount_asyncv);
@@ -2650,6 +2757,74 @@ unsafe extern "C" fn file_enumerate_children<T: FileImpl>(
                     *error = err.to_glib_full()
                 }
                 std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn file_enumerate_children_async<T: FileImpl>(
+    file: *mut ffi::GFile,
+    attributes: *const c_char,
+    flags: ffi::GFileQueryInfoFlags,
+    io_priority: i32,
+    cancellable: *mut ffi::GCancellable,
+    callback: ffi::GAsyncReadyCallback,
+    user_data: glib::ffi::gpointer,
+) {
+    unsafe {
+        let instance = &*(file as *mut T::Instance);
+        let imp = instance.imp();
+        let wrap: File = from_glib_none(file);
+        let attributes: glib::GString = from_glib_none(attributes);
+        let cancellable: Option<Cancellable> = from_glib_none(cancellable);
+
+        // Closure that will invoke the C callback when the LocalTask completes
+        let closure = move |task: LocalTask<FileEnumerator>,
+                            source_object: Option<&glib::Object>| {
+            let result: *mut ffi::GAsyncResult = task.upcast_ref::<AsyncResult>().to_glib_none().0;
+            let source_object: *mut glib::gobject_ffi::GObject = source_object.to_glib_none().0;
+            callback.unwrap()(source_object, result, user_data)
+        };
+
+        let t = LocalTask::new(
+            Some(wrap.upcast_ref::<glib::Object>()),
+            cancellable.as_ref(),
+            closure,
+        );
+
+        // Spawn the async work on the main context
+        glib::MainContext::ref_thread_default().spawn_local(async move {
+            // Call the trait method's future version
+            let res = imp
+                .enumerate_children_future(
+                    attributes.as_str(),
+                    from_glib(flags),
+                    from_glib(io_priority),
+                )
+                .await;
+
+            // Store result in the task
+            t.return_result(res);
+        });
+    }
+}
+
+unsafe extern "C" fn file_enumerate_children_finish(
+    _file: *mut ffi::GFile,
+    res_ptr: *mut ffi::GAsyncResult,
+    error_ptr: *mut *mut glib::ffi::GError,
+) -> *mut ffi::GFileEnumerator {
+    unsafe {
+        let res: AsyncResult = from_glib_none(res_ptr);
+        let t = res.downcast::<LocalTask<FileEnumerator>>().unwrap();
+        let ret = t.propagate();
+        match ret {
+            Ok(val) => val.to_glib_full(),
+            Err(e) => {
+                if !error_ptr.is_null() {
+                    *error_ptr = e.into_glib_ptr();
+                }
+                Ptr::from::<()>(std::ptr::null_mut())
             }
         }
     }

--- a/gio/src/subclass/file.rs
+++ b/gio/src/subclass/file.rs
@@ -186,6 +186,16 @@ pub trait FileImpl: ObjectImpl + ObjectSubclass<Type: IsA<File>> {
         self.parent_set_attribute(attribute, value, flags, cancellable)
     }
 
+    fn set_attributes_future(
+        &self,
+        info: &FileInfo,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+    {
+        self.parent_set_attributes_future(info, flags, priority)
+    }
+
     fn set_attributes_from_info(
         &self,
         info: &FileInfo,
@@ -1380,6 +1390,104 @@ pub trait FileImplExt: FileImpl {
                 ))
             }
         }
+    }
+
+    fn parent_set_attributes_async<R: FnOnce(Result<FileInfo, Error>) + 'static>(
+        &self,
+        info: &FileInfo,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+        cancellable: Option<&Cancellable>,
+        callback: R,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface =
+                type_data.as_ref().parent_interface::<File>() as *const ffi::GFileIface;
+
+            let f = (*parent_iface)
+                .set_attributes_async
+                .expect("no parent interface implementation for \"set_attributes_async\"");
+            let finish = (*parent_iface)
+                .set_attributes_finish
+                .expect("no parent interface \"set_attributes_finish\" implementation");
+
+            let user_data: Box<(glib::thread_guard::ThreadGuard<R>, _)> =
+                Box::new((glib::thread_guard::ThreadGuard::new(callback), finish));
+
+            unsafe extern "C" fn set_attributes_async_trampoline<
+                T: FnOnce(Result<FileInfo, Error>) + 'static,
+            >(
+                source_object_ptr: *mut glib::gobject_ffi::GObject,
+                res: *mut ffi::GAsyncResult,
+                user_data: glib::ffi::gpointer,
+            ) {
+                unsafe {
+                    let mut error = std::ptr::null_mut();
+                    let mut out: *mut ffi::GFileInfo = std::ptr::null_mut();
+                    let cb: Box<(
+                        glib::thread_guard::ThreadGuard<T>,
+                        unsafe extern "C" fn(
+                            *mut ffi::GFile,
+                            *mut ffi::GAsyncResult,
+                            *mut *mut ffi::GFileInfo,
+                            *mut *mut glib::ffi::GError,
+                        ) -> glib::ffi::gboolean,
+                    )> = Box::from_raw(user_data as *mut _);
+                    cb.1(source_object_ptr as _, res, &mut out, &mut error);
+                    let result = if error.is_null() {
+                        Ok(from_glib_full(out))
+                    } else {
+                        Err(from_glib_full(error))
+                    };
+                    let cb = cb.0.into_inner();
+                    cb(result);
+                }
+            }
+
+            f(
+                self.obj().unsafe_cast_ref::<File>().to_glib_none().0,
+                info.to_glib_none().0,
+                flags.into_glib(),
+                priority.into_glib(),
+                cancellable.to_glib_none().0,
+                Some(set_attributes_async_trampoline::<R>),
+                Box::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn parent_set_attributes_future(
+        &self,
+        info: &FileInfo,
+        flags: FileQueryInfoFlags,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+    {
+        let info = info.clone();
+        Box::pin(GioFuture::new(
+            &self.ref_counted(),
+            move |imp, cancellable, send| {
+                imp.parent_set_attributes_async(
+                    &info,
+                    flags,
+                    priority,
+                    Some(cancellable),
+                    move |res| {
+                        send.resolve(res);
+                    },
+                );
+            },
+        ))
     }
 
     fn parent_set_attributes_from_info(
@@ -2837,6 +2945,8 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         iface.query_settable_attributes = Some(file_query_settable_attributes::<T>);
         iface.query_writable_namespaces = Some(file_query_writable_namespaces::<T>);
         iface.set_attribute = Some(file_set_attribute::<T>);
+        iface.set_attributes_async = Some(file_set_attributes_async::<T>);
+        iface.set_attributes_finish = Some(file_set_attributes_finish);
         iface.set_attributes_from_info = Some(file_set_attributes_from_info::<T>);
         iface.read_fn = Some(file_read_fn::<T>);
         iface.append_to = Some(file_append_to::<T>);
@@ -2885,8 +2995,6 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         // iface._query_settable_attributes_finish = Some(_file_query_settable_attributes_finish::<T>);
         // iface._query_writable_namespaces_async = Some(_file_query_writable_namespaces_async::<T>);
         // iface._query_writable_namespaces_finish = Some(_file_query_writable_namespaces_finish::<T>);
-        // iface.set_attributes_async = Some(file_set_attributes_async::<T>);
-        // iface.set_attributes_finish = Some(file_set_attributes_finishv);
         // iface.read_async = Some(file_read_async::<T>);
         // iface.read_finish = Some(file_read_finish::<T>);
         // iface.append_to_async = Some(file_append_to_async::<T>);
@@ -3654,6 +3762,75 @@ unsafe extern "C" fn file_set_attribute<T: FileImpl>(
                     *error = err.to_glib_full()
                 }
                 false.into_glib()
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn file_set_attributes_async<T: FileImpl>(
+    file: *mut ffi::GFile,
+    info: *mut ffi::GFileInfo,
+    flags: ffi::GFileQueryInfoFlags,
+    io_priority: i32,
+    cancellable: *mut ffi::GCancellable,
+    callback: ffi::GAsyncReadyCallback,
+    user_data: glib::ffi::gpointer,
+) {
+    unsafe {
+        let instance = &*(file as *mut T::Instance);
+        let imp = instance.imp();
+        let wrap: File = from_glib_none(file);
+        let info: FileInfo = from_glib_none(info);
+        let cancellable: Option<Cancellable> = from_glib_none(cancellable);
+
+        // Closure that will invoke the C callback when the LocalTask completes
+        let closure = move |task: LocalTask<FileInfo>, source_object: Option<&glib::Object>| {
+            let result: *mut ffi::GAsyncResult = task.upcast_ref::<AsyncResult>().to_glib_none().0;
+            let source_object: *mut glib::gobject_ffi::GObject = source_object.to_glib_none().0;
+            callback.unwrap()(source_object, result, user_data)
+        };
+
+        let t = LocalTask::new(
+            Some(wrap.upcast_ref::<glib::Object>()),
+            cancellable.as_ref(),
+            closure,
+        );
+
+        // Spawn the async work on the main context
+        glib::MainContext::ref_thread_default().spawn_local(async move {
+            // Call the trait method's future version
+            let res = imp
+                .set_attributes_future(&info, from_glib(flags), from_glib(io_priority))
+                .await;
+
+            // Store result in the task
+            t.return_result(res);
+        });
+    }
+}
+
+unsafe extern "C" fn file_set_attributes_finish(
+    _file: *mut ffi::GFile,
+    res_ptr: *mut ffi::GAsyncResult,
+    info_ptr: *mut *mut ffi::GFileInfo,
+    error_ptr: *mut *mut glib::ffi::GError,
+) -> glib::ffi::gboolean {
+    unsafe {
+        let res: AsyncResult = from_glib_none(res_ptr);
+        let t = res.downcast::<LocalTask<FileInfo>>().unwrap();
+        let ret = t.propagate();
+        match ret {
+            Ok(val) => {
+                if !info_ptr.is_null() {
+                    *info_ptr = val.to_glib_full();
+                }
+                glib::ffi::GTRUE
+            }
+            Err(e) => {
+                if !error_ptr.is_null() {
+                    *error_ptr = e.into_glib_ptr();
+                }
+                glib::ffi::GFALSE
             }
         }
     }

--- a/gio/src/subclass/file.rs
+++ b/gio/src/subclass/file.rs
@@ -139,6 +139,13 @@ pub trait FileImpl: ObjectImpl + ObjectSubclass<Type: IsA<File>> {
         self.parent_find_enclosing_mount(cancellable)
     }
 
+    fn find_enclosing_mount_future(
+        &self,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Mount, Error>> + 'static>> {
+        self.parent_find_enclosing_mount_future(priority)
+    }
+
     fn set_display_name(
         &self,
         display_name: &str,
@@ -1071,6 +1078,88 @@ pub trait FileImplExt: FileImpl {
                 ))
             }
         }
+    }
+
+    fn parent_find_enclosing_mount_async<R: FnOnce(Result<Mount, Error>) + 'static>(
+        &self,
+        priority: glib::Priority,
+        cancellable: Option<&Cancellable>,
+        callback: R,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface =
+                type_data.as_ref().parent_interface::<File>() as *const ffi::GFileIface;
+
+            let f = (*parent_iface)
+                .find_enclosing_mount_async
+                .expect("no parent interface implementation for \"find_enclosing_mount_async\"");
+            let finish = (*parent_iface)
+                .find_enclosing_mount_finish
+                .expect("no parent interface \"find_enclosing_mount_finish\" implementation");
+
+            let user_data: Box<(glib::thread_guard::ThreadGuard<R>, _)> =
+                Box::new((glib::thread_guard::ThreadGuard::new(callback), finish));
+
+            unsafe extern "C" fn find_enclosing_mount_async_trampoline<
+                T: FnOnce(Result<Mount, Error>) + 'static,
+            >(
+                source_object_ptr: *mut glib::gobject_ffi::GObject,
+                res: *mut ffi::GAsyncResult,
+                user_data: glib::ffi::gpointer,
+            ) {
+                unsafe {
+                    let mut error = std::ptr::null_mut();
+                    let cb: Box<(
+                        glib::thread_guard::ThreadGuard<T>,
+                        unsafe extern "C" fn(
+                            *mut gio_sys::GFile,
+                            *mut gio_sys::GAsyncResult,
+                            *mut *mut glib::ffi::GError,
+                        ) -> *mut ffi::GMount,
+                    )> = Box::from_raw(user_data as *mut _);
+                    let ret = cb.1(source_object_ptr as _, res, &mut error);
+                    let result = if error.is_null() {
+                        Ok(from_glib_full(ret))
+                    } else {
+                        Err(from_glib_full(error))
+                    };
+                    let cb = cb.0.into_inner();
+                    cb(result);
+                };
+            }
+
+            f(
+                self.obj().unsafe_cast_ref::<File>().to_glib_none().0,
+                priority.into_glib(),
+                cancellable.to_glib_none().0,
+                Some(find_enclosing_mount_async_trampoline::<R>),
+                Box::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn parent_find_enclosing_mount_future(
+        &self,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Mount, Error>> + 'static>> {
+        Box::pin(GioFuture::new(
+            &self.ref_counted(),
+            move |imp, cancellable, send| {
+                imp.parent_find_enclosing_mount_async(priority, Some(cancellable), move |res| {
+                    send.resolve(res);
+                });
+            },
+        ))
     }
 
     fn parent_set_display_name(
@@ -2641,6 +2730,8 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         iface.query_filesystem_info_async = Some(file_query_filesystem_info_async::<T>);
         iface.query_filesystem_info_finish = Some(file_query_filesystem_info_finish);
         iface.find_enclosing_mount = Some(file_find_enclosing_mount::<T>);
+        iface.find_enclosing_mount_async = Some(file_find_enclosing_mount_async::<T>);
+        iface.find_enclosing_mount_finish = Some(file_find_enclosing_mount_finish);
         iface.set_display_name = Some(file_set_display_name::<T>);
         iface.query_settable_attributes = Some(file_query_settable_attributes::<T>);
         iface.query_writable_namespaces = Some(file_query_writable_namespaces::<T>);
@@ -2689,8 +2780,6 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         }
         // `GFile` already implements `xxx_async/xxx_finish` vfuncs and this should be ok.
         // TODO: when needed, override the `GFile` implementation of the following vfuncs:
-        // iface.find_enclosing_mount_async = Some(file_find_enclosing_mount_asyncv);
-        // iface.find_enclosing_mount_finish = Some(file_find_enclosing_mount_finish::<T>);
         // iface.set_display_name_async = Some(file_set_display_name_async::<T>);
         // iface.set_display_name_finish = Some(file_set_display_name_finish::<T>);
         // iface._query_settable_attributes_async = Some(_file_query_settable_attributes_async::<T>);
@@ -3238,6 +3327,66 @@ unsafe extern "C" fn file_find_enclosing_mount<T: FileImpl>(
                     *error = err.to_glib_full()
                 }
                 std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn file_find_enclosing_mount_async<T: FileImpl>(
+    file: *mut ffi::GFile,
+    io_priority: i32,
+    cancellable: *mut ffi::GCancellable,
+    callback: ffi::GAsyncReadyCallback,
+    user_data: glib::ffi::gpointer,
+) {
+    unsafe {
+        let instance = &*(file as *mut T::Instance);
+        let imp = instance.imp();
+        let wrap: File = from_glib_none(file);
+        let cancellable: Option<Cancellable> = from_glib_none(cancellable);
+
+        // Closure that will invoke the C callback when the LocalTask completes
+        let closure = move |task: LocalTask<Mount>, source_object: Option<&glib::Object>| {
+            let result: *mut ffi::GAsyncResult = task.upcast_ref::<AsyncResult>().to_glib_none().0;
+            let source_object: *mut glib::gobject_ffi::GObject = source_object.to_glib_none().0;
+            callback.unwrap()(source_object, result, user_data)
+        };
+
+        let t = LocalTask::new(
+            Some(wrap.upcast_ref::<glib::Object>()),
+            cancellable.as_ref(),
+            closure,
+        );
+
+        // Spawn the async work on the main context
+        glib::MainContext::ref_thread_default().spawn_local(async move {
+            // Call the trait method's future version
+            let res = imp
+                .find_enclosing_mount_future(from_glib(io_priority))
+                .await;
+
+            // Store result in the task
+            t.return_result(res);
+        });
+    }
+}
+
+unsafe extern "C" fn file_find_enclosing_mount_finish(
+    _file: *mut ffi::GFile,
+    res_ptr: *mut ffi::GAsyncResult,
+    error_ptr: *mut *mut glib::ffi::GError,
+) -> *mut ffi::GMount {
+    unsafe {
+        let res: AsyncResult = from_glib_none(res_ptr);
+        let t = res.downcast::<LocalTask<Mount>>().unwrap();
+        let ret = t.propagate();
+        match ret {
+            Ok(val) => val.to_glib_full(),
+            Err(e) => {
+                if !error_ptr.is_null() {
+                    *error_ptr = e.into_glib_ptr();
+                }
+                Ptr::from::<()>(std::ptr::null_mut())
             }
         }
     }

--- a/gio/src/subclass/file.rs
+++ b/gio/src/subclass/file.rs
@@ -154,6 +154,14 @@ pub trait FileImpl: ObjectImpl + ObjectSubclass<Type: IsA<File>> {
         self.parent_set_display_name(display_name, cancellable)
     }
 
+    fn set_display_name_future(
+        &self,
+        display_name: &str,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<File, Error>> + 'static>> {
+        self.parent_set_display_name_future(display_name, priority)
+    }
+
     fn query_settable_attributes(
         &self,
         cancellable: Option<&Cancellable>,
@@ -1188,6 +1196,97 @@ pub trait FileImplExt: FileImpl {
                 Err(from_glib_full(error))
             }
         }
+    }
+
+    fn parent_set_display_name_async<R: FnOnce(Result<File, Error>) + 'static>(
+        &self,
+        display_name: &str,
+        priority: glib::Priority,
+        cancellable: Option<&Cancellable>,
+        callback: R,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface =
+                type_data.as_ref().parent_interface::<File>() as *const ffi::GFileIface;
+
+            let f = (*parent_iface)
+                .set_display_name_async
+                .expect("no parent interface implementation for \"set_display_name_async\"");
+            let finish = (*parent_iface)
+                .set_display_name_finish
+                .expect("no parent interface \"set_display_name_finish\" implementation");
+
+            let user_data: Box<(glib::thread_guard::ThreadGuard<R>, _)> =
+                Box::new((glib::thread_guard::ThreadGuard::new(callback), finish));
+
+            unsafe extern "C" fn set_display_name_async_trampoline<
+                T: FnOnce(Result<File, Error>) + 'static,
+            >(
+                source_object_ptr: *mut glib::gobject_ffi::GObject,
+                res: *mut ffi::GAsyncResult,
+                user_data: glib::ffi::gpointer,
+            ) {
+                unsafe {
+                    let mut error = std::ptr::null_mut();
+                    let cb: Box<(
+                        glib::thread_guard::ThreadGuard<T>,
+                        unsafe extern "C" fn(
+                            *mut gio_sys::GFile,
+                            *mut gio_sys::GAsyncResult,
+                            *mut *mut glib::ffi::GError,
+                        ) -> *mut ffi::GFile,
+                    )> = Box::from_raw(user_data as *mut _);
+                    let ret = cb.1(source_object_ptr as _, res, &mut error);
+                    let result = if error.is_null() {
+                        Ok(from_glib_full(ret))
+                    } else {
+                        Err(from_glib_full(error))
+                    };
+                    let cb = cb.0.into_inner();
+                    cb(result);
+                };
+            }
+
+            f(
+                self.obj().unsafe_cast_ref::<File>().to_glib_none().0,
+                display_name.to_glib_none().0,
+                priority.into_glib(),
+                cancellable.to_glib_none().0,
+                Some(set_display_name_async_trampoline::<R>),
+                Box::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn parent_set_display_name_future(
+        &self,
+        display_name: &str,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<File, Error>> + 'static>> {
+        let display_name = String::from(display_name);
+        Box::pin(GioFuture::new(
+            &self.ref_counted(),
+            move |imp, cancellable, send| {
+                imp.parent_set_display_name_async(
+                    &display_name,
+                    priority,
+                    Some(cancellable),
+                    move |res| {
+                        send.resolve(res);
+                    },
+                );
+            },
+        ))
     }
 
     fn parent_query_settable_attributes(
@@ -2733,6 +2832,8 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         iface.find_enclosing_mount_async = Some(file_find_enclosing_mount_async::<T>);
         iface.find_enclosing_mount_finish = Some(file_find_enclosing_mount_finish);
         iface.set_display_name = Some(file_set_display_name::<T>);
+        iface.set_display_name_async = Some(file_set_display_name_async::<T>);
+        iface.set_display_name_finish = Some(file_set_display_name_finish);
         iface.query_settable_attributes = Some(file_query_settable_attributes::<T>);
         iface.query_writable_namespaces = Some(file_query_writable_namespaces::<T>);
         iface.set_attribute = Some(file_set_attribute::<T>);
@@ -2780,8 +2881,6 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         }
         // `GFile` already implements `xxx_async/xxx_finish` vfuncs and this should be ok.
         // TODO: when needed, override the `GFile` implementation of the following vfuncs:
-        // iface.set_display_name_async = Some(file_set_display_name_async::<T>);
-        // iface.set_display_name_finish = Some(file_set_display_name_finish::<T>);
         // iface._query_settable_attributes_async = Some(_file_query_settable_attributes_async::<T>);
         // iface._query_settable_attributes_finish = Some(_file_query_settable_attributes_finish::<T>);
         // iface._query_writable_namespaces_async = Some(_file_query_writable_namespaces_async::<T>);
@@ -3414,6 +3513,68 @@ unsafe extern "C" fn file_set_display_name<T: FileImpl>(
                     *error = err.to_glib_full()
                 }
                 std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn file_set_display_name_async<T: FileImpl>(
+    file: *mut ffi::GFile,
+    display_name: *const c_char,
+    io_priority: i32,
+    cancellable: *mut ffi::GCancellable,
+    callback: ffi::GAsyncReadyCallback,
+    user_data: glib::ffi::gpointer,
+) {
+    unsafe {
+        let instance = &*(file as *mut T::Instance);
+        let imp = instance.imp();
+        let wrap: File = from_glib_none(file);
+        let display_name: glib::GString = from_glib_none(display_name);
+        let cancellable: Option<Cancellable> = from_glib_none(cancellable);
+
+        // Closure that will invoke the C callback when the LocalTask completes
+        let closure = move |task: LocalTask<File>, source_object: Option<&glib::Object>| {
+            let result: *mut ffi::GAsyncResult = task.upcast_ref::<AsyncResult>().to_glib_none().0;
+            let source_object: *mut glib::gobject_ffi::GObject = source_object.to_glib_none().0;
+            callback.unwrap()(source_object, result, user_data)
+        };
+
+        let t = LocalTask::new(
+            Some(wrap.upcast_ref::<glib::Object>()),
+            cancellable.as_ref(),
+            closure,
+        );
+
+        // Spawn the async work on the main context
+        glib::MainContext::ref_thread_default().spawn_local(async move {
+            // Call the trait method's future version
+            let res = imp
+                .set_display_name_future(display_name.as_str(), from_glib(io_priority))
+                .await;
+
+            // Store result in the task
+            t.return_result(res);
+        });
+    }
+}
+
+unsafe extern "C" fn file_set_display_name_finish(
+    _file: *mut ffi::GFile,
+    res_ptr: *mut ffi::GAsyncResult,
+    error_ptr: *mut *mut glib::ffi::GError,
+) -> *mut ffi::GFile {
+    unsafe {
+        let res: AsyncResult = from_glib_none(res_ptr);
+        let t = res.downcast::<LocalTask<File>>().unwrap();
+        let ret = t.propagate();
+        match ret {
+            Ok(val) => val.to_glib_full(),
+            Err(e) => {
+                if !error_ptr.is_null() {
+                    *error_ptr = e.into_glib_ptr();
+                }
+                Ptr::from::<()>(std::ptr::null_mut())
             }
         }
     }

--- a/gio/src/subclass/file.rs
+++ b/gio/src/subclass/file.rs
@@ -126,6 +126,15 @@ pub trait FileImpl: ObjectImpl + ObjectSubclass<Type: IsA<File>> {
         self.parent_query_filesystem_info(attributes, cancellable)
     }
 
+    fn query_filesystem_info_future(
+        &self,
+        attributes: &str,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+    {
+        self.parent_query_filesystem_info_future(attributes, priority)
+    }
+
     fn find_enclosing_mount(&self, cancellable: Option<&Cancellable>) -> Result<Mount, Error> {
         self.parent_find_enclosing_mount(cancellable)
     }
@@ -940,6 +949,98 @@ pub trait FileImplExt: FileImpl {
                 ))
             }
         }
+    }
+
+    fn parent_query_filesystem_info_async<R: FnOnce(Result<FileInfo, Error>) + 'static>(
+        &self,
+        attributes: &str,
+        priority: glib::Priority,
+        cancellable: Option<&Cancellable>,
+        callback: R,
+    ) {
+        let main_context = glib::MainContext::ref_thread_default();
+        let is_main_context_owner = main_context.is_owner();
+        let has_acquired_main_context = (!is_main_context_owner)
+            .then(|| main_context.acquire().ok())
+            .flatten();
+        assert!(
+            is_main_context_owner || has_acquired_main_context.is_some(),
+            "Async operations only allowed if the thread is owning the MainContext"
+        );
+        unsafe {
+            let type_data = Self::type_data();
+            let parent_iface =
+                type_data.as_ref().parent_interface::<File>() as *const ffi::GFileIface;
+
+            let f = (*parent_iface)
+                .query_filesystem_info_async
+                .expect("no parent interface implementation for \"query_filesystem_info_async\"");
+            let finish = (*parent_iface)
+                .query_filesystem_info_finish
+                .expect("no parent interface \"query_filesystem_info_finish\" implementation");
+
+            let user_data: Box<(glib::thread_guard::ThreadGuard<R>, _)> =
+                Box::new((glib::thread_guard::ThreadGuard::new(callback), finish));
+
+            unsafe extern "C" fn query_filesystem_info_async_trampoline<
+                T: FnOnce(Result<FileInfo, Error>) + 'static,
+            >(
+                source_object_ptr: *mut glib::gobject_ffi::GObject,
+                res: *mut ffi::GAsyncResult,
+                user_data: glib::ffi::gpointer,
+            ) {
+                unsafe {
+                    let mut error = std::ptr::null_mut();
+                    let cb: Box<(
+                        glib::thread_guard::ThreadGuard<T>,
+                        unsafe extern "C" fn(
+                            *mut gio_sys::GFile,
+                            *mut gio_sys::GAsyncResult,
+                            *mut *mut glib::ffi::GError,
+                        ) -> *mut ffi::GFileInfo,
+                    )> = Box::from_raw(user_data as *mut _);
+                    let ret = cb.1(source_object_ptr as _, res, &mut error);
+                    let result = if error.is_null() {
+                        Ok(from_glib_full(ret))
+                    } else {
+                        Err(from_glib_full(error))
+                    };
+                    let cb = cb.0.into_inner();
+                    cb(result);
+                };
+            }
+
+            f(
+                self.obj().unsafe_cast_ref::<File>().to_glib_none().0,
+                attributes.to_glib_none().0,
+                priority.into_glib(),
+                cancellable.to_glib_none().0,
+                Some(query_filesystem_info_async_trampoline::<R>),
+                Box::into_raw(user_data) as *mut _,
+            );
+        }
+    }
+
+    fn parent_query_filesystem_info_future(
+        &self,
+        attributes: &str,
+        priority: glib::Priority,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+    {
+        let attributes = String::from(attributes);
+        Box::pin(GioFuture::new(
+            &self.ref_counted(),
+            move |imp, cancellable, send| {
+                imp.parent_query_filesystem_info_async(
+                    &attributes,
+                    priority,
+                    Some(cancellable),
+                    move |res| {
+                        send.resolve(res);
+                    },
+                );
+            },
+        ))
     }
 
     fn parent_find_enclosing_mount(
@@ -2537,6 +2638,8 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         iface.query_info_async = Some(file_query_info_async::<T>);
         iface.query_info_finish = Some(file_query_info_finish);
         iface.query_filesystem_info = Some(file_query_filesystem_info::<T>);
+        iface.query_filesystem_info_async = Some(file_query_filesystem_info_async::<T>);
+        iface.query_filesystem_info_finish = Some(file_query_filesystem_info_finish);
         iface.find_enclosing_mount = Some(file_find_enclosing_mount::<T>);
         iface.set_display_name = Some(file_set_display_name::<T>);
         iface.query_settable_attributes = Some(file_query_settable_attributes::<T>);
@@ -2586,8 +2689,6 @@ unsafe impl<T: FileImpl> IsImplementable<T> for File {
         }
         // `GFile` already implements `xxx_async/xxx_finish` vfuncs and this should be ok.
         // TODO: when needed, override the `GFile` implementation of the following vfuncs:
-        // iface.query_filesystem_info_async = Some(file_query_filesystem_info_async::<T>);
-        // iface.query_filesystem_info_finish = Some(file_query_filesystem_info_finish::<T>);
         // iface.find_enclosing_mount_async = Some(file_find_enclosing_mount_asyncv);
         // iface.find_enclosing_mount_finish = Some(file_find_enclosing_mount_finish::<T>);
         // iface.set_display_name_async = Some(file_set_display_name_async::<T>);
@@ -3052,6 +3153,68 @@ unsafe extern "C" fn file_query_filesystem_info<T: FileImpl>(
                     *error = err.to_glib_full()
                 }
                 std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn file_query_filesystem_info_async<T: FileImpl>(
+    file: *mut ffi::GFile,
+    attributes: *const c_char,
+    io_priority: i32,
+    cancellable: *mut ffi::GCancellable,
+    callback: ffi::GAsyncReadyCallback,
+    user_data: glib::ffi::gpointer,
+) {
+    unsafe {
+        let instance = &*(file as *mut T::Instance);
+        let imp = instance.imp();
+        let wrap: File = from_glib_none(file);
+        let attributes: glib::GString = from_glib_none(attributes);
+        let cancellable: Option<Cancellable> = from_glib_none(cancellable);
+
+        // Closure that will invoke the C callback when the LocalTask completes
+        let closure = move |task: LocalTask<FileInfo>, source_object: Option<&glib::Object>| {
+            let result: *mut ffi::GAsyncResult = task.upcast_ref::<AsyncResult>().to_glib_none().0;
+            let source_object: *mut glib::gobject_ffi::GObject = source_object.to_glib_none().0;
+            callback.unwrap()(source_object, result, user_data)
+        };
+
+        let t = LocalTask::new(
+            Some(wrap.upcast_ref::<glib::Object>()),
+            cancellable.as_ref(),
+            closure,
+        );
+
+        // Spawn the async work on the main context
+        glib::MainContext::ref_thread_default().spawn_local(async move {
+            // Call the trait method's future version
+            let res = imp
+                .query_filesystem_info_future(attributes.as_str(), from_glib(io_priority))
+                .await;
+
+            // Store result in the task
+            t.return_result(res);
+        });
+    }
+}
+
+unsafe extern "C" fn file_query_filesystem_info_finish(
+    _file: *mut ffi::GFile,
+    res_ptr: *mut ffi::GAsyncResult,
+    error_ptr: *mut *mut glib::ffi::GError,
+) -> *mut ffi::GFileInfo {
+    unsafe {
+        let res: AsyncResult = from_glib_none(res_ptr);
+        let t = res.downcast::<LocalTask<FileInfo>>().unwrap();
+        let ret = t.propagate();
+        match ret {
+            Ok(val) => val.to_glib_full(),
+            Err(e) => {
+                if !error_ptr.is_null() {
+                    *error_ptr = e.into_glib_ptr();
+                }
+                Ptr::from::<()>(std::ptr::null_mut())
             }
         }
     }

--- a/gio/src/subclass/file/tests.rs
+++ b/gio/src/subclass/file/tests.rs
@@ -227,6 +227,24 @@ mod imp {
             }
         }
 
+        fn enumerate_children_future(
+            &self,
+            attributes: &str,
+            flags: FileQueryInfoFlags,
+            _priority: glib::Priority,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<FileEnumerator, Error>> + 'static>,
+        > {
+            let attributes = String::from(attributes);
+            Box::pin(GioFuture::new(
+                &self.ref_counted(),
+                move |self_, cancellable, send| {
+                    let res = self_.enumerate_children(&attributes, flags, Some(cancellable));
+                    send.resolve(res);
+                },
+            ))
+        }
+
         fn query_info(
             &self,
             attributes: &str,
@@ -1471,6 +1489,77 @@ fn file_enumerate_children() {
 
     // both children should equal
     assert_eq!(my_custom_children, expected)
+}
+
+#[test]
+fn file_enumerate_children_future() {
+    // run test in a main context dedicated and configured as the thread default one
+    let _ = glib::MainContext::new().with_thread_default(|| {
+        // invoke `MyCustomFile` implementation of `crate::ffi::GFileIface::enumerate_children_async/finish`
+        let my_custom_file =
+            MyCustomFile::with_type_state("/my_file", FileType::Regular, MyFileState::Exist);
+        let res = glib::MainContext::ref_thread_default().block_on(
+            my_custom_file.enumerate_children_future(
+                "*",
+                FileQueryInfoFlags::NONE,
+                glib::Priority::DEFAULT,
+            ),
+        );
+        assert!(res.is_err(), "unexpected enumerator");
+        let err = res.unwrap_err();
+
+        // invoke `MyFile` implementation of `crate::ffi::GFileIface::enumerate_children_async/finish`
+        let my_file = MyFile::with_type_state("/my_file", FileType::Regular, MyFileState::Exist);
+        let res =
+            glib::MainContext::ref_thread_default().block_on(my_file.enumerate_children_future(
+                "*",
+                FileQueryInfoFlags::NONE,
+                glib::Priority::DEFAULT,
+            ));
+        assert!(res.is_err(), "unexpected enumerator");
+        let expected = res.unwrap_err();
+
+        // both errors should equal
+        assert_eq!(err.message(), expected.message());
+        assert_eq!(err.kind::<IOErrorEnum>(), expected.kind::<IOErrorEnum>());
+
+        // invoke `MyCustomFile` implementation of `crate::ffi::GFileIface::enumerate_children_async/finish`
+        let my_custom_parent =
+            MyCustomFile::with_children("/my_parent", vec!["my_file1", "my_file2"]);
+        let res = glib::MainContext::ref_thread_default().block_on(
+            my_custom_parent.enumerate_children_future(
+                "*",
+                FileQueryInfoFlags::NONE,
+                glib::Priority::DEFAULT,
+            ),
+        );
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let my_custom_enumerator = res.unwrap();
+        let res = my_custom_enumerator
+            .map(|res| res.map(|file_info| file_info.name()))
+            .collect::<Result<Vec<_>, _>>();
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let my_custom_children = res.unwrap();
+
+        // invoke `MyFile` implementation of `crate::ffi::GFileIface::enumerate_children_async/finish`
+        let my_parent = MyFile::with_children("/my_parent", vec!["my_file1", "my_file2"]);
+        let res =
+            glib::MainContext::ref_thread_default().block_on(my_parent.enumerate_children_future(
+                "*",
+                FileQueryInfoFlags::NONE,
+                glib::Priority::DEFAULT,
+            ));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let my_enumerator = res.unwrap();
+        let res = my_enumerator
+            .map(|res| res.map(|file_info| file_info.name()))
+            .collect::<Result<Vec<_>, _>>();
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let expected = res.unwrap();
+
+        // both children should equal
+        assert_eq!(my_custom_children, expected)
+    });
 }
 
 #[test]

--- a/gio/src/subclass/file/tests.rs
+++ b/gio/src/subclass/file/tests.rs
@@ -288,6 +288,23 @@ mod imp {
             Ok(file_info)
         }
 
+        fn query_info_future(
+            &self,
+            attributes: &str,
+            flags: FileQueryInfoFlags,
+            _priority: glib::Priority,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+        {
+            let attributes = String::from(attributes);
+            Box::pin(GioFuture::new(
+                &self.ref_counted(),
+                move |self_, cancellable, send| {
+                    let res = self_.query_info(&attributes, flags, Some(cancellable));
+                    send.resolve(res);
+                },
+            ))
+        }
+
         fn query_filesystem_info(
             &self,
             attributes: &str,
@@ -1587,6 +1604,46 @@ fn file_query_info() {
         file_info.attribute_as_string("xattr::key2"),
         expected.attribute_as_string("xattr::key2")
     );
+}
+
+#[test]
+fn file_query_info_future() {
+    // run test in a main context dedicated and configured as the thread default one
+    let _ = glib::MainContext::new().with_thread_default(|| {
+        // invoke `MyCustomFile` implementation of `crate::ffi::GFileIface::query_info_async/finish`
+        let my_custom_file =
+            MyCustomFile::with_xattr("/my_file", vec!["xattr::key1=value1", "xattr::key2=value2"]);
+        let res =
+            glib::MainContext::ref_thread_default().block_on(my_custom_file.query_info_future(
+                "*",
+                FileQueryInfoFlags::NONE,
+                glib::Priority::DEFAULT,
+            ));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let file_info = res.unwrap();
+
+        // invoke `MyFile` implementation of `crate::ffi::GFileIface::query_info_async/finish`
+        let my_file =
+            MyFile::with_xattr("/my_file", vec!["xattr::key1=value1", "xattr::key2=value2"]);
+        let res = glib::MainContext::ref_thread_default().block_on(my_file.query_info_future(
+            "*",
+            FileQueryInfoFlags::NONE,
+            glib::Priority::DEFAULT,
+        ));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let expected = res.unwrap();
+
+        // both results should equal
+        assert_eq!(file_info.name(), expected.name());
+        assert_eq!(
+            file_info.attribute_as_string("xattr::key1"),
+            expected.attribute_as_string("xattr::key1")
+        );
+        assert_eq!(
+            file_info.attribute_as_string("xattr::key2"),
+            expected.attribute_as_string("xattr::key2")
+        );
+    });
 }
 
 #[test]

--- a/gio/src/subclass/file/tests.rs
+++ b/gio/src/subclass/file/tests.rs
@@ -313,6 +313,22 @@ mod imp {
             self.query_info(attributes, FileQueryInfoFlags::NONE, cancellable)
         }
 
+        fn query_filesystem_info_future(
+            &self,
+            attributes: &str,
+            _priority: glib::Priority,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+        {
+            let attributes = String::from(attributes);
+            Box::pin(GioFuture::new(
+                &self.ref_counted(),
+                move |self_, cancellable, send| {
+                    let res = self_.query_filesystem_info(&attributes, Some(cancellable));
+                    send.resolve(res);
+                },
+            ))
+        }
+
         fn find_enclosing_mount(&self, _cancellable: Option<&Cancellable>) -> Result<Mount, Error> {
             Err(Error::new(
                 IOErrorEnum::NotSupported,
@@ -1671,6 +1687,39 @@ fn file_query_filesystem_info() {
         file_info.attribute_as_string("xattr::key2"),
         expected.attribute_as_string("xattr::key2")
     );
+}
+
+#[test]
+fn file_query_filesystem_info_future() {
+    // run test in a main context dedicated and configured as the thread default one
+    let _ = glib::MainContext::new().with_thread_default(|| {
+        // invoke `MyCustomFile` implementation of `crate::ffi::GFileIface::query_filesystem_info_async/finish`
+        let my_custom_file =
+            MyCustomFile::with_xattr("/my_file", vec!["xattr::key1=value1", "xattr::key2=value2"]);
+        let res = glib::MainContext::ref_thread_default()
+            .block_on(my_custom_file.query_filesystem_info_future("*", glib::Priority::DEFAULT));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let file_info = res.unwrap();
+
+        // invoke `MyFile` implementation of `crate::ffi::GFileIface::query_filesystem_info_async/finish`
+        let my_file =
+            MyFile::with_xattr("/my_file", vec!["xattr::key1=value1", "xattr::key2=value2"]);
+        let res = glib::MainContext::ref_thread_default()
+            .block_on(my_file.query_filesystem_info_future("*", glib::Priority::DEFAULT));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let expected = res.unwrap();
+
+        // both results should equal
+        assert_eq!(file_info.name(), expected.name());
+        assert_eq!(
+            file_info.attribute_as_string("xattr::key1"),
+            expected.attribute_as_string("xattr::key1")
+        );
+        assert_eq!(
+            file_info.attribute_as_string("xattr::key2"),
+            expected.attribute_as_string("xattr::key2")
+        );
+    });
 }
 
 #[test]

--- a/gio/src/subclass/file/tests.rs
+++ b/gio/src/subclass/file/tests.rs
@@ -362,6 +362,22 @@ mod imp {
             Ok(Self::Type::new(path).upcast())
         }
 
+        fn set_display_name_future(
+            &self,
+            display_name: &str,
+            _priority: glib::Priority,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<File, Error>> + 'static>>
+        {
+            let display_name = String::from(display_name);
+            Box::pin(GioFuture::new(
+                &self.ref_counted(),
+                move |self_, cancellable, send| {
+                    let res = self_.set_display_name(&display_name, Some(cancellable));
+                    send.resolve(res);
+                },
+            ))
+        }
+
         fn query_settable_attributes(
             &self,
             _cancellable: Option<&Cancellable>,
@@ -1794,6 +1810,30 @@ fn file_set_display_name() {
 
     // both new paths should equal
     assert_eq!(renamed.path(), expected.path());
+}
+
+#[test]
+fn file_set_display_name_future() {
+    // run test in a main context dedicated and configured as the thread default one
+    let _ = glib::MainContext::new().with_thread_default(|| {
+        // invoke `MyCustomFile` implementation of `crate::ffi::GFileIface::set_display_name_async/finish`
+        let my_custom_file = MyCustomFile::new("/my_file");
+        let res = glib::MainContext::ref_thread_default().block_on(
+            my_custom_file.set_display_name_future("my_file_new_name", glib::Priority::DEFAULT),
+        );
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let renamed = res.unwrap();
+
+        // invoke `MyFile` implementation of `crate::ffi::GFileIface::set_display_name_async/finish`
+        let my_file = MyFile::new("/my_file");
+        let res = glib::MainContext::ref_thread_default()
+            .block_on(my_file.set_display_name_future("my_file_new_name", glib::Priority::DEFAULT));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let expected = res.unwrap();
+
+        // both new paths should equal
+        assert_eq!(renamed.path(), expected.path());
+    });
 }
 
 #[test]

--- a/gio/src/subclass/file/tests.rs
+++ b/gio/src/subclass/file/tests.rs
@@ -446,6 +446,26 @@ mod imp {
             }
         }
 
+        fn set_attributes_future(
+            &self,
+            info: &FileInfo,
+            flags: FileQueryInfoFlags,
+            _priority: glib::Priority,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<FileInfo, Error>> + 'static>>
+        {
+            let info = info.clone();
+            Box::pin(GioFuture::new(
+                &self.ref_counted(),
+                move |self_, cancellable, send| {
+                    // Call set_attributes_from_info and return the info
+                    let res = self_
+                        .set_attributes_from_info(&info, flags, Some(cancellable))
+                        .map(|_| info);
+                    send.resolve(res);
+                },
+            ))
+        }
+
         fn set_attributes_from_info(
             &self,
             info: &FileInfo,
@@ -1928,6 +1948,43 @@ fn file_set_attribute() {
         file_info.attribute_as_string("xattr::key1"),
         expected.attribute_as_string("xattr::key1")
     );
+}
+
+#[test]
+fn file_set_attributes_future() {
+    // run test in a main context dedicated and configured as the thread default one
+    let _ = glib::MainContext::new().with_thread_default(|| {
+        // invoke `MyCustomFile` implementation of `crate::ffi::GFileIface::set_attributes_async/finish`
+        let my_custom_file = MyCustomFile::new("/my_file");
+        let info = FileInfo::new();
+        info.set_attribute_string("xattr::key1", "value1");
+        let res =
+            glib::MainContext::ref_thread_default().block_on(my_custom_file.set_attributes_future(
+                &info,
+                FileQueryInfoFlags::NONE,
+                glib::Priority::DEFAULT,
+            ));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let file_info = res.unwrap();
+
+        // invoke `MyFile` implementation of `crate::ffi::GFileIface::set_attributes_async/finish`
+        let my_file = MyFile::new("/my_file");
+        let info = FileInfo::new();
+        info.set_attribute_string("xattr::key1", "value1");
+        let res = glib::MainContext::ref_thread_default().block_on(my_file.set_attributes_future(
+            &info,
+            FileQueryInfoFlags::NONE,
+            glib::Priority::DEFAULT,
+        ));
+        assert!(res.is_ok(), "{}", res.unwrap_err());
+        let expected = res.unwrap();
+
+        // both file attributes should equal
+        assert_eq!(
+            file_info.attribute_as_string("xattr::key1"),
+            expected.attribute_as_string("xattr::key1")
+        );
+    });
 }
 
 #[test]


### PR DESCRIPTION
Add support of custom implementation of async/finish version of file_enumerate_children, file_query_info, file_query_filesystem_info, file_find_enclosing_mount, file_set_display_name, file_set_attributes