### PR TITLE
fix: manually free the indirect returned value of `pango_tab_array_get_tabs`

### DIFF
--- a/pango/src/tab_array.rs
+++ b/pango/src/tab_array.rs
@@ -1,5 +1,7 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
+use std::ffi::c_void;
+
 use glib::{Slice, translate::*};
 
 use crate::{TabAlign, TabArray};
@@ -23,6 +25,7 @@ impl TabArray {
             for i in 0..locations.len() {
                 alignments_vec.push(from_glib(*alignments.add(i)));
             }
+            glib::ffi::g_free(alignments as *mut c_void);
             (alignments_vec, locations)
         }
     }


### PR DESCRIPTION
As we can see in https://gitlab.gnome.org/GNOME/pango/-/blob/main/pango/pango-tabs.c?ref_type=heads#L354

function `pango_tab_array_get_tabs` would allocate a memory for `alignments` and return it through parameter in-directly, therefore we need to free it manually through `g_free`