### PR TITLE
glib: backport VariantStrIter::impl_get soundness fix to 0.18

### DIFF
--- a/glib/src/variant_iter.rs
+++ b/glib/src/variant_iter.rs
@@ -117,13 +117,13 @@ impl<'a> VariantStrIter<'a> {
 
     fn impl_get(&self, i: usize) -> &'a str {
         unsafe {
-            let p: *mut libc::c_char = std::ptr::null_mut();
+            let mut p: *mut libc::c_char = std::ptr::null_mut();
             let s = b"&s\0";
             ffi::g_variant_get_child(
                 self.variant.to_glib_none().0,
                 i,
                 s as *const u8 as *const _,
-                &p,
+                &mut p,
                 std::ptr::null::<i8>(),
             );
             let p = std::ffi::CStr::from_ptr(p);


### PR DESCRIPTION
Backports the `VariantStrIter::impl_get` soundness fix from #1343 to the `0.18` branch, so that a `glib` 0.18.6 can be released for RUSTSEC-2024-0429 / GHSA-wrw7-89jp-8q8g.

The diff is byte-identical to b5a4071, which has been on `main` since March 2024. No API change, no behaviour change beyond removing the UB.

## Why this needs to land on 0.18 specifically

The advisory's fix version is 0.20.0, but a large part of the ecosystem cannot reach 0.20 — it is pinned to `glib` 0.18 through the GTK3 bindings:

```
tauri 2.x → gtk 0.18.2 → glib ^0.18 → glib 0.18.5
             gdk 0.18.2 ↗
             webkit2gtk 2.0.2 (webkit2gtk-4.1) ↗
```

`gtk-rs/gtk3-rs` — which publishes `gtk`, `gdk`, `gdk-pixbuf`, `gdkx11`, `atk`, `javascriptcore-rs` and `soup3` — was archived in March 2024. It is read-only, so no `gtk` release depending on `glib >= 0.20` will ever exist. Tauri closed tauri-apps/tauri#12564 as `not_planned` after concluding that un-archiving gtk3-rs was not realistic and that a fork was out of scope; their GTK4 migration is targeted at Tauri v3.

The important detail is that **none of that is a blocker here**. The unsound code lives in `glib`, whose repository is active and which still has a live `0.18` branch. Because `gtk` 0.18.2 depends on `glib` with a caret requirement (`^0.18`), a `glib` 0.18.6 patch release is picked up automatically by every existing GTK3 and Tauri consumer, with no changes to the archived repository and no work required from downstream. That is the whole fix.

The practical effect today is that every Tauri v2 application on Linux carries an unresolvable Dependabot / `cargo audit` finding. The usual answer is an ignore entry in `audit.toml` with a note explaining why it cannot be fixed, which is not a great steady state for an advisory whose fix is two characters.

## Verification

Built and tested against the `0.18` branch with rustc 1.97.1 and GLib 2.80.0.

The bug still reproduces on current stable, and the branch's **own test suite catches it** — `variant_iter`'s existing `test_variant_iter_array` exercises `array_iter_str()`:

```
$ cargo test --release --lib variant_iter        # 0.18 branch, unpatched
running 11 tests
error: test failed, to rerun pass `--lib`
Caused by:
  process didn't exit successfully: [...] (signal: 11, SIGSEGV: invalid memory reference)
```

With this commit applied:

```
$ cargo test --release --lib variant_iter
running 11 tests
test result: ok. 11 passed; 0 failed
```

Debug builds pass either way, which is why this went unnoticed on the branch — the optimizer is what discards the write through `&p`.

Since existing coverage already fails on the unpatched branch, I did not add a new test. Happy to add a dedicated regression test if you'd prefer one.

## Note on process

I've kept this to the code change only, since the version bump on this branch looks like it's normally a separate maintainer commit (`Update versions to 0.18.5`, 42b9caf). If a `0.18.6` release is something you're willing to cut, I'm glad to add the version bump here or in a follow-up, whichever fits your workflow.

There was an earlier attempt at this in #1964, but it was opened against `main` and closed a minute later, so it never got a look. This one targets `0.18`.
