### PR TITLE
glib: Fix double-free in StrV::clear() by writing NULL terminator

### DIFF
--- a/glib/src/collections/strv.rs
+++ b/glib/src/collections/strv.rs
@@ -799,6 +799,10 @@ impl StrV {
                 ffi::g_free(*self.ptr.as_ptr().add(i) as ffi::gpointer);
             }
 
+            if self.capacity != 0 {
+                *self.ptr.as_ptr().add(0) = ptr::null_mut();
+            }
+
             self.len = 0;
         }
     }
@@ -1939,5 +1943,14 @@ mod test {
         for (i, item) in items.into_iter().enumerate() {
             assert_eq!(ptr_slice[i], item);
         }
+    }
+
+    #[test]
+    fn test_clear_no_double_free() {
+        let mut strv = StrV::from(&["one", "two", "three"][..]);
+        assert_eq!(strv.len(), 3);
+        strv.clear();
+        assert_eq!(strv.len(), 0);
+        // drop must not double-free
     }
 }


### PR DESCRIPTION
clear() frees each string via g_free() but did not write a NULL terminator at position 0 afterward. Since Drop calls g_strfreev(), which walks the array until NULL, the stale (already-freed) pointers were freed again, causing a double-free.