### PR TITLE
gio: free g_filename_from_utf8 result in file child trampoline

### DIFF
--- a/gio/src/subclass/file.rs
+++ b/gio/src/subclass/file.rs
@@ -2612,6 +2612,9 @@ unsafe extern "C" fn file_get_child_for_display_name<T: FileImpl>(
             }
             return std::ptr::null_mut();
         }
+        // `g_filename_from_utf8` returns a newly allocated string even when
+        // we only use it for validation; free it immediately.
+        glib::ffi::g_free(basename as *mut _);
 
         let res = imp.child_for_display_name(&GString::from_glib_borrow(display_name));
         match res {


### PR DESCRIPTION
## Summary

`file_get_child_for_display_name` calls:

```rust
let basename = glib::ffi::g_filename_from_utf8(
    display_name,
    -1,
    ...
);
```

`g_filename_from_utf8` returns a newly allocated string, but the trampoline
only uses the result to check for allocation failure and never frees it.

Valgrind on the passing test `subclass::file::tests::file_child_for_display_name`:

```text
==3384403== 8 bytes in 1 blocks are definitely lost
==3384403==    by g_malloc
==3384403==    by g_strndup
==3384403==    by g_filename_from_utf8
==3384403==    by gio::subclass::file::file_get_child_for_display_name
...
==3384403==    definitely lost: 24 bytes in 3 blocks
```

Three monomorphized instances of the generic trampoline each leak 8 bytes.

## Fix

Free the returned filename once the null check is done:

```rust
if basename.is_null() { ... return null; }
glib::ffi::g_free(basename as *mut _);
```

After this change, the same test reports:

```text
definitely lost: 0 bytes
indirectly lost: 0 bytes
```
