### PR TITLE
gio: Don't require the arguments of run() to be valid UTF-8

### DIFF
--- a/gio/src/application.rs
+++ b/gio/src/application.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use std::{boxed::Box as Box_, mem::transmute, ops::ControlFlow};
+use std::{boxed::Box as Box_, ffi::OsStr, mem::transmute, ops::ControlFlow};
 
 use glib::{
     ExitCode, GString,
@@ -12,14 +12,35 @@ use glib::{
 use crate::{Application, ApplicationCommandLine, File, ffi};
 
 pub trait ApplicationExtManual: IsA<Application> {
+    // rustdoc-stripper-ignore-next
+    /// Runs the application with the arguments of the process.
+    ///
+    /// Arguments are taken as they are, without requiring them to be valid
+    /// UTF-8: on unix an argument is a byte string, and a file name that is not
+    /// valid UTF-8 is enough to make [`std::env::args()`] panic.
     #[doc(alias = "g_application_run")]
     fn run(&self) -> ExitCode {
-        self.run_with_args(&std::env::args().collect::<Vec<_>>())
+        self.run_with_args_os(&std::env::args_os().collect::<Vec<_>>())
     }
 
     #[doc(alias = "g_application_run")]
     fn run_with_args<S: AsRef<str>>(&self, args: &[S]) -> ExitCode {
         let argv: Vec<&str> = args.iter().map(|a| a.as_ref()).collect();
+        let argc = argv.len() as i32;
+        let exit_code = unsafe {
+            ffi::g_application_run(self.as_ref().to_glib_none().0, argc, argv.to_glib_none().0)
+        };
+        ExitCode::try_from(exit_code).unwrap()
+    }
+
+    // rustdoc-stripper-ignore-next
+    /// Runs the application with the given arguments.
+    ///
+    /// Same as [`run_with_args()`][Self::run_with_args()], for arguments that
+    /// are not necessarily valid UTF-8.
+    #[doc(alias = "g_application_run")]
+    fn run_with_args_os<S: AsRef<OsStr>>(&self, args: &[S]) -> ExitCode {
+        let argv: Vec<&OsStr> = args.iter().map(|a| a.as_ref()).collect();
         let argc = argv.len() as i32;
         let exit_code = unsafe {
             ffi::g_application_run(self.as_ref().to_glib_none().0, argc, argv.to_glib_none().0)


### PR DESCRIPTION
Fixes #2023, both parts of what you suggested there.

`run()` collects `std::env::args()`, which panics on an argument that is not valid UTF-8. On unix an argument is a byte string, so a file name from a Windows share or an old archive aborts the application before it starts, and there is no way around it from the safe API since `run_with_args()` takes `AsRef<str>`.

`run()` uses `args_os()` now, and `run_with_args_os()` is there for callers that build the list themselves. `run_with_args()` is untouched.

On Windows nothing changes in practice: GLib ignores `argc`/`argv` there and takes the command line from `g_win32_get_command_line()`.

Checked with the reproduction from the issue, built against this branch: it used to panic in `env.rs`, now the application starts and `connect_open` gets the file with its bytes intact. `cargo test -p gio` passes, and clippy with `-D warnings` is clean.
