### PR TITLE
glib: fix unsoundness in VariantStrIter::impl_get (RUSTSEC-2024-0429)

### DIFF
--- a/glib/src/variant_iter.rs
+++ b/glib/src/variant_iter.rs
@@ -117,13 +117,13 @@ impl<'a> VariantStrIter<'a> {
 
     fn impl_get(&self, i: usize) -> &'a str {
         unsafe {
-            let p: *mut libc::c_char = std::ptr::null_mut();
+            let mut p: *mut libc::c_char = std::ptr::null_mut();
             let s = b"&s\0";
             ffi::g_variant_get_child(
                 self.variant.to_glib_none().0,
                 i,
                 s as *const u8 as *const _,
-                &p,
+                &mut p,
                 std::ptr::null::<i8>(),
             );
             let p = std::ffi::CStr::from_ptr(p);


### PR DESCRIPTION
Backport of the fix shipped in glib 0.20.0 to the 0.18 branch.

VariantStrIter::impl_get passed an immutable reference (&p) to a NULL-initialized *mut c_char as the out-argument of the variadic C function g_variant_get_child, which mutates the pointer in place. Writing through an immutable reference is undefined behavior, and recent Rust compilers optimize the write away entirely, leaving p NULL and causing CStr::from_ptr to dereference a NULL pointer in next/next_back/nth/nth_back/last.

The fix passes the out-argument as &mut p, matching upstream.

Backported to 0.18 because Tauri still depends on the glib 0.18 series and needs this vulnerability fixed without jumping to 0.20 - the entire ecosystem is still stuck on 0.18 unfortunately, so we would take advantage of this advisory fix on the 0.18 minor.

https://rustsec.org/advisories/RUSTSEC-2024-0429.html