### PR TITLE
glib: fix UB in VariantStrIter::impl_get (RUSTSEC-2024-0429)

### DIFF
--- a/glib/src/variant_iter.rs
+++ b/glib/src/variant_iter.rs
@@ -117,13 +117,13 @@ impl<'a> VariantStrIter<'a> {
 
     fn impl_get(&self, i: usize) -> &'a str {
         unsafe {
-            let p: *mut libc::c_char = std::ptr::null_mut();
+            let mut p: *mut libc::c_char = std::ptr::null_mut();
             let s = b"&s\0";
             ffi::g_variant_get_child(
                 self.variant.to_glib_none().0,
                 i,
                 s as *const u8 as *const _,
-                &p,
+                &mut p,
                 std::ptr::null::<i8>(),
             );
             let p = std::ffi::CStr::from_ptr(p);


### PR DESCRIPTION
`g_variant_get_child` writes through the out-pointer — needs `&mut p`, not `&p`. Same fix as 0.20, backported to 0.18 (tauri's gtk stack is still pinned here and trips RUSTSEC-2024-0429).