### PR TITLE
fix: make `rustc` can generate `drop` glue on error path

### DIFF
--- a/cairo/src/context.rs
+++ b/cairo/src/context.rs
@@ -449,13 +449,13 @@ impl Context {
     #[doc(alias = "cairo_copy_clip_rectangle_list")]
     pub fn copy_clip_rectangle_list(&self) -> Result<RectangleList, Error> {
         unsafe {
-            let rectangle_list = ffi::cairo_copy_clip_rectangle_list(self.0.as_ptr());
+            let rectangle_list = RectangleList {
+                ptr: ffi::cairo_copy_clip_rectangle_list(self.0.as_ptr()),
+            };
 
-            status_to_result((*rectangle_list).status)?;
+            status_to_result((*rectangle_list.ptr).status)?;
 
-            Ok(RectangleList {
-                ptr: rectangle_list,
-            })
+            Ok(rectangle_list)
         }
     }
 

--- a/gio/src/subclass/file_enumerator.rs
+++ b/gio/src/subclass/file_enumerator.rs
@@ -1,6 +1,6 @@
 // Take a look at the license at the top of the repository in the LICENSE file.
 
-use glib::{prelude::*, subclass::prelude::*, translate::*};
+use glib::{subclass::prelude::*, translate::*};
 use std::pin::Pin;
 
 use crate::{


### PR DESCRIPTION
- **gio: Fix new 1.98 clippy warning**
- **fix: Pack the return value early so that the `rustc` compiler can generate the `drop` glue on the error path when `matches!(status, err)`**
